### PR TITLE
[Oktatas.hu] Mark as mixedcontent

### DIFF
--- a/src/chrome/content/rules/Oktatas.hu.xml
+++ b/src/chrome/content/rules/Oktatas.hu.xml
@@ -1,4 +1,4 @@
-<ruleset name="Oktat&#225;si Hivatal">
+<ruleset name="Oktat&#225;si Hivatal" platform="mixedcontent">
   <target host="kir.hu" />
   <target host="oktatas.hu" />
   <target host="www.kir.hu" />


### PR DESCRIPTION
This change marks the Oktatas.hu ruleset as mixedcontent, as enforcing HTTPS now breaks the site.
