### PR TITLE
Updated Instragram ruleset.

### DIFF
--- a/src/chrome/content/rules/Instagram.xml
+++ b/src/chrome/content/rules/Instagram.xml
@@ -104,7 +104,7 @@
 		but that case is handled by the previous rule.
 								-->
 	<rule from="^http://instagr\.am/(p|static)/"
-		to="https://instagr.am/$1/" />
+		to="https://instagram.com/$1/" />
 
 	<rule from="^http://(?:www\.)?instagram\.com/favicon\.ico"
 		to="https://instagram.com/favicon.ico" />


### PR DESCRIPTION
There is currently an issue with the TLS/SSL certificate in use at https://instagr.am/

Updated the Instagram ruleset to use https://instagram.com/ instead

![bug-20140119-instragram-tls-cert-common-name](https://f.cloud.github.com/assets/180537/1950566/67a6566e-814e-11e3-94f9-f34bccb5a80d.png)
