### PR TITLE
Exclude mc.heroku.com from general Heroku ruleset.

### DIFF
--- a/src/chrome/content/rules/Heroku.xml
+++ b/src/chrome/content/rules/Heroku.xml
@@ -10,6 +10,7 @@
 	<target host="*.heroku.com" />
 	<target host="*.herokuapp.com" />
 
+	<exclusion pattern="^http://mc\.heroku\.com/"/>
 
 	<!--	Avoiding cross-domain cookies.
 						-->


### PR DESCRIPTION
`mc.heroku.com` is a domain CNAME'd to a service that doesn't provide HTTPS thus it's yielding 404s.  This PR excludes that domain from the general Heroku Ruleset.
