### PR TITLE
Enable/Disable Rules UI quick fix.

### DIFF
--- a/src/chrome/content/code/HTTPSRules.js
+++ b/src/chrome/content/code/HTTPSRules.js
@@ -564,6 +564,18 @@ const HTTPSRules = {
         intoList.push(fromList[i]);
   },
 
+  loadAllRulesets: function() {
+    for (var host in this.targets) {
+      var ruleset_ids = this.targets[host];
+      for (var i = 0; i < ruleset_ids.length; i++) {
+        var id = ruleset_ids[i];
+        if (!this.rulesetsByID[id]) {
+          this.loadRulesetById(id);
+        }
+      }
+    }
+  },
+
   // Load a ruleset by numeric id, e.g. 234
   // NOTE: This call runs synchronously, which can lock up the browser UI. Is
   // there any way to fix that, given that we need to run blocking in the request

--- a/src/chrome/content/preferences.js
+++ b/src/chrome/content/preferences.js
@@ -10,7 +10,7 @@ https_everywhere = CC["@eff.org/https-everywhere;1"]
   .getService(Components.interfaces.nsISupports)
   .wrappedJSObject;
 
-rulesets = Array.slice(https_everywhere.https_rules.rulesets);
+rulesets = [];
 
 const id_prefix = "he_enable";
 const pref_prefix = "extensions.https_everywhere.";
@@ -149,7 +149,9 @@ function compareRules(a, b, col) {
 
 function https_prefs_init(doc) {
   var st = document.getElementById('sites_tree');
-  
+  https_everywhere.https_rules.loadAllRulesets();
+  rulesets = Array.slice(https_everywhere.https_rules.rulesets);
+
   // GLOBAL VARIABLE!
   treeView = {
     rules: rulesets,


### PR DESCRIPTION
Load all rules at dialog open time. Slow.

This gets us back to correct functionality while I work on a better solution that maintains responsiveness while load rules, or loads rules at search time.
