### PR TITLE
make-sqlite.py locale fix

### DIFF
--- a/utils/make-sqlite.py
+++ b/utils/make-sqlite.py
@@ -16,11 +16,7 @@ from lxml import etree
 # This is important for deterministic builds.
 # https://trac.torproject.org/projects/tor/ticket/11630#comment:20
 # It's also helpful to ensure consistency for the lowercase check below.
-# Systems differ on UTF8 or UTF-8. Use try to test both to avoid failures.
-try :
-     locale.setlocale(locale.LC_ALL, 'en_US.UTF8')
-except :
-       locale.setlocale(locale.LC_ALL, 'en_US.UTF-8')
+locale.setlocale(locale.LC_ALL, 'en_US.UTF-8')
 
 conn = sqlite3.connect(os.path.join(os.path.dirname(__file__), '../src/defaults/rulesets.sqlite'))
 c = conn.cursor()


### PR DESCRIPTION
This would fix #653. My Python is hella basic though, so this might be horribly wrong. Open to criticism and/or suggestions. @jsha

It works locally, but that doesn't necessarily mean I've done it right, heh.
