### PR TITLE
Add Amazon AWS exclusion rule, fixing #167

### DIFF
--- a/src/chrome/content/rules/AmazonAWS.xml
+++ b/src/chrome/content/rules/AmazonAWS.xml
@@ -128,6 +128,10 @@
 				https://trac.torproject.org/projects/tor/ticket/7608 
 											 -->
 		<exclusion pattern="^http://charts-datawrapper\.s3\.amazonaws\.com/" />
+		<!--
+			Breaks forecast.io radar images
+							-->
+		<exclusion pattern="^http://darkskysatellite(maps)?\.s3\.amazonaws\.com/" />
 	<target host="amazonwebservices.com" />
 	<target host="*.amazonwebservices.com" />
 	<target host="*.images-amazon.com" />


### PR DESCRIPTION
This fixes radar images on forecast.io
Without this, the radar images do not display due to a CORS violation.

This fixes #167 
