### PR TITLE
Secure image.e.mozilla.org using a248.e.akamai.net

### DIFF
--- a/src/chrome/content/rules/Mozilla.xml
+++ b/src/chrome/content/rules/Mozilla.xml
@@ -29,7 +29,7 @@
 			- getpersonas-cdn.mozilla.net
 			- hardhat.mozilla.net
 
-		- images.s4.exacttarget.com.edgesuite.net
+		- a248.e.akamai.net/f/1/1/1/image.e.mozilla.org/
 
 			- image.e.mozilla.org
 
@@ -312,13 +312,22 @@
 
 				https://mail1.eff.org/pipermail/https-everywhere-rules/2013-June/001635.html
 													-->
-		<exclusion pattern="^http://(?:bonsai|browserquest|trychooser\.pub\.build|dxr|\w+\.e|graphs|krakenbenchmark|releases|sfx-images|start|w(?:ebsite|ww)-archive)\.mozilla\.org/" />
+		<exclusion pattern="^http://(?:bonsai|browserquest|trychooser\.pub\.build|dxr|(?:(?!image)\w)+\.e|graphs|krakenbenchmark|releases|sfx-images|start|w(?:ebsite|ww)-archive)\.mozilla\.org/" />
 	<target host="mdn.mozillademos.org" />
 	<target host="mozillaignite.com" />
 	<target host="*.mozillaignite.com" />
 	<target host="*.mozillamessaging.com" />
 	<target host="webfwd.org" />
 	<target host="www.webfwd.org" />
+	
+	<!-- Images in e-mail newsletters
+	
+	Example:
+	http://image.e.mozilla.org/lib/fe9915707361037e75/m/1/headerLogo_112x90.jpg
+	https://a248.e.akamai.net/f/1/1/1/image.e.mozilla.org/lib/fe9915707361037e75/m/1/headerLogo_112x90.jpg
+	-->
+	<rule from="^http://image\.e\.mozilla\.org/"
+		to="https://a248.e.akamai.net/f/1/1/1/image.e.mozilla.org/" />
 
 
 	<!--	Not secured by server:
@@ -359,10 +368,7 @@
 	<!--	Would these rules be safe?
 
 	<rule from="^http://click\.e\.mozilla\.org/"
-		to="https://click.virt.s4.exacttarget.com/" />
-
-	<rule from="^http://image\.e\.mozilla\.org/"
-		to="https://image.s4.exacttarget.com/" /-->
+		to="https://click.virt.s4.exacttarget.com/" /-->
 
 	<!--	Redirects like so over http.
 						-->


### PR DESCRIPTION
Allows images in Mozilla e-mail newsletters to be loaded over HTTPS
