### PR TITLE
Add exclusion for books.google.com.

### DIFF
--- a/src/chrome/content/rules/GoogleServices.xml
+++ b/src/chrome/content/rules/GoogleServices.xml
@@ -215,6 +215,7 @@
 		<!--exclusion pattern="^http://books\.google\.com/(?!books/(\w+\.js|css/|javascript/)|favicon\.ico|googlebooks/|images/|intl/)" /-->
 		<exclusion pattern="^http://cbks0\.google\.com/(?:$|\?)" />
 		<exclusion pattern="^http://gg\.google\.com/(?!csi(?:$|\?))" />
+		<exclusion pattern="^http://books.google.com" />
 	<target host="google.com.*" />
 	<target host="accounts.google.com.*" />
 	<target host="adwords.google.com.*" />


### PR DESCRIPTION
It redirects from HTTPS->HTTP, presumably because it uses AppCache, which does
not support HTTPS.

Fixes #756 

cc @cooperq for code review.