### PR TITLE
Disable Rdio.

### DIFF
--- a/src/chrome/content/rules/Rdio.xml
+++ b/src/chrome/content/rules/Rdio.xml
@@ -15,11 +15,14 @@
 
 	<target host="rd.io" />
 	<target host="www.rd.io" />
+<!-- disabled 2013-12-21: Logged-in Rdio.com redirects from HTTPS to HTTP, creating
+     a loop.
 	<target host="rdio.com" />
 	<target host="*.rdio.com" />
 
 
 	<securecookie host="^\.rdio\.com$" name=".+" />
+-->
 
 
 	<rule from="^http://(www\.)?rd(\.io|io\.com)/"


### PR DESCRIPTION
Logged-in www.rdio.com redirects from HTTPS to HTTP, creating a loop.
