### PR TITLE
Use LC_ALL=C for filename sorting in make-sqlite.

### DIFF
--- a/utils/make-sqlite.py
+++ b/utils/make-sqlite.py
@@ -16,7 +16,7 @@ from lxml import etree
 # This is important for deterministic builds.
 # https://trac.torproject.org/projects/tor/ticket/11630#comment:20
 # It's also helpful to ensure consistency for the lowercase check below.
-locale.setlocale(locale.LC_ALL, 'en_US.UTF-8')
+locale.setlocale(locale.LC_ALL, 'C')
 
 conn = sqlite3.connect(os.path.join(os.path.dirname(__file__), '../src/defaults/rulesets.sqlite'))
 c = conn.cursor()


### PR DESCRIPTION
Sorting is necessary for deterministic builds. Per
https://trac.torproject.org/projects/tor/ticket/11630#comment:19,
gk's build machine doesn't have the UTF-8 locale. Since the locale
doesn't determine output encoding, only sorting, and all that matters
is that the sort order is deterministic, LC_ALL=C is fine, and more
likely to be present on any given machine.

cc @cooperq for code review.

Reminder to self: Also cherry-pick to 4.0 branch after submit.
