### PR TITLE
Avoid vim [sic!] dependency

### DIFF
--- a/makecrx.sh
+++ b/makecrx.sh
@@ -135,7 +135,7 @@ version_hex="0200 0000" # 2
 pub_len_hex=$(byte_swap $(printf '%08x\n' $(ls -l "$pub" | awk '{print $5}')))
 sig_len_hex=$(byte_swap $(printf '%08x\n' $(ls -l "$sig" | awk '{print $5}')))
 (
-  echo "$crmagic_hex $version_hex $pub_len_hex $sig_len_hex" | xxd -r -p
+  echo "$crmagic_hex $version_hex $pub_len_hex $sig_len_hex" | sed -e 's/\s//g' -e 's/\([0-9A-F]\{2\}\)/\\\\\\x\1/gI' | xargs printf
   cat "$pub" "$sig" "$zip"
 ) > "$crx"
 #rm -rf pkg/crx


### PR DESCRIPTION
I know this sounds crazy, but `xxd` is a weird tool, that is part of `vim`. It might be better to avoid it in favour of `sed`. I'm not sure, though.

```
WARNINGS
       The tools weirdness matches its creators brain.
       Use entirely at your own risk.
       Copy files. Trace it. Become a wizard.
```

© `man xxd`
