### PR TITLE
Add exclusion for Brightcove URL that was breaking videos on TheAtlantic

### DIFF
--- a/src/chrome/content/rules/Brightcove.xml
+++ b/src/chrome/content/rules/Brightcove.xml
@@ -89,6 +89,14 @@
 		<!--
 			https://mail1.eff.org/pipermail/https-everywhere-rules/2013-May/001587.html
 													-->
+		<!--
+			Videos fail to load.
+			https://trac.torproject.org/projects/tor/ticket/12405
+			The Brightcove player loads in an iframe, whose URL gets correctly
+			rewritten to HTTPS. However, that iframe attempts to load a script
+			that runs afoul of the mixed content blocking bug. -->
+		<exclusion pattern="^https://secure.brightcove.com/services/viewer/" />
+
 		<exclusion pattern="^http://admin\.brightcove\.com/viewer/us20[\d\.]+/BrightcoveBootloader\.swf(?:\?|$)" />
 		<!--exclusion pattern="^https?://c\.brightcove\.com/services/messagebroker/amf\?playerId=" /-->
 		<exclusion pattern="^http://admin\.brightcove\.com/viewer/.+\.swf(?:\?|$)" />


### PR DESCRIPTION
Fixes https://trac.torproject.org/projects/tor/ticket/12405

cc @joshmaker, thanks for the bug report!
