### PR TITLE
simplified and corrected Imgur ruleset

### DIFF
--- a/src/chrome/content/rules/Imgur.xml
+++ b/src/chrome/content/rules/Imgur.xml
@@ -1,72 +1,22 @@
 <!--
-	CDN buckets:
 
-		- wac.4220.edgecastcdn.net/??4220/
+	Imgur now has full HTTPS support on all subdomains.
+	Previously, there were issues as discussed :
+			https://mail1.eff.org/pipermail/https-everywhere-rules/2013-July/001645.html
+			https://bugzilla.mozilla.org/show_bug.cgi?id=866986#c7
 
-			- s
-			- i.stack
-
-		- imgur-store.myshopify.com
-
-			- store
-
-
-	Nonfunctional subdomains:
-
-		- stack		(refused)
-
-
-	Problematic subdomains:
-
-		- img	(refused)
-
-
-	Partially covered subdomains:
-
-		- (www.)
-
-
-	Fully covered subdomains:
-
-		- (www.)
-		- i
-		- img		(→ i)
-		- origin
-		- s
-		- i.stack
-		- store		(→ imgur-store.myshopify.com)
+	Ruleset simplified and fixed by bryn@imgur.com, January 2014.
 
 -->
 <ruleset name="Imgur">
 
 	<target host="imgur.com" />
 	<target host="*.imgur.com" />
-		<!--
-			https://mail1.eff.org/pipermail/https-everywhere-rules/2013-July/001645.html
 
-			https://bugzilla.mozilla.org/show_bug.cgi?id=866986#c7
-										-->
-		<!--exclusion pattern="^http://(?:www\.)?imgur\.com/(?!(?:images|include|min|register|signin)(?:/|\?|$))" /-->
+	<rule from="^http://imgur\.com/"
+		to="https://imgur.com/"/>
 
-
-	<securecookie host="^\.?imgur\.com" name=".+" />
-
-
-	<rule from="^http://(s\.)?imgur\.com/"
+	<rule from="^http://(\w\.)?imgur\.com/"
 		to="https://$1imgur.com/"/>
-
-	<!--	This rule breaks the Imgur Uploader Firefox extension:
-
-	<rule from="^http://api\.imgur\.com/"
-		to="https://api.imgur.com/" /-->
-
-	<rule from="^http://(i|origin|i\.stack|www)\.imgur\.com/"
-		to="https://$1.imgur.com/" />
-
-	<rule from="^http://img\.imgur\.com/"
-		to="https://i.imgur.com/" />
-
-	<rule from="^http://store\.imgur\.com/"
-		to="https://imgur-store.myshopify.com/" />
 
 </ruleset>


### PR DESCRIPTION
Hello there. I'm Bryn, an Imgur employee. It came to our attention that there were issues with our ruleset and functionality. Since we now have full HTTPS support on imgur.com and its subdomains, I've simplified the ruleset and made corrections. I've tested this ruleset both stand-alone and with the Imgur Uploader Extension (v1.06 - not developed or owned by us at Imgur). All seems well FWIW.
