### PR TITLE
add uptimerobot.com ruleset

### DIFF
--- a/src/chrome/content/rules/uptimerobot.xml
+++ b/src/chrome/content/rules/uptimerobot.xml
@@ -1,0 +1,7 @@
+<ruleset name="Uptime Robot">
+  <target host="uptimerobot.com" />
+
+  <rule from="^http://uptimerobot\.com/" to="https://uptimerobot.com/"/>
+
+  <securecookie host="^(?:.*\.)?uptimerobot\.com$" name=".+" />
+</ruleset>


### PR DESCRIPTION
Adds rules for uptimerobot.com which offers SSL but for some reason doesn't default to using it.
