### PR TITLE
Add ysu.edu and ysubookstore.com

### DIFF
--- a/src/chrome/content/rules/Ysu.edu.xml
+++ b/src/chrome/content/rules/Ysu.edu.xml
@@ -1,0 +1,31 @@
+<!--
+        Mixed content:
+
+                - Fonts, on ^ from:
+
+                        - fonts.googleapis.com *
+
+                - Scripts, on ^ from:
+
+                        - code.jquery.com *
+
+                - Iframe, on ^ from:
+
+                        - www.meltwaternews.com *
+
+        * Secured by us
+-->
+<ruleset name="Youngstown State University (partial)" default_off="Needs additional testing" platform="mixedcontent">
+  <target host="ysu.edu" />
+  <target host="www.ysu.edu" />
+
+  <!-- Only www and a few other subdomains work. I haven't found an alternative
+       for content on web.ysu.edu, unfortunately. -->
+  <rule from="^http://(?:www\.|)ysu\.edu/" to="https://swww.ysu.edu/" />
+  <rule from="^http://(cfweb\.cc|csis)\.ysu\.edu/"
+        to="https://$1.ysu.edu/" />
+
+  <!-- This is a 200 that uses JavaScript to redirect. Would rather encrypt the
+       entire communication. -->
+  <rule from="^http://my\.ysu\.edu/" to="https://my.ysu.edu/" />
+</ruleset>

--- a/src/chrome/content/rules/Ysubookstore.com.xml
+++ b/src/chrome/content/rules/Ysubookstore.com.xml
@@ -1,0 +1,6 @@
+<ruleset name="Youngstown State University Bookstore">
+  <target host="ysubookstore.com" />
+  <target host="www.ysubookstore.com" />
+
+  <rule from="^http://(www\.)?ysubookstore\.com/" to="https://www.ysubookstore.com/" />
+</ruleset>


### PR DESCRIPTION
Leaving ysu.edu off by default for now, I think it needs some more testing.
I'm also trying to work with them to fix some of the mixed-content warnings.

Signed-off-by: Ricky Elrod ricky@elrod.me
