### PR TITLE
removed broken flavors.me ruleset causing redirect loops

### DIFF
--- a/src/chrome/content/rules/Flavors.me.xml
+++ b/src/chrome/content/rules/Flavors.me.xml
@@ -1,33 +1,12 @@
 <!--
-	Most of help.flavors.me is handled in ENTP-clients.xml.
-
-
-	CDN buckets:
-
-	- d1c4j9e82wzmkz.cloudfront.net
-	- d1y65ifo1occf8.cloudfront.net/f2300b6/
-	- flavors-production-backgrounds.s3.amazonaws.com
-		- Equivalent to dygz78ls5cy51.cloudfront.net
-	- flavors-production-profile-images.s3.amazonaws.com
-		- Equivalent to dgxx4eluoh5w5.cloudfront.net
-
-
-	Nonfunctional subdomains:
-
-		- blog	(hosted on Tumblr)
-
+	Subdomains contain user pages that don't support HTTPS
 -->
 <ruleset name="Flavors.me">
 
-	<target host="flavors.me" />
-	<target host="*.flavors.me" />
+        <target host="flavors.me" />
 
-
-	<rule from="^http://((?:de|es|fr|jp|n[lo]|pt|ru|sv|www)\.)?flavors\.me/"
-		to="https://$1flavors.me/" />
-
-	<rule from="^https?://help\.flavors\.me/(help|pkg|stylesheets)/"
-		to="https://asset-2.tenderapp.com/$1/" />
-
+        <rule from="^http://flavors\.me/"
+                to="https://flavors.me/" />
 
 </ruleset>
+


### PR DESCRIPTION
flavors.me profiles don't work over https because browsers
block 3rd party content and prevent it from loading

the site tries to redirect users away from https which leads
to a redirect loop

the file is outdated and doesn't match existing site structure
