### PR TITLE
[ProPublica.org]: mail.propublica.org

### DIFF
--- a/src/chrome/content/rules/ProPublica.org.xml
+++ b/src/chrome/content/rules/ProPublica.org.xml
@@ -49,7 +49,7 @@
 	<rule from="^http://cdn\.propublica\.net/"
 		to="https://s3.amazonaws.com/cdn.propublica.net/" />
 
-	<rule from="^http://(www\.|projects\.|static\.|securedrop\.)?propublica\.org/"
+	<rule from="^http://(www\.|mail\.|projects\.|static\.|securedrop\.)?propublica\.org/"
 		to="https://$1propublica.org/" />
 
 	<rule from="^http://tiles-[abcd]\.propublica\.org/"


### PR DESCRIPTION
I think this covers the last of our HTTPS-capable subdomains. Following up on #705 #706. This updated site ruleset has been tested pretty thoroughly at this point — per @semenko's comment in #705, I’ll probably PR the ruleset into stable once this gets into master.
