### PR TITLE
Chrome rules.js cleanups

### DIFF
--- a/chromium/rules.js
+++ b/chromium/rules.js
@@ -201,8 +201,7 @@ RuleSets.prototype = {
 
     // Replace each portion of the domain with a * in turn
     var segmented = host.split(".");
-    // length-1 to skip the TLD (there are no www.domain.* rules).
-    for (var i = 0; i < segmented.length - 1; ++i) {
+    for (var i = 0; i < segmented.length; ++i) {
       tmp = segmented[i];
       segmented[i] = "*";
       this.setInsert(results, this.targets[segmented.join(".")]);


### PR DESCRIPTION
(for issue #12)

Cleanup odd references, old relics, and ugly code.

Some changes include:
- Reduce the ruleCache size a bit
- Add a smaller cookie host cache
- Remove old, unused global_ruleset code
- Optimize the ruleset calculation
- Rearrange a cookie testing loop to return ASAP if it can't work 
