### PR TITLE
Set a more sane default log level

### DIFF
--- a/chromium/util.js
+++ b/chromium/util.js
@@ -3,6 +3,18 @@ DBUG=2;
 INFO=3;
 NOTE=4;
 WARN=5;
+// FYI: Logging everything is /very/ slow. Chrome will log & buffer
+// these console logs even when the debug tools are closed. :(
+
+// TODO: Add an easy UI to change the log level.
+// (Developers can just type DEFAULT_LOG_LEVEL=1 in the console)
+DEFAULT_LOG_LEVEL=4;
 function log(level, str) {
-  console.log(str);
+    if (level >= DEFAULT_LOG_LEVEL) {
+        if (level === WARN) {
+            // Show warning with a little yellow icon in Chrome.
+            console.warn(str);
+        }
+        console.log(str);
+    }
 }


### PR DESCRIPTION
(for issue #12)

Logging /alone/ takes 50%+ of HTTPS Everywhere's profile time in Chrome (!)

Chrome will log & buffer console.log() even when the console is closed.

This means that for 99.9% of users (who never open the console), Chrome wastes
staggering amounts of time logging and buffering extremely verbose data.

For now, this just sets a default log level and includes adds the .warn() function.

TODO (Upcoming commit): Add a UI element to change the default log level.

Developers can simply type (in the console): DEFAULT_LOG_LEVEL=1;

Signed-off-by: Nick Semenkovich semenko@alum.mit.edu
