### PR TITLE
add rule for Caschys Blog

### DIFF
--- a/src/chrome/content/rules/Stadt-bremerhaven.de.xml
+++ b/src/chrome/content/rules/Stadt-bremerhaven.de.xml
@@ -1,0 +1,7 @@
+<ruleset name="Caschys Blog">
+<target host="stadt-bremerhaven.de"/>
+<target host="*.stadt-bremerhaven.de"/>
+
+<rule from="^http://m\.stadt-bremerhaven\.de/" to="https://m.stadt-bremerhaven.de/"/>
+<rule from="^http://(www\.)?stadt-bremerhaven\.de/" to="https://stadt-bremerhaven.de/"/>
+</ruleset>


### PR DESCRIPTION
TLS is available for the german it news blog stadt-bremerhaven.de
Added a rule for both the desktop and the mobile version
