### PR TITLE
add ruleset for vault.cca.edu

### DIFF
--- a/src/chrome/content/rules/Vault.cca.edu.xml
+++ b/src/chrome/content/rules/Vault.cca.edu.xml
@@ -1,0 +1,4 @@
+<ruleset name="Vault.cca.edu">
+  <target host="vault.cca.edu" />
+  <rule from="^http://vault\.cca\.edu/" to="https://vault.cca.edu/" />
+</ruleset>


### PR DESCRIPTION
Domain is for the digital archive of California College of the Arts. It supports, but does not by itself force, HTTPS.
