### PR TITLE
Ruleset for womenonwaves.org

### DIFF
--- a/src/chrome/content/rules/Womenonwaves.org.xml
+++ b/src/chrome/content/rules/Womenonwaves.org.xml
@@ -1,0 +1,6 @@
+<ruleset name="Womenonwaves.org">
+  <target host="womenonwaves.org" />
+  <target host="www.womenonwaves.org" />
+
+  <rule from="^http://(www\.)?womenonwaves\.org/" to="https://www.womenonwaves.org/" />
+</ruleset>


### PR DESCRIPTION
womenonwaves is the organization that edits womenonweb.net which is already part of the ruleset. womenonweb is a website proposing an online medical abortion service to people in countries where abortion is forbidden or otherwise complicated.
