### PR TITLE
files.pfsense.org and snapshots.pfsense.org are now HTTPS-enabled, updat...

### DIFF
--- a/src/chrome/content/rules/PfSense.org.xml
+++ b/src/chrome/content/rules/PfSense.org.xml
@@ -1,7 +1,7 @@
 <!--
 	Nonfunctional subdomains:
 
-		- various downloads URLs not listed below (updates.pfsense.org, files.pfsense.org, etc.)
+		- various downloads URLs not listed below 
 
 
 	Fully covered subdomains:
@@ -13,6 +13,8 @@
 		- forum
 		- portal
 		- redmine
+		- files
+		- snapshots
 
 
 	Observed cookie domains:
@@ -32,7 +34,7 @@
 	<securecookie host=".+\.pfsense\.org$" name=".+" />
 
 
-	<rule from="^http://(blog|devwiki|doc|forum|portal|redmine|www)\.pfsense\.org/"
+	<rule from="^http://(blog|devwiki|doc|forum|portal|redmine|www|snapshots|files)\.pfsense\.org/"
 		to="https://$1.pfsense.org/" />
 
 </ruleset>


### PR DESCRIPTION
...e accordingly
