### PR TITLE
Add rule for pegelf.de

### DIFF
--- a/src/chrome/content/rules/Pegelf.de.xml
+++ b/src/chrome/content/rules/Pegelf.de.xml
@@ -1,0 +1,7 @@
+<ruleset name="Pegelf.de">
+  <target host="www.pegelf.de" />
+  <target host="pegelf.de" />
+
+  <exclusion pattern="^http://blog\.pegelf\.de/"/>
+  <rule from="^http://(www\.)?pegelf\.de/" to="https://pegelf.de/"/>
+</ruleset>


### PR DESCRIPTION
This is a simple rule for https://pegelf.de
