### PR TITLE
[Skanetrafiken.se] Add Skanetrafiken.se.xml

### DIFF
--- a/src/chrome/content/rules/Skanetrafiken.se.xml
+++ b/src/chrome/content/rules/Skanetrafiken.se.xml
@@ -1,0 +1,16 @@
+<!--
+    Unsupported domains:
+    
+    www.reseplaneraren.skanetrafiken.se     (cannot establish connection)
+-->
+<ruleset name="Skanetrafiken.se">
+  <target host="skanetrafiken.se"/>
+  <target host="www.skanetrafiken.se"/>
+  <target host="shop.skanetrafiken.se"/>
+  <target host="www.shop.skanetrafiken.se"/>
+
+  <securecookie host="skanetrafiken\.se$" name=".*"/>
+  <securecookie host="\.skanetrafiken\.se$" name=".*"/>
+  
+  <rule from="^https?://(?:www\.)?([^\.]+\.)?skanetrafiken.se/" to="https://www.$1skanetrafiken.se/"/>
+</ruleset>


### PR DESCRIPTION
Redirects to HTTPS. `www.reseplaneraren.skanetrafiken.se` was left out since it's not available on HTTPS.
