### PR TITLE
Expand NewsBlur rule

### DIFF
--- a/src/chrome/content/rules/NewsBlur.xml
+++ b/src/chrome/content/rules/NewsBlur.xml
@@ -2,7 +2,7 @@
   <target host="*.newsblur.com" />
   <target host="newsblur.com" />
 
-  <rule from="^http://icons\.newsblur\.com/" to="https://s3.amazonaws.com/icons.newsblur.com/"/>
+  <rule from="^http://(icons|pages)\.newsblur\.com/" to="https://s3.amazonaws.com/$1.newsblur.com/"/>
   <rule from="^http://newsblur\.com/" to="https://www.newsblur.com/"/>
   <rule from="^http://([^/:@.]*)\.newsblur\.com/" to="https://$1.newsblur.com/" />
   <rule from="^https://popular\.global\.newsblur\.com/" to="http://popular.global.newsblur.com/" downgrade="1" />


### PR DESCRIPTION
1. Rewrite "blurblog" subdomains - [username].newsblur.com - to HTTPS (however, they link to //popular.global.newsblur.com which has an invalid cert, so I also added a downgrade rule for that).  The more generic subdomain rule also covers the www and dev subdomains, so I removed the separate rules for them.
2. Subdomains pages.newsblur.com and icons.newsblur.com are S3 bucket aliases.
