### PR TITLE
Chrome: background.js performance / displayPageAction

### DIFF
--- a/chromium/background.js
+++ b/chromium/background.js
@@ -14,10 +14,10 @@ for (r in rs) {
 }
 */
 
-// If a ruleset could apply to a tab, then add the little HTTPS
-// Everywhere icon to the address bar.
+// Add the HTTPS Everywhere icon to the URL address bar.
+// TODO: Switch from pageAction to browserAction?
 function displayPageAction(tabId) {
-  if (tabId !== -1 && this.activeRulesets.getRulesets(tabId)) {
+  if (tabId !== -1) {
     chrome.tabs.get(tabId, function(tab) {
       if(typeof(tab) === "undefined") {
         log(DBUG, "Not a real tab. Skipping showing pageAction.");
@@ -136,8 +136,6 @@ function onBeforeRequest(details) {
       newuristr = rs[i].apply(canonical_url);
     }
   }
-
-  displayPageAction(details.tabId);
 
   if (newuristr) {
     // re-insert userpass info which was stripped temporarily
@@ -279,9 +277,18 @@ wr.onHeadersReceived.addListener(onHeadersReceived, {urls: ["https://*/*"]},
 wr.onResponseStarted.addListener(onResponseStarted,
                                  {urls: ["https://*/*", "http://*/*"]});
 
-// Add the small HTTPS Everywhere icon in the address bar if any rules apply to this tab.
+
+// Add the small HTTPS Everywhere icon in the address bar.
+// Note: We can't use any other hook (onCreated, onActivated, etc.) because Chrome resets the
+// pageActions on URL change. We should strongly consider switching from pageAction to browserAction.
 chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
     displayPageAction(tabId);
+});
+
+// Pre-rendered tabs / instant experiments sometimes skip onUpdated.
+// See http://crbug.com/109557
+chrome.tabs.onReplaced.addListener(function(addedTabId, removedTabId) {
+    displayPageAction(addedTabId);
 });
 
 // Listen for cookies set/updated and secure them if applicable. This function is async/nonblocking,


### PR DESCRIPTION
(for issue #12)

I'll hold off on other pull requests so @jsha's changes for Switch Planner can have happier merges :)

This updates some comments and makes changes to displayPageAction.

displayPageAction tests to see if we can add the pageAction icon to an address bar.

It only needs to happen _once_ per tab (if there's an applicable ruleset), but currently happens hundreds-to-thousands of times, as /every single request/ triggers it multiple times (in onBeforeRequest, in onCompleted, and via tabs.onUpdated).

This removes two unnecessary hooks (in dd0bdb4), then removes the worst offender under onBeforeRequest (blocking) and adds a timer (in 1d5df8f).

---

Later on, if people like the idea, I might switch from pageAction to browserAction (https://developer.chrome.com/extensions/browserAction.html)

Then, use setBadgeText to actively count & display the number of re-written hostnames. Kinda' like disconnect.me: 

![image](https://f.cloud.github.com/assets/167135/1824363/672efc86-7195-11e3-995e-70405d13761f.png)

Signed-off-by: Nick Semenkovich <semenko@alum.mit.edu>
