### PR TITLE
Hacky MCB workaround

### DIFF
--- a/src/chrome.manifest
+++ b/src/chrome.manifest
@@ -40,7 +40,7 @@ component {32c165b4-fe5e-4964-9250-603c410631b4} components/https-everywhere.js
 contract @eff.org/https-everywhere;1 {32c165b4-fe5e-4964-9250-603c410631b4}
 
 category profile-after-change HTTPSEverywhere @eff.org/https-everywhere;1
-category content-policy HTTPSEverywhere @eff.org/https-everywhere;1
+category content-policy @mozilla.org/mixedcontentblocker;1 @eff.org/https-everywhere;1
 
 overlay chrome://browser/content/browser.xul chrome://https-everywhere/content/toolbar_button.xul
 overlay chrome://navigator/content/navigator.xul chrome://https-everywhere/content/toolbar_button.xul


### PR DESCRIPTION
The idea is to create a stand-in mixed content blocker that simply defers to the real one, but after rewriting the URL first.

Disclaimer: I know next to nothing about XPCOM and the nicest thing I can say about this patch is that it seems to work.
