### PR TITLE
Exclusion for generate_204 captive portal detection issue.

### DIFF
--- a/src/chrome/content/rules/GoogleAPIs.xml
+++ b/src/chrome/content/rules/GoogleAPIs.xml
@@ -77,6 +77,10 @@
 	<target host="*.googleapis.com" />
 	<target host="gstatic.com" />
 	<target host="*.gstatic.com" />
+	<!--	Captive portal detection redirects to this URL, and many captive
+		portals break TLS, so exempt this redirect URL.
+		See GitHub bug #368
+							-->
 		<exclusion pattern="^http://www\.gstatic\.com/generate_204" />
 	<target host="api.recaptcha.net" />
 	<target host="gdata.youtube.com" />


### PR DESCRIPTION
Fix for issue #368 (I think). Haven't had a chance to test yet.

Signed-off-by: Nick Semenkovich <semenko@alum.mit.edu>
