### PR TITLE
Added new ruleset for WebShop Revolution (webshoprevolution.com)

### DIFF
--- a/src/chrome/content/rules/WebShopRevolution.com.xml
+++ b/src/chrome/content/rules/WebShopRevolution.com.xml
@@ -1,0 +1,13 @@
+<ruleset name="WebShop Revolution">
+    
+    <!-- WebShop Revolution Sites and Client Shops -->
+    <target host="webshoprevolution.com" />
+    <target host="*.webshoprevolution.com" />
+
+    <!-- Rule for no subdomain - http://webshoprevolution.com -->
+    <rule from="^http://webshoprevolution\.com/" to="https://webshoprevolution.com/" />
+    
+    <!-- Rule for any subdomain - http://*.webshoprevolution.com -->
+    <rule from="^http://([\w-]+)\.webshoprevolution\.com/" to="https://$1.webshoprevolution.com/" />
+
+</ruleset>


### PR DESCRIPTION
Created a new ruleset for [WebShop Revolution](https://www.webshoprevolution.com) and sub-sites (some of which are in closed beta)

Tested in Firefox 32.01a (HTTPS Everywhere v3.5.1) and with trivial-validate.py
