### PR TITLE
Fix OpenStreetMap

### DIFF
--- a/src/chrome/content/rules/OpenStreetMap.xml
+++ b/src/chrome/content/rules/OpenStreetMap.xml
@@ -9,7 +9,7 @@
 	<rule from="^http://tile\.openstreetmap\.org/"
 		to="https://a.tile.openstreetmap.org/"/>
 
-	<rule from="^http://(blog|help|lists|piwik|taginfo|[abc]\.tile|trac|wiki)\.openstreetmap\.org/"
+	<rule from="^http://(blog|help|lists|nominatim|piwik|taginfo|[abc]\.tile|trac|wiki)\.openstreetmap\.org/"
 		to="https://$1.openstreetmap.org/"/>
 
 </ruleset>


### PR DESCRIPTION
This fixes an old ruleset that's been disabled since last summer, and re-enables it.

Not sure if that's appropriate during a ruleset freeze. It definitely needs testing, as OSM is embedded in many many sites, but they've made progress on deploying SSL and it seems to work just fine now.

Your call!
