### PR TITLE
Change #! lines to specify python2.7 (required for argparse module)

### DIFF
--- a/makecrx.sh
+++ b/makecrx.sh
@@ -37,7 +37,7 @@ VERSION=`python -c "import json ; print(json.loads(open('chromium/manifest.json'
 echo "Building chrome version" $VERSION
 
 if [ -f utils/trivial-validate.py ]; then
-	VALIDATE="python utils/trivial-validate.py --ignoredups google --ignoredups facebook"
+	VALIDATE="./utils/trivial-validate.py --ignoredups google --ignoredups facebook"
 elif [ -x utils/trivial-validate ] ; then
   # This case probably never happens
 	VALIDATE=./utils/trivial-validate
@@ -117,7 +117,7 @@ trap 'rm -f "$pub" "$sig" "$zip"' EXIT
 
 # zip up the crx dir
 cwd=$(pwd -P)
-(cd "$dir" && python ../../utils/create_xpi.py -n "$cwd/$zip" -x "../../.build_exclusions" .)
+(cd "$dir" && ../../utils/create_xpi.py -n "$cwd/$zip" -x "../../.build_exclusions" .)
 echo >&2 "Unsigned package has shasum: `shasum "$cwd/$zip"`" 
 
 # signature

--- a/makexpi.sh
+++ b/makexpi.sh
@@ -52,7 +52,7 @@ fi
 
 if [ "$1" != "--fast" ] ; then
   if [ -f utils/trivial-validate.py ]; then
-    VALIDATE="python utils/trivial-validate.py --ignoredups google --ignoredups facebook"
+    VALIDATE="./utils/trivial-validate.py --ignoredups google --ignoredups facebook"
   elif [ -f trivial-validate.py ] ; then
     VALIDATE="python trivial-validate.py --ignoredups google --ignoredups facebook"
   elif [ -x utils/trivial-validate ] ; then
@@ -128,7 +128,7 @@ cd src
 rm -f "../$XPI_NAME"
 #zip -q -X -9r "../$XPI_NAME" . "-x@../.build_exclusions"
 
-python ../utils/create_xpi.py -n "../$XPI_NAME" -x "../.build_exclusions" "."
+../utils/create_xpi.py -n "../$XPI_NAME" -x "../.build_exclusions" "."
 
 ret="$?"
 if [ "$ret" != 0 ]; then

--- a/utils/create_xpi.py
+++ b/utils/create_xpi.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2.7
 
 # Uses the Python zip implementation to create deterministic XPI's
 # Author: Yan Zhu, yan@mit.edu

--- a/utils/trivial-validate.py
+++ b/utils/trivial-validate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2.7
 
 import argparse
 import sys, re, os


### PR DESCRIPTION
This was necessary to get makecrx.sh and makexpi.sh to run on a Mac OS X box with python 2.6 as the default.
