### PR TITLE
Adds *.tox.im ruleset in preparation for May

### DIFF
--- a/src/chrome/content/rules/tox.xml
+++ b/src/chrome/content/rules/tox.xml
@@ -1,0 +1,6 @@
+<ruleset name="Tox">
+  <target host="tox.im" />
+  <target host="*.tox.im" />
+  <rule from="http://tox\.im/" to="https://tox.im" />
+  <rule from="^http://([^/:@]*)\.tox\.im/" to="https://$1.tox.im/" />
+</ruleset>


### PR DESCRIPTION
Just getting ready for the hold on rulesets to be lifted, funny enough we just finished forcing https for our urls requiring authentication.

This provides it for our other subdomains who use sni. (Due to ie 6 support forcing https isn't an option in our sni sites)
