### PR TITLE
Fix Issue244

### DIFF
--- a/src/chrome/content/rules/RecycleNow.xml
+++ b/src/chrome/content/rules/RecycleNow.xml
@@ -1,4 +1,4 @@
-<ruleset name="Recycle Now" default_off="Site does not support HTTPS currently">
+<ruleset name="Recycle Now (No HTTPS)" default_off="Site does not support HTTPS currently">
 
 	<target host="recyclenow.com"/>
 	<target host="www.recyclenow.com"/>


### PR DESCRIPTION
I have verified that recyclenow.com does not support HTTPS and the page will fail to load unless HTTP is used.
