### PR TITLE
Add a rule for Etherpad.fr

### DIFF
--- a/src/chrome/content/rules/etherpad.fr.xml
+++ b/src/chrome/content/rules/etherpad.fr.xml
@@ -1,0 +1,6 @@
+<ruleset name="etherpad.fr">
+  <target host="etherpad.fr" />
+  <target host="www.etherpad.fr" />
+
+  <rule from="^http://(www\.)?etherpad\.fr/" to="https://etherpad.fr/" />
+</ruleset>


### PR DESCRIPTION
Please note that I am not the website's owner, but Etherpad.fr has had working
SSL for a while, now.
