### PR TITLE
[ProPublica.org]: Add securedrop.propublica.org

### DIFF
--- a/src/chrome/content/rules/ProPublica.org.xml
+++ b/src/chrome/content/rules/ProPublica.org.xml
@@ -49,7 +49,7 @@
 	<rule from="^http://cdn\.propublica\.net/"
 		to="https://s3.amazonaws.com/cdn.propublica.net/" />
 
-	<rule from="^http://(www\.|projects\.|static\.)?propublica\.org/"
+	<rule from="^http://(www\.|projects\.|static\.|securedrop\.)?propublica\.org/"
 		to="https://$1propublica.org/" />
 
 	<rule from="^http://tiles-[abcd]\.propublica\.org/"


### PR DESCRIPTION
Endpoint for our SecureDrop info page. Forgot to include this in #705, sorry.
