### PR TITLE
[FoxyProxy] Adding forums support; cert is fixed

### DIFF
--- a/src/chrome/content/rules/Get_Foxy_Proxy.org.xml
+++ b/src/chrome/content/rules/Get_Foxy_Proxy.org.xml
@@ -1,16 +1,14 @@
-<!--
-	Nonfunctional subdomains:
-
-		- forums	(refused)
-
--->
 <ruleset name="Get Foxy Proxy.org (partial)">
 
 	<target host="getfoxyproxy.org" />
 	<target host="www.getfoxyproxy.org" />
+	<target host="forums.getfoxyproxy.org" />
 
 
 	<rule from="^http://(www\.)?getfoxyproxy\.org/"
 		to="https://$1getfoxyproxy.org/" />
+
+	<rule from="http://forums\.getfoxyproxy\.org/"
+		to="https://forums.getfoxyproxy.org/"
 
 </ruleset>


### PR DESCRIPTION
https://forums.getfoxyproxy.org/ now return valid certificate.
