### PR TITLE
Added ruleset for Stichting IAPC

### DIFF
--- a/src/chrome/content/rules/iapc.utwente.nl.xml
+++ b/src/chrome/content/rules/iapc.utwente.nl.xml
@@ -12,4 +12,5 @@
 	<rule from="^http://iapc\.(utwente\.)?nl/" to="https://www.iapc.utwente.nl/"/>
 	<rule from="^http://([^/:@]*\.)?isdewinkelopen\.nl/" to="https://isdewinkelopen.iapc.utwente.nl/"/>
 	<rule from="^http://([^/:@]*\.)?startjesucces\.nl/" to="https://startjesucces.iapc.utwente.nl/"/>
+	<securecookie host="(^|\.)iapc.utwente.nl$" name=".*" />
 </ruleset>


### PR DESCRIPTION
Our student association at the University of Twente uses HTTPS for all internal and public web services.
