### PR TITLE
[Wikimedia] Add HTTP-only subdomain parsoid-lb.eqiad.wikimedia.org

### DIFF
--- a/src/chrome/content/rules/Wikimedia.xml
+++ b/src/chrome/content/rules/Wikimedia.xml
@@ -14,7 +14,7 @@
 	<target host="www.mediawiki.org" />
 	<target host="wikimedia.org" />
 	<target host="*.wikimedia.org" />
-		<exclusion pattern="^http://(?:apt|cs|cz|status|torrus|ubuntu)\.wikimedia\.org" />
+		<exclusion pattern="^http://(?:apt|cs|cz|parsoid-lb\.eqiad|status|torrus|ubuntu)\.wikimedia\.org" />
 		<!-- https://mail1.eff.org/pipermail/https-everywhere-rules/2012-June/001189.html -->
 		<exclusion pattern="^http://lists\.wikimedia\.org/pipermail(?:$|/)" />
 	<target host="wikimediafoundation.org" />


### PR DESCRIPTION
See http://parsoid-lb.eqiad.wikimedia.org/
