### PR TITLE
[Rejseplanen.dk] Disable due to wrong hostname in certificates.

### DIFF
--- a/src/chrome/content/rules/Rejseplanen.dk.xml
+++ b/src/chrome/content/rules/Rejseplanen.dk.xml
@@ -1,4 +1,4 @@
-<ruleset name="Rejseplanen.dk">
+<ruleset name="Rejseplanen.dk (broken)" default_off="wrong host in certificates">
   <target host="rejseplanen.dk" />
   <target host="*.rejseplanen.dk" />
 


### PR DESCRIPTION
SSL certificates are for 'dsb-commuter.rejseplanen.dk'. Redirecting to this
domain works, but a lot of things break due to mixed content and/or SSL
validation errors for subdomains.
