### PR TITLE
fix typo in rule, change ; to :

### DIFF
--- a/src/chrome/content/rules/ServerPilot.io.xml
+++ b/src/chrome/content/rules/ServerPilot.io.xml
@@ -14,7 +14,7 @@
 	<securecookie host="^\.serverpilot\.io$" name=".+" />
 
 
-	<rule from="^http;//(manage\.|www\.)?serverpilot\.io/"
+	<rule from="^http://(manage\.|www\.)?serverpilot\.io/"
 		to="https://$1serverpilot.io/" />
 
 </ruleset>


### PR DESCRIPTION
fix typo in serverpilot.io rule, http; should be http:
