### PR TITLE
[Fastmail] include new "fastmail.com" domain

### DIFF
--- a/src/chrome/content/rules/Fastmail.xml
+++ b/src/chrome/content/rules/Fastmail.xml
@@ -15,18 +15,20 @@
 -->
 <ruleset name="Fastmail (partial)">
 
+	<target host="fastmail.com" />
 	<target host="fastmail.fm" />
+	<target host="*.fastmail.com" />
 	<target host="*.fastmail.fm" />
 
 
 	<!--	Secured by server:
 					-->
-	<!--securecookie host="^\.(beta|qa|www)\.fastmail\.fm$" name="^_s$" /-->
+	<!--securecookie host="^\.(beta|qa|www)\.fastmail\.(com|fm)$" name="^_s$" /-->
 
-	<securecookie host="^\.www\.fastmail\.fm$" name=".+" />
+	<securecookie host="^\.www\.fastmail\.(com|fm)$" name=".+" />
 
 
-	<rule from="^http://((?:beta|qa|www)\.)?fastmail\.fm/"
-		to="https://$1fastmail.fm/" />
+	<rule from="^http://((?:beta|qa|www)\.)?fastmail\.(com|fm)/"
+		to="https://$1fastmail.com/" />
 
 </ruleset>


### PR DESCRIPTION
Fastmail got a new domain name!
Keep the fastmail.fm domain for old bookmarks and links.
