### PR TITLE
WSJ dropped SSL support for si.* (all images 404).

### DIFF
--- a/src/chrome/content/rules/News-Corporation.xml
+++ b/src/chrome/content/rules/News-Corporation.xml
@@ -56,9 +56,9 @@
 								-->
 		<exclusion pattern="^http://barrons\.wsj\.net/css/barronsDependencies/" />
 		<!--
-			2013 images 404:
+			All of si.wsj now seems to 404, but others (s., sc., ...) do not.
 					-->
-		<exclusion pattern="^https?://si?\.wsj\.net/public/resources/images/\w\w-\w{5}_\w{3,6}_\w_2013" />
+		<exclusion pattern="^https?://si?\.wsj\.net/" />
 	<target host="services.wsje.com" />
 	<target host="smartmoney.com" />
 	<target host="*.smartmoney.com" />


### PR DESCRIPTION
Fix WSJ.com -- it's been very broken for a while now.

Signed-off-by: Nick Semenkovich <semenko@alum.mit.edu>
