### PR TITLE
Quick fix for Twitch/Justin.tv

### DIFF
--- a/src/chrome/content/rules/Justin.tv.xml
+++ b/src/chrome/content/rules/Justin.tv.xml
@@ -17,6 +17,7 @@
 		- s *
 		- static	(mismatched, CN: *.justin.tv)
 		- blog.justin.tv	(wordpress)
+                - static-cdn.jtvnw.net
 
 	* Times out
 
@@ -27,7 +28,6 @@
 
 			- s		(→ static.justin.tv)
 			- static	(→ static.justin.tv)
-			- static-cdn	(→ static.justin.tv)
 
 		- justin.tv
 		- static.justin.tv
@@ -36,13 +36,11 @@
 -->
 <ruleset name="Justin.tv (partial)">
 
-
 	<target host="justin.tv" />
 	<target host="static.justin.tv" />
 	<target host="twitch.tv" />
 
-
-
+        
 	<rule from="^http://(static\.)?(justin|twitch)\.tv/"
 		to="https://$1$2.tv/" />
 


### PR DESCRIPTION
Quick fix to allow usage of Twitch/Justin.tv sites. Current master will show grey screen. Additional testing/changes to this rule should allow more thorough usage of HTTPS Everywhere Twitch/Justin.tv, as the site does not utilize SSH on all content served over some subdomains.
