### PR TITLE
Fixed tor donation link 404 for swedish locale.

### DIFF
--- a/chromium/_locales/sv/messages.json
+++ b/chromium/_locales/sv/messages.json
@@ -27,7 +27,7 @@
         "message": "Donera till Tor"
     },
     "about_tor_lang_code": {
-        "message": "sv"
+        "message": "en"
     },
     "about_donate_eff": {
         "message": "Donera till EFF"

--- a/src/chrome/locale/sv/https-everywhere.dtd
+++ b/src/chrome/locale/sv/https-everywhere.dtd
@@ -7,7 +7,7 @@
 <!ENTITY https-everywhere.about.thanks "Tack till">
 <!ENTITY https-everywhere.about.contribute  "Om du gillar HTTPS Everywhere, kanske du kan tänka dig">
 <!ENTITY https-everywhere.about.donate_tor "Donera till Tor">
-<!ENTITY https-everywhere.about.tor_lang_code "sv">
+<!ENTITY https-everywhere.about.tor_lang_code "en">
 <!ENTITY https-everywhere.about.donate_eff "Donera till EFF">
 
 <!ENTITY https-everywhere.menu.about "Om HTTPS Everywhere">


### PR DESCRIPTION
Updated about.tor_lang_code to "en", since there are no "sv" verision of Tor webpage.
