### PR TITLE
Add simple rule for www.york.ac.uk

### DIFF
--- a/src/chrome/content/rules/University_of_York.xml
+++ b/src/chrome/content/rules/University_of_York.xml
@@ -1,0 +1,7 @@
+<ruleset name="University of York">
+
+  <target host="www.york.ac.uk" />
+
+  <rule from="^http://www\.york\.ac\.uk/" to="https://www.york.ac.uk/" />
+
+</ruleset>


### PR DESCRIPTION
To force http://www.york.ac.uk/ to https://www.york.ac.uk/
