### PR TITLE
Fixed the regex in secure.twitch.tv 

### DIFF
--- a/src/chrome/content/rules/Justin.tv.xml
+++ b/src/chrome/content/rules/Justin.tv.xml
@@ -48,5 +48,5 @@
 	
 	<rule from="^http://chatdepot\.twitch\.tv/" to="https://chatdepot.twitch.tv/"/>
 
-  <rule from="^http://secure\.twitch\.tv/*" to="https://secure.twitch.tv/$1" />
+  <rule from="^http://secure\.twitch\.tv/" to="https://secure.twitch.tv/" />
 </ruleset>


### PR DESCRIPTION
The $1 becomes a literal in this context and the wildcard can be disregarded as well.
