### PR TITLE
[Atlantic Media] redirect assets, cdn, ssl to https://cdn

### DIFF
--- a/src/chrome/content/rules/Atlantic-Media.xml
+++ b/src/chrome/content/rules/Atlantic-Media.xml
@@ -21,13 +21,16 @@
 
 	Problematic domains:
 
-		- cdn.theatlantic.com		(404, cert: gp1.wac.edgecastcdn.net)
 		- cdn.theatlanticcities.com	(cert: gp1.wac.edgecastcdn.net; 404)
+		- ssl.theatlantic.com		(some images 404)
+		- assets.theatlantic.com	(self-signed)
 
 
 	Fully covered domains:
 
-		- cdn.theatlantic.com	(→ ssl.theatlantic.com)
+		- cdn.theatlantic.com
+		- ssl.theatlantic.com		(→ cdn.theatlantic.com)
+		- assets.theatlantic.com	(→ cdn.theatlantic.com)
 
 -->
 <ruleset name="Atlantic Media (partial)">
@@ -54,8 +57,10 @@
 	<rule from="^http://secure\.nationaljournal\.com/"
 		to="https://secure.nationaljournal.com/" />
 
-	<rule from="^http://(?:cdn|ssl)\.theatlantic\.com/"
-		to="https://ssl.theatlantic.com/" />
+	<!-- not 100% sure about this, but it's the
+		  least broken configuration I can find -->
+	<rule from="^http://(?:assets|cdn|ssl)\.theatlantic\.com/"
+		to="https://cdn.theatlantic.com/" />
 
 	<rule from="^http://admin\.theatlantic(cities|wire)\.com/"
 		to="https://admin.theatlantic$1.com/" />


### PR DESCRIPTION
The reported cert/404 problems with cdn seem to be gone.
assets was not previously covered - https://assets is self-signed, but seems to be the same content.
Redirecting to ssl seems to break some images, such as this:
   https://ssl.theatlantic.com/newsroom/img/posts/2013/12/PenGoogle/4b1d41ac0.jpg <-- 404
   https://cdn.theatlantic.com/newsroom/img/posts/2013/12/PenGoogle/4b1d41ac0.jpg <-- works
