### PR TITLE
Remove some old hosts for actblue.com

### DIFF
--- a/src/chrome/content/rules/ActBlue.xml
+++ b/src/chrome/content/rules/ActBlue.xml
@@ -2,34 +2,31 @@
 	CDN buckets:
 
 		- s3.amazonaws.com/i.actblue.com/
-		- d1gjqyr9cva5pi.cloudfront.net
-		- d1q85vn0sl19b5.cloudfront.net
-		- d2f8x7hc613baw.cloudfront.net
-		- dopnrkrjwe62k.cloudfront.net
 
 
 	Nonfunctional subdomains:
 
-		- blog	(hosted at actblue.typepad.com; doesn't redirect
-			 back, but that doesn't support https either.)
+		- blog	(hosted at blogdotactbluedotcom.wordpress.com)
 
 -->
 <ruleset name="ActBlue (partial)">
 
 	<target host="actblue.com" />
 	<target host="*.actblue.com" />
-	<target host="s.secure.actblue.com" />
 
 
 	<securecookie host="^\.actblue\.com$" name=".*" />
 
 
-	<!--	Server actually redirects from (www.) to secure.
-							-->
-	<rule from="^http://(?:(?:s\.)?secure\.|www\.)?actblue\.com/"
+	<rule from="^http://secure\.actblue\.com/"
 		to="https://secure.actblue.com/" />
 
-	<rule from="^https?://(i|public)\.actblue\.com/"
-		to="https://s3.amazonaws.com/$1.actblue.com/" />
+	<!--	Server actually redirects from (www.) to secure.
+							-->
+	<rule from="^https?://(?:www|m)\.actblue\.com/"
+		to="https://secure.actblue.com/" />
+
+	<rule from="^https?://i\.actblue\.com/"
+		to="https://s3.amazonaws.com/i.actblue.com/" />
 
 </ruleset>


### PR DESCRIPTION
Hi, admin for ActBlue here. I noticed your rules for our site referred to some CDNs and S3 buckets that are no longer used. I have attempted to clean them up and simplify the redirects. I have also added m.actblue.com to redirects (our servers do this redirect -- there used to be a different URLs for mobile).

Please let me know if I need to sign any CLA or if this needs improvement. Thanks.
