### PR TITLE
Fix filename and rule name for Appcache/5apps(.com)

### DIFF
--- a/src/chrome/content/rules/5apps.com-mismatches.xml
+++ b/src/chrome/content/rules/5apps.com-mismatches.xml
@@ -1,4 +1,4 @@
-<ruleset name="Appache (mismatches)" default_off="tender certificate">
+<ruleset name="5apps (mismatches)" default_off="tender certificate">
 
 	<target host="help.5apps.com"/>
 

--- a/src/chrome/content/rules/5apps.com.xml
+++ b/src/chrome/content/rules/5apps.com.xml
@@ -6,7 +6,7 @@
 		- libs
 
 -->
-<ruleset name="Appache (partial)">
+<ruleset name="5apps (partial)">
 
 	<target host="5apps.com" />
 	<target host="*.5apps.com" />


### PR DESCRIPTION
While browsing our website I noticed that HTTPS Everywhere had a typo in
the site name. As our products and websites are known under the name
5apps, rather than the formal company name Appcache Ltd, I renamed all
of it to 5apps instead of just fixing the typo.
