### PR TITLE
[NewsBlur] Secure the domain cookie

### DIFF
--- a/src/chrome/content/rules/NewsBlur.xml
+++ b/src/chrome/content/rules/NewsBlur.xml
@@ -6,5 +6,5 @@
   <rule from="^http://newsblur\.com/" to="https://www.newsblur.com/"/>
   <rule from="^http://([^/:@.]*)\.newsblur\.com/" to="https://$1.newsblur.com/" />
   <rule from="^https://popular\.global\.newsblur\.com/" to="http://popular.global.newsblur.com/" downgrade="1" />
-  <securecookie host="^www\.newsblur\.com$" name=".*" />
+  <securecookie host="^(?:www)?\.newsblur\.com$" name=".*" />
 </ruleset>


### PR DESCRIPTION
Missed this one: there's a session cookie for host=.newsblur.com that's not secured by default.
