### PR TITLE
[Tumblr] send 25.media to 31.media

### DIFF
--- a/src/chrome/content/rules/Tumblr.xml
+++ b/src/chrome/content/rules/Tumblr.xml
@@ -96,9 +96,6 @@
 	<target host="tumblr.com" />
 	<target host="*.tumblr.com" />
 
-	<!-- 25.media gives cert for a248.e.akamai.net -->
-	<exclusion pattern="^http://25\.media\.tumblr\.com/" />
-
 	<!--	Tracking cookies:
 					-->
 	<securecookie host="^(?:secure\.assets|www)\.tumblr\.com$" name="^__utmf$" />
@@ -132,6 +129,10 @@
 	<rule from="^http://(www\.)?tumblr\.com/(?=$|dmca|examples/share/\w|(?:forgot_password|impixu|register|teaser)(?:$|[?/])|images/|javascript/|login|logout|photo/|register|settings/|svc/log/|svc/teaser(?:$|[#?/]))"
 		to="https://$1tumblr.com/" />
 
+	<!-- 25.media gives cert for a248.e.akamai.net -->
+	<rule from="^http://(?:25\.)?media\.tumblr\.com/"
+		to="https://31.media.tumblr.com/" />
+
 	<rule from="^http://(a|(?:origin|secure)\.assets|\d+\.media|platform|origin\.platform|secure\.static|vt?)\.tumblr\.com/"
 		to="https://$1.tumblr.com/" />
 
@@ -140,9 +141,6 @@
 
 	<rule from="^http://data\.tumblr\.com/"
 		to="https://gs1.wac.edgecastcdn.net/8019B6/data.tumblr.com/" />
-
-	<rule from="^http://media\.tumblr\.com/"
-		to="https://31.media.tumblr.com/" />
 
 	<rule from="^http://static\.tumblr\.com/"
 		to="https://d2g9v1gts353nd.cloudfront.net/" />


### PR DESCRIPTION
- fdb8a0e6 excluded 25.media entirely, but this much better solution was suggested here: https://lists.eff.org/pipermail/https-everywhere-rules/2013-December/001783.html

Hope it's alright to correct my own patch!
