### PR TITLE
Fix UBS rule case error from recent merge.

### DIFF
--- a/src/chrome/content/rules/UBS.xml
+++ b/src/chrome/content/rules/UBS.xml
@@ -72,6 +72,9 @@
 	<securecookie host="^.*\.ubs\.com$" name=".+" />
 
 
+	<rule from="^http://(?:www\.)?ubs\.com/"
+	      to="https://www.ubs.com/"/>
+
 	<rule from="^https?://ubs\.com/"
 		to="https://www.ubs.com/" />
 

--- a/src/chrome/content/rules/ubs.xml
+++ b/src/chrome/content/rules/ubs.xml
@@ -1,9 +1,0 @@
-<ruleset name="UBS">
-	<target host="ubs.com"/>
-	<target host="www.ubs.com"/>
-
-	<rule from="^http://(?:www\.)?ubs\.com/"
-		to="https://www.ubs.com/"/>
-	<rule from="^http://([^/:@]*)\.ubs\.com/"
-		to="https://$1.ubs.com/"/>
-</ruleset>


### PR DESCRIPTION
Recently took a UBS PR that broke case-insensitive systems, found in other tests. Cool!
