### PR TITLE
Make install.rdf compatible with AMO.

### DIFF
--- a/src/install.rdf
+++ b/src/install.rdf
@@ -30,7 +30,7 @@
             <Description>
                 <em:id>{92650c4d-4b8e-4d2a-b7eb-24ecf4f6b63a}</em:id>
                 <em:minVersion>2.17</em:minVersion>
-                <em:maxVersion>2.31</em:maxVersion>
+                <em:maxVersion>2.32</em:maxVersion>
             </Description>
         </em:targetApplication>
         <!-- thunderbird -->
@@ -38,7 +38,7 @@
             <Description>
                 <em:id>{3550f703-e582-4d05-9a08-453d09bdfdc6}</em:id> 
                 <em:minVersion>17.*</em:minVersion>
-                <em:maxVersion>32.*</em:maxVersion>
+                <em:maxVersion>35.*</em:maxVersion>
             </Description> 
         </em:targetApplication> 
         <!-- Conkeror -->
@@ -54,7 +54,7 @@
           <Description>
             <em:id>{aa3c5121-dab2-40e2-81ca-7ea25febc110}</em:id>
             <em:minVersion>21.0</em:minVersion>
-            <em:maxVersion>33.0</em:maxVersion>
+            <em:maxVersion>35.0</em:maxVersion>
           </Description>
         </em:targetApplication>
     </Description>


### PR DESCRIPTION
AMO is picky about the values of minVersion/maxVersion fields, they have to be
listed in:
https://addons.mozilla.org/en-US/firefox/pages/appversions/

Note: In order to upload to AMO we'll also need to remove the updateURL and
updateKey fields.

This is a merge against the 4.0 release branch.
