### PR TITLE
remove an item from the rule cache when it is disabled by the user. This...

### DIFF
--- a/chromium/popup.js
+++ b/chromium/popup.js
@@ -14,6 +14,8 @@ function toggleRuleLine(checkbox, ruleset) {
     localStorage[ruleset.name] = ruleset.active;
   } else {
     delete localStorage[ruleset.name];
+    // purge the name from the cache so that this unchecking is persistent.
+    backgroundPage.ruleCache.remove(ruleset.name);
   }
   // Now reload the selected tab of the current window.
   chrome.tabs.reload();

--- a/chromium/rules.js
+++ b/chromium/rules.js
@@ -205,7 +205,7 @@ RuleSets.prototype = {
     // Have we cached this result? If so, return it!
     var cached_item = ruleCache.get(host);
     if (cached_item !== undefined) {
-        log(DBUG, "Ruleset cache hit for " + host);
+        log(DBUG, "Ruleset cache hit for " + host + " items:" + cached_item.length);
         return cached_item;
     }
     log(DBUG, "Ruleset cache miss for " + host);


### PR DESCRIPTION
... prevents duplicate rules from being created and ensures that the user action is in effect right away.
