### PR TITLE
Add rules for WebPlatform.org

### DIFF
--- a/src/chrome/content/rules/WebPlatform.xml
+++ b/src/chrome/content/rules/WebPlatform.xml
@@ -1,0 +1,23 @@
+<!--
+	Problematic domains:
+
+		- webplatform.org
+		- talk.webplatform.org
+		- www1.webplatform.org
+-->
+<ruleset name="WebPlatform">
+	<target host="blog.webplatform.org" />
+	<target host="code.webplatform.org" />
+	<target host="docs.webplatform.org" />
+	<target host="preview.webplatform.org" />
+	<target host="project.webplatform.org" />
+	<target host="result.webplatform.org" />
+	<target host="source.webplatform.org" />
+	<target host="static.webplatform.org" />
+	<target host="stats.webplatform.org" />
+	<target host="www.webplatform.org" />
+ 	<rule
+ 		from="^http://(blog|code|docs|preview|project|result|source|static|stats|www)\.webplatform\.org/"
+		to="https://$1.webplatform.org/" />
+	<securecookie host="^(blog|code|docs|preview|project|result|source|static|stats|www)\.webplatform\.org$" name=".+" />
+</ruleset>


### PR DESCRIPTION
I used the CN + SANs in their current certificate and then tested each manually.

``` bash
$ getcertnames docs.webplatform.org
Testing docs.webplatform.org…

Common Name:

www1.webplatform.org

Subject Alternative Name(s):

www1.webplatform.org
webplatform.org
www.webplatform.org
talk.webplatform.org
blog.webplatform.org
docs.webplatform.org
code.webplatform.org
result.webplatform.org
preview.webplatform.org
project.webplatform.org
stats.webplatform.org
static.webplatform.org
source.webplatform.org
```
