### PR TITLE
add ruleset for img.shields.io

### DIFF
--- a/src/chrome/content/rules/Img.shields.io.xml
+++ b/src/chrome/content/rules/Img.shields.io.xml
@@ -1,0 +1,5 @@
+<ruleset name="Img.shields.io">
+  <target host="img.shields.io" />
+
+  <rule from="^http://img\.shields\.io/" to="https://img.shields.io/" />
+</ruleset>


### PR DESCRIPTION
simple rule but no 'www' subdomain
also doesn't apply to main shields.io site, just img subdomain
