### PR TITLE
Fix invalid regular expression in DNTX.com.xml

### DIFF
--- a/src/chrome/content/rules/DNTX.com.xml
+++ b/src/chrome/content/rules/DNTX.com.xml
@@ -18,7 +18,7 @@
 
 	<!--	Server drops args but not paths:
 						-->
-	<rule from="^http://dntx\.com/([^?]*)?(?:\?.*)?"
+	<rule from="^http://dntx\.com/([^?]*).*"
 		to="https://www.dntx.com/$1" />
 
 	<rule from="^http://www\.dntx\.com/"


### PR DESCRIPTION
This was causing the rule validation to fail.  The modified regex relies on the greedy [^?]\* to match everything before the ?, and .\* to match the rest.
