### PR TITLE
Disable doubleclick rule by default to avoid breaking video content

### DIFF
--- a/src/chrome/content/rules/Doubleclick.net.xml
+++ b/src/chrome/content/rules/Doubleclick.net.xml
@@ -63,7 +63,7 @@
 	NB: If there's still any breakage *give details*.
 
 -->
-<ruleset name="Doubleclick.net (testing)">
+<ruleset name="Doubleclick.net (testing)" default_off="Breaks video content, probably best to block doubleclick instead">
 
 	<target host="doubleclick.com" />
 	<target host="www.doubleclick.com" />


### PR DESCRIPTION
As per Issue #240, the doubleclick.net ruleset is preventing content such as videos (e.g. on ted.com) from playing.  I've run into this problem myself in the past and verified then and again recently that disabling the doubleclick ruleset resolves the issue.
