### PR TITLE
[ProPublica.org] add map tile CDN

### DIFF
--- a/src/chrome/content/rules/ProPublica.org.xml
+++ b/src/chrome/content/rules/ProPublica.org.xml
@@ -16,5 +16,7 @@
 	<rule from="^http://cdn\.propublica\.net/"
 		to="https://s3.amazonaws.com/cdn.propublica.net/"/>
 
+	<rule from="^http://tiles-[abcd]\.propublica\.org/"
+		to="https://d3i4wq2ul46tvd.cloudfront.net/"/>
 </ruleset>
 


### PR DESCRIPTION
As used in [this project](http://projects.propublica.org/louisiana/) and some other places that don’t have protocol scheme smarts just yet.

i.e.
http://tiles-a.propublica.org/louisiana/raster/1/505/847/11/processed_loss_gain_0.png
ꜜ
https://d3i4wq2ul46tvd.cloudfront.net/louisiana/raster/1/505/847/11/processed_loss_gain_0.png
