### PR TITLE
Run Chrome incognito in split mode

### DIFF
--- a/chromium/manifest.json
+++ b/chromium/manifest.json
@@ -21,6 +21,7 @@
         "16": "icon16.png", 
         "48": "icon48.png"
     }, 
+    "incognito": "split",
     "manifest_version": 2, 
     "minimum_chrome_version": "18", 
     "name": "__MSG_about_ext_name__", 


### PR DESCRIPTION
Since we now have an LRU cache, be very paranoid about the incognito <-> normal browsing boundary. This runs the extension in a separate process in incognito mode (no shared cache, etc.)

For details: http://developer.chrome.com/extensions/manifest/incognito.html

Upside: No cache leakage.

Downside: More memory usage when in incognito mode.

Signed-off-by: Nick Semenkovich <semenko@alum.mit.edu>
