### PR TITLE
Remove rule for SL.se since it breaks their site

### DIFF
--- a/src/chrome/content/rules/SL.se.xml
+++ b/src/chrome/content/rules/SL.se.xml
@@ -1,6 +1,0 @@
-<ruleset name="SL.se">
-	<target host="sl.se" />
-	<rule from="^http://sl\.se/" to="https://sl.se/"/>
-	<rule from="^http://www\.sl\.se/" to="https://sl.se/"/>
-</ruleset>
-


### PR DESCRIPTION
The new site for SL.se redirects all https requests to http and therefore HTTPS everywhere breaks the javascript functionality on their site.

```
$ curl -D - https://sl.se   
HTTP/1.1 302 Found
Cache-Control: private, max-age=0, s-maxage=0
Content-Type: text/html; charset=utf-8
Location: http://sl.se/
Server: Microsoft-IIS/7.5
Set-Cookie: ASP.NET_SessionId=tfyog1cyeskx0ma0iafai2tk; path=/; HttpOnly
X-AspNetMvc-Version: 4.0
X-AspNet-Version: 4.0.30319
X-Powered-By: ASP.NET
Date: Tue, 29 Jul 2014 12:01:18 GMT
Content-Length: 130

<html><head><title>Object moved</title></head><body>
<h2>Object moved to <a href="http://sl.se/">here</a>.</h2>
</body></html>
```
