### PR TITLE
Build scripts fail when RELAX NG check fails.

### DIFF
--- a/makecrx.sh
+++ b/makecrx.sh
@@ -43,37 +43,70 @@ if [ "$1" != "--fast" -o ! -f "$RULESETS_SQLITE" ] ; then
   python2.7 ./utils/make-sqlite.py
 fi
 
-if [ -f utils/trivial-validate.py ]; then
-	VALIDATE="./utils/trivial-validate.py --ignoredups google --ignoredups facebook"
-elif [ -x utils/trivial-validate ] ; then
-  # This case probably never happens
-	VALIDATE=./utils/trivial-validate
-else
-	VALIDATE=./trivial-validate
-fi
+# =============== BEGIN VALIDATION ================
+# Unless we're in a hurry, validate the ruleset library & locales
 
-if $VALIDATE src/chrome/content/rules >&2
-then
-  echo Validation of included rulesets completed. >&2
-  echo >&2
-else
-  echo ERROR: Validation of rulesets failed. >&2
+die() {
+  echo >&2 "ERROR:" "$@"
   exit 1
-fi
+}
 
-if [ -f utils/relaxng.xml -a -x "$(which xmllint)" ] >&2
-then
-  # Use find and xargs to avoid "too many args" error on Mac OS X
-  if find src/chrome/content/rules/ -name "*.xml" | xargs xmllint --noout --relaxng utils/relaxng.xml
-  then
-    echo Validation of rulesets with RELAX NG grammar completed. >&2
+if [ "$1" != "--fast" ] ; then
+  if [ -f utils/trivial-validate.py ]; then
+    VALIDATE="python2.7 ./utils/trivial-validate.py --ignoredups google --ignoredups facebook"
+  elif [ -f trivial-validate.py ] ; then
+    VALIDATE="python2.7 trivial-validate.py --ignoredups google --ignoredups facebook"
+  elif [ -x utils/trivial-validate ] ; then
+    # This case probably never happens
+    VALIDATE=./utils/trivial-validate
   else
-    echo ERROR: Validation of rulesets with RELAX NG grammar failed. >&2
-    exit 1
+    VALIDATE=./trivial-validate
   fi
-else
-  echo Validation of rulesets with RELAX NG grammar was SKIPPED. >&2
+
+  if $VALIDATE src/chrome/content/rules >&2
+  then
+    echo Validation of included rulesets completed. >&2
+    echo >&2
+  else
+    die "Validation of rulesets failed."
+  fi
+
+  # Check for xmllint.
+  type xmllint >/dev/null || die "xmllint not available"
+
+  GRAMMAR="utils/relaxng.xml"
+  if [ -f "$GRAMMAR" ]
+  then
+    # xmllint spams stderr with "<FILENAME> validates, even with the --noout
+    # flag. We can't grep -v for that line, because the pipeline will mask error
+    # status from xmllint. Instead we run it once going to /dev/null, and if
+    # there's an error run it again, showing only error output.
+    validate_grammar() {
+      find src/chrome/content/rules -name "*.xml" | \
+       xargs xmllint --noout --relaxng utils/relaxng.xml
+    }
+    if validate_grammar 2>/dev/null
+    then
+      echo Validation of rulesets against $GRAMMAR succeeded. >&2
+    else
+      validate_grammar 2>&1 | grep -v validates
+      die "Validation of rulesets against $GRAMMAR failed."
+    fi
+  else
+    echo Validation of rulesets against $GRAMMAR SKIPPED. >&2
+  fi
+
+  if [ -x ./utils/compare-locales.sh ] >&2
+  then
+    if ./utils/compare-locales.sh >&2
+    then
+      echo Validation of included locales completed. >&2
+    else
+      die "Validation of locales failed."
+    fi
+  fi
 fi
+# =============== END VALIDATION ================
 
 sed -e "s/VERSION/$VERSION/g" chromium/updates-master.xml > chromium/updates.xml
 

--- a/makexpi.sh
+++ b/makexpi.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/bin/bash
+set -o errexit -o pipefail
 APP_NAME=https-everywhere
 
 # builds a .xpi from the git repository, placing the .xpi in the root
@@ -66,6 +67,11 @@ fi
 # =============== BEGIN VALIDATION ================
 # Unless we're in a hurry, validate the ruleset library & locales
 
+die() {
+  echo >&2 "ERROR:" "$@"
+  exit 1
+}
+
 if [ "$1" != "--fast" ] ; then
   if [ -f utils/trivial-validate.py ]; then
     VALIDATE="python2.7 ./utils/trivial-validate.py --ignoredups google --ignoredups facebook"
@@ -83,22 +89,33 @@ if [ "$1" != "--fast" ] ; then
     echo Validation of included rulesets completed. >&2
     echo >&2
   else
-    echo ERROR: Validation of rulesets failed. >&2
-    exit 1
+    die "Validation of rulesets failed."
   fi
 
-  if [ -f utils/relaxng.xml -a -x "$(which xmllint)" ] >&2
+  # Check for xmllint.
+  type xmllint >/dev/null || die "xmllint not available"
+
+  GRAMMAR="utils/relaxng.xml"
+  if [ -f "$GRAMMAR" ]
   then
-    if find src/chrome/content/rules -name "*.xml" | xargs xmllint --noout --relaxng utils/relaxng.xml
+    # xmllint spams stderr with "<FILENAME> validates, even with the --noout
+    # flag. We can't grep -v for that line, because the pipeline will mask error
+    # status from xmllint. Instead we run it once going to /dev/null, and if
+    # there's an error run it again, showing only error output.
+    validate_grammar() {
+      find src/chrome/content/rules -name "*.xml" | \
+       xargs xmllint --noout --relaxng utils/relaxng.xml
+    }
+    if validate_grammar 2>/dev/null
     then
-      echo Validation of rulesets with RELAX NG grammar completed. >&2
+      echo Validation of rulesets against $GRAMMAR succeeded. >&2
     else
-      echo ERROR: Validation of rulesets with RELAX NG grammar failed. >&2
-      exit 1
+      validate_grammar 2>&1 | grep -v validates
+      die "Validation of rulesets against $GRAMMAR failed."
     fi
   else
-    echo Validation of rulesets with RELAX NG grammar was SKIPPED. >&2
-  fi 2>&1 | grep -v validates
+    echo Validation of rulesets against $GRAMMAR SKIPPED. >&2
+  fi
 
   if [ -x ./utils/compare-locales.sh ] >&2
   then
@@ -106,8 +123,7 @@ if [ "$1" != "--fast" ] ; then
     then
       echo Validation of included locales completed. >&2
     else
-      echo ERROR: Validation of locales failed. >&2
-      exit 1
+      die "Validation of locales failed."
     fi
   fi
 fi


### PR DESCRIPTION
Also revamp makexpi a little bit and copy fixes to makecrx.

Fixes #462

Rejected approach: set -o pipefail seems like it would work, but grep -v foo returns status 1 if no lines are output.

TODO: DRY up build process #471
