### PR TITLE
Fixed NKNews.org rule

### DIFF
--- a/src/chrome/content/rules/NK_News.org.xml
+++ b/src/chrome/content/rules/NK_News.org.xml
@@ -1,30 +1,14 @@
 <!--
-	Nonfunctional subdomains:
+  Nonfunctional subdomains:
 
-		- kcnawatch	(shows www)
-
-
-	Some pages redirect to http.
-
-
-	Mixed content:
-
-		- Images on shop from shop *
-
-	* Secured by us
-
+    - kcnawatch
 -->
 <ruleset name="NK News.org (partial)">
+  <target host="nknews.org" />
+  <target host="*.nknews.org" />
 
-	<target host="nknews.org" />
-	<target host="*.nknews.org" />
-		<exclusion pattern="^http://(?:www\.)?nknews\.org/+(?!favicon\.ico|register(?:$|[?/])|wp-content/|wp-includes/)" />
+  <securecookie host="^shop\.nknews\.org$" name=".+" />
 
-
-	<securecookie host="^shop\.nknews\.org$" name=".+" />
-
-
-	<rule from="^http://(shop\.|www\.)?nknews\.org/"
-		to="https://$1nknews.org/" />
-
+  <rule from="^http://(shop\.|www\.)?nknews\.org/"
+    to="https://$1nknews.org/" />
 </ruleset>


### PR DESCRIPTION
Nknews.org recently redesigned their site, which caused the old rule to break. The exclusion pattern excluded the whole site.
