### PR TITLE
pfsense.org now supports HTTPS for www and blog subdomains. Update rules...

### DIFF
--- a/src/chrome/content/rules/PfSense.org.xml
+++ b/src/chrome/content/rules/PfSense.org.xml
@@ -1,14 +1,13 @@
 <!--
 	Nonfunctional subdomains:
 
-		- (www.) *
-		- blog *
-
-	* Refused
+		- various downloads URLs not listed below (updates.pfsense.org, files.pfsense.org, etc.)
 
 
 	Fully covered subdomains:
 
+		- www
+		- blog
 		- devwiki
 		- doc
 		- forum
@@ -33,7 +32,7 @@
 	<securecookie host=".+\.pfsense\.org$" name=".+" />
 
 
-	<rule from="^http://(devwiki|doc|forum|portal|redmine)\.pfsense\.org/"
+	<rule from="^http://(blog|devwiki|doc|forum|portal|redmine|www)\.pfsense\.org/"
 		to="https://$1.pfsense.org/" />
 
 </ruleset>


### PR DESCRIPTION
... accordingly.
