### PR TITLE
Exclude Wells Fargo OCSP server validator.wellsfargo.com

### DIFF
--- a/src/chrome/content/rules/WellsFargo.xml
+++ b/src/chrome/content/rules/WellsFargo.xml
@@ -2,6 +2,7 @@
   <target host="wellsfargo.com" />
   <target host="*.wellsfargo.com" />
 
+  <exclusion pattern="^http://validator\.wellsfargo\.com/"/>
   <rule from="^http://wellsfargo\.com/" to="https://www.wellsfargo.com/" />
   <rule from="^http://([^/:@\.]+)\.wellsfargo\.com/" to="https://$1.wellsfargo.com/" />
 </ruleset>


### PR DESCRIPTION
Exclude Wells Fargo OCSP server validator.wellsfargo.com
This is an HTTP-only OCSP server with no response on port 443.  Attempting to force-upgrade OCSP connections breaks sites that use the Wells Fargo certificate authority including healthbenefits.wellsfargo.com, wellsfargocommunity.com, and others.
