### PR TITLE
[Oracle] Remove broken subdomain download.oracle.com

### DIFF
--- a/src/chrome/content/rules/Oracle.xml
+++ b/src/chrome/content/rules/Oracle.xml
@@ -55,6 +55,7 @@
 			- ^			(refused)
 			- crmondemand *
 			- docs			(works, akamai)
+			- download (mismatched)
 			- japanmediacentre **	(works; mismatched, CN: *.presscentre.com)
 
 		- oracleimg.com *
@@ -306,7 +307,7 @@
 	<rule from="^http://crmondemand\.oracle\.com/"
 		to="https://www.oracle.com/us/products/applications/crmondemand/index.html" />
 
-	<rule from="^http://(i?academy|acsportal|advancedsupport|amr|amr-stage|apex|apexea|asktom|blogs(?:-stage)?|campus|cloud|\w+\.(?:em1|us0|us1)\.cloud|communities|competencycentre|conference|digitalmedia|dne|download|edelivery(?:-hqdc-test)?|education(?:-stage)?|emeajobs|emeapressoffice|etrm|(?:cn\.|kr\.)?forums(?:-stage)?|(?:bi-|crm-|fin-|[hs]cm-|ic-|pr[cj]-)?fusioncrm|fusionhelp(?:-stage)?|gcmprm|hs-ws1|ilearning(?:content)?|irecruitment|itsp|itsp-stage|linux|login(?:-stage)?|medianetwork|my?|myprofile(?:-mktas)?|oai|oss|otn|partners|plmap|public-yum|search|shop|solutions|stbeehive|strtc|suppliers|support(?:html)?|updates|wfs|wikis(?:-stage)?|workforce|www(?:-portal)?-stage)\.oracle\.com/"
+	<rule from="^http://(i?academy|acsportal|advancedsupport|amr|amr-stage|apex|apexea|asktom|blogs(?:-stage)?|campus|cloud|\w+\.(?:em1|us0|us1)\.cloud|communities|competencycentre|conference|digitalmedia|dne|edelivery(?:-hqdc-test)?|education(?:-stage)?|emeajobs|emeapressoffice|etrm|(?:cn\.|kr\.)?forums(?:-stage)?|(?:bi-|crm-|fin-|[hs]cm-|ic-|pr[cj]-)?fusioncrm|fusionhelp(?:-stage)?|gcmprm|hs-ws1|ilearning(?:content)?|irecruitment|itsp|itsp-stage|linux|login(?:-stage)?|medianetwork|my?|myprofile(?:-mktas)?|oai|oss|otn|partners|plmap|public-yum|search|shop|solutions|stbeehive|strtc|suppliers|support(?:html)?|updates|wfs|wikis(?:-stage)?|workforce|www(?:-portal)?-stage)\.oracle\.com/"
 		to="https://$1.oracle.com/" />
 
 	<rule from="^http://docs\.oracle\.com/(?=favicon\.ico|.+/(?:cs|graphic)s/)"


### PR DESCRIPTION
Disable redirection for download.oracle.com
Example of broken URL: https://docs.oracle.com/javase/tutorial/uiswing/components/scrollpane.html
