### PR TITLE
[Atlassian] exclude click.mailer.atlassian.com

### DIFF
--- a/src/chrome/content/rules/Atlassian.xml
+++ b/src/chrome/content/rules/Atlassian.xml
@@ -33,6 +33,7 @@
 								-->
   <!--exclusion pattern="http://downloads\.atlassian\.com/" /-->
 
+	<exclusion pattern="http://click\.mailer\.atlassian\.com/" />
 
 	<securecookie host="^(?:ace|answers|aug|confluence|developer|jira|marketplace|my)\.atlassian\.com$" name=".+" />
 


### PR DESCRIPTION
- there appears to be no SSL at all on this subdomain.
