### PR TITLE
Rule for ulule.com

### DIFF
--- a/src/chrome/content/rules/Ulule.xml
+++ b/src/chrome/content/rules/Ulule.xml
@@ -1,0 +1,10 @@
+<ruleset name="Ulule" platform="mixedcontent">
+
+    <target host="*.ulule.com" />
+    <target host="ulule.com" />
+
+    <rule from="^http://(www\.)?ulule\.com/" to="https://$1ulule.com/"/>
+
+    <rule from="^http://(fr|de|es|it|br)\.ulule\.com/" to="https://$1.ulule.com/"/>
+
+</ruleset>


### PR DESCRIPTION
Everything works correctly except some AJAX requests for the Facebook-like notifications that trigger a mixed content error. So I added platform="mixedcontent", is that the right way to go?
