### PR TITLE
Fix getBrowserForChannel to work on non-e10s.

### DIFF
--- a/src/components/https-everywhere.js
+++ b/src/components/https-everywhere.js
@@ -334,7 +334,7 @@ HTTPSEverywhere.prototype = {
           .getInterface(CI.nsILoadContext);
       } catch(e) {
         this.log(NOTE, "no loadGroup notificationCallbacks for "
-                 + channel.URI.spec + ': ' + e);
+                 + channel.URI.spec + ": " + e);
         return null;
       }
     }


### PR DESCRIPTION
cc @cooperq for code review.
