### PR TITLE
Fix #310

### DIFF
--- a/src/chrome/content/rules/Mozilla.xml
+++ b/src/chrome/content/rules/Mozilla.xml
@@ -319,7 +319,7 @@
 		to="https://mozillalabs.com/" />
 
 	<rule from="^https?://people\.mozilla\.org/"
-		to="https://people.mozilla.com/" />
+		to="https://people.mozilla.org/" />
 
 	<!--	Redirects like so over http.
 						-->


### PR DESCRIPTION
people.mozilla.org was incorrectly redirecting to people.mozilla.com
