### PR TITLE
Exclude blog.4chan.org

### DIFF
--- a/src/chrome/content/rules/4chan.xml
+++ b/src/chrome/content/rules/4chan.xml
@@ -43,7 +43,7 @@
 		<!--
 			Blogger:
 					-->
-		<exclusion pattern="^http://status\." />
+		<exclusion pattern="^http://(status|blog)\." />
 	<target host="4chan-ads.org" />
 	<target host="*.4chan-ads.org" />
 	<target host="4channel.org" />


### PR DESCRIPTION
4chan's blog is hosted on Tumblr which doesn't support SSL for custom domains. Loading `blog.4chan.org` over SSL won't work.
