### PR TITLE
[Github] separate rule for github pages

### DIFF
--- a/src/chrome/content/rules/Github-Pages.xml
+++ b/src/chrome/content/rules/Github-Pages.xml
@@ -1,0 +1,11 @@
+<!--
+	For other GitHub coverage, see Github.xml.
+-->
+<ruleset name="GitHub Pages">
+
+	<target host="*.github.io" />
+
+	<rule from="^http://([^/@:\.]+)\.github\.io/"
+		to="https://$1.github.io/" />
+
+</ruleset>

--- a/src/chrome/content/rules/Github.xml
+++ b/src/chrome/content/rules/Github.xml
@@ -1,6 +1,7 @@
 <!--
 	Other GitHub rulesets:
 
+		- Github-Pages.xml
 		- Guag.es.xml
 		- Speaker_Deck.com.xml
 
@@ -54,8 +55,6 @@
 
 		- collector.githubapp.com
 
-		- github.io
-
 		- githubusercontent.com
 
 -->
@@ -64,7 +63,6 @@
 	<target host="github.com" />
 	<target host="*.github.com" />
 	<target host="github.io" />
-	<target host="*.github.io" />
 	<target host="*.githubusercontent.com" />
 	<target host="collector.githubapp.com" />
 
@@ -88,9 +86,6 @@
 
 	<rule from="^https?://github\.io/"
 		to="https://pages.github.com/" />
-
-	<rule from="^http://([^/@:\.]+)\.github\.io/"
-		to="https://$1.github.io/" />
 
 	<rule from="^http://([^/@:\.]+)\.githubusercontent\.com/"
 		to="https://$1.githubusercontent.com/" />


### PR DESCRIPTION
Some github pages are not designed for https due to mixed content, and aren't motivated to fix because their primarily purpose is to CNAME a vanity domain (which can't support SSL). This makes it easier to work with those pages - especially for dev & testing - without disabling all of Github
