### PR TITLE
Make sure HTTPS is used over the 'secure' subdomain on twitch.tv

### DIFF
--- a/src/chrome/content/rules/Justin.tv.xml
+++ b/src/chrome/content/rules/Justin.tv.xml
@@ -47,4 +47,6 @@
 	<rule from="^http://api\.twitch\.tv/" to="https://api.twitch.tv/"/>
 	
 	<rule from="^http://chatdepot\.twitch\.tv/" to="https://chatdepot.twitch.tv/"/>
+
+  <rule from="^http://secure\.twitch\.tv/*" to="https://secure.twitch.tv/$1" />
 </ruleset>


### PR DESCRIPTION
User login/registration on twitch.tv (covered by the justin.tv rule) uses the `secure` subdomain, which uses HTTPS (eg: https://secure.twitch.tv/user/login).  I just extended the rule to ensure coverage for the `secure` subdomain.
