### PR TITLE
Initialize Convergence's NSS.js with nss library path (#8314)

### DIFF
--- a/src/chrome/content/code/NSS.js
+++ b/src/chrome/content/code/NSS.js
@@ -31,8 +31,10 @@ NSS.initialize = function(nssPath) {
   try {
     sharedLib = ctypes.open(nssPath);    
   } catch (e) {
-    dump("Failed to find nss3 in installed directory, checking system paths.\n");
-    sharedLib = ctypes.open(ctypes.libraryName("nss3"));
+    Components.utils.import("resource://gre/modules/Services.jsm");
+    var nssFile = Services.dirsvc.get("GreD", Ci.nsILocalFile);
+    nssFile.append(ctypes.libraryName("nss3"));
+    sharedLib = ctypes.open(nssFile.path);
   }
 
   NSS.types = new Object();

--- a/src/components/ssl-observatory.js
+++ b/src/components/ssl-observatory.js
@@ -137,7 +137,7 @@ function SSLObservatory() {
     this.setupASNWatcher();
 
   try {
-    NSS.initialize("");
+    NSS.initialize(ctypes.libraryName("nss3"));
   } catch(e) {
     this.log(WARN, "Failed to initialize NSS component:" + e);
   }


### PR DESCRIPTION
glibc's dlopen [treats empty library name string as equivalent to NULL](https://sourceware.org/git/?p=glibc.git;a=blob;f=dlfcn/dlopen.c;h=fa58c4cebff4bc5d2f087b216a6d2c15b1ffa64b;hb=HEAD#l66) and returns an RTLD_DEFAULT handle. OS X' stricter implementation doesn't and fails to load anything when "" is passed as filename. So nss loading via js-ctypes in NSS.js fails on Macs leading  to the console error seen in trac defect 8314.  

Instead of empty string, ssl-observatory can try passing the full library name and if that fails, the full path to libnss3 (in the same way [Convergence initializes NSS.js](https://github.com/moxie0/Convergence/blob/2699d3c4e562983aa500780448ebb3e0bf2384c8/client/components/Convergence.js#L78)
