### PR TITLE
Add exclusion for blog-assets.newrelic.com.

### DIFF
--- a/src/chrome/content/rules/New-Relic.xml
+++ b/src/chrome/content/rules/New-Relic.xml
@@ -25,6 +25,7 @@
 	<target host="newrelic.com" />
 	<target host="*.newrelic.com" />
 		<exclusion pattern="^http://blog\.newrelic\.com/(?!wp-(?:admin(?:$|[?/])|content/|includes/|login\.php))" />
+		<exclusion pattern="^http://blog-assets\.newrelic\.com/.*" />
 
 
 	<securecookie host="^(?:.*\.)?newrelic\.com$" name=".+" />


### PR DESCRIPTION
The CN on the cert doesn't match. Cert is for *.netdna-ssl.com.
