### PR TITLE
Mark XPIs dirty when there are uncommitted changes

### DIFF
--- a/makexpi.sh
+++ b/makexpi.sh
@@ -135,7 +135,11 @@ if [ "$1" ] && [ "$1" != "--fast" ] ; then
 	XPI_NAME="$XPI_NAME.xpi"
 else
   # During development, generate packages named with the short hash of HEAD.
-	XPI_NAME="$XPI_NAME~`git rev-parse --short HEAD`.xpi"
+	XPI_NAME="$XPI_NAME~`git rev-parse --short HEAD`"
+        if ! git diff-index --quiet HEAD; then
+            XPI_NAME="$XPI_NAME-dirty"
+        fi
+        XPI_NAME="$XPI_NAME.xpi"
 fi
 
 [ -d pkg ] || mkdir pkg


### PR DESCRIPTION
Minor change to make it clear when an XPI is built from a dirty state.

(Unfortunately, Github doesn't seem to allow @pde or I to open pull requests from our own HTTPS-E repos because we didn't fork from this one.)
