### PR TITLE
[NewsBlur] exclude blog subdomain (tumblr CNAME)

### DIFF
--- a/src/chrome/content/rules/NewsBlur.xml
+++ b/src/chrome/content/rules/NewsBlur.xml
@@ -1,6 +1,8 @@
 <ruleset name="NewsBlur">
-  <target host="*.newsblur.com" />
   <target host="newsblur.com" />
+  <target host="*.newsblur.com" />
+  <!-- blog CNAMEs to tumblr -->
+  <exclusion pattern="^http://blog\.newsblur\.com/" />
 
   <rule from="^http://(icons|pages)\.newsblur\.com/" to="https://s3.amazonaws.com/$1.newsblur.com/"/>
   <rule from="^http://newsblur\.com/" to="https://www.newsblur.com/"/>


### PR DESCRIPTION
The subdomain blog.newsblur.com is a CNAME for tumblr with no HTTPS support.
