### PR TITLE
[Dell] partially re-add linux.dell.com

### DIFF
--- a/src/chrome/content/rules/Dell.xml
+++ b/src/chrome/content/rules/Dell.xml
@@ -47,6 +47,7 @@
 				- zh ¹
 
 		- partnerdirect ²
+		- linux ²
 
 	¹ cfs-file.ashx & resized-image.ashx 404, at least some pages redirect to http
 	² At least some pages redirect to http
@@ -107,6 +108,7 @@
 			False/broken MCB:
 						-->
 		<exclusion pattern="^http://(www\.)?dell\.com/+(?!content/|favicon\.ico)" />
+		<exclusion pattern="^http://linux\.dell\.com/(?:wiki|$)" />
 	<target host="ideastorm.com" />
 	<target host="www.ideastorm.com" />
 
@@ -118,7 +120,7 @@
 	<rule from="^http://(www(?:-cdn)?\.)?dell\.com/"
 		to="https://www.dell.com/" />
 
-	<rule from="^http://(accessories|a?fcs|(?:chatpro|dellchat|cs)\.ap|b2bservices|(?:ec2|si|snp)\.cdn|\w\w\.community|ecomm2?|support\.euro|img|mobility|partnerdirect|premier|signin|sso|support(?:apj)?|pbar\.us|www1-cdn)\.dell\.com/"
+	<rule from="^http://(accessories|a?fcs|(?:chatpro|dellchat|cs)\.ap|b2bservices|(?:ec2|si|snp)\.cdn|\w\w\.community|ecomm2?|support\.euro|img|linux|mobility|partnerdirect|premier|signin|sso|support(?:apj)?|pbar\.us|www1-cdn)\.dell\.com/"
 		to="https://$1.dell.com/" />
 
 	<rule from="^http://accessories-cdn\.dell\.com/"


### PR DESCRIPTION
- mediawiki redirects to http but other things work fine, such as /git /files /biosdisk etc
