### PR TITLE
Secure BlogOverflow.com subdomains

### DIFF
--- a/src/chrome/content/rules/Stack-Exchange.xml
+++ b/src/chrome/content/rules/Stack-Exchange.xml
@@ -31,6 +31,7 @@
 		- cdn-chat.sstatic.com
         	- *.stackexchange.com
 		- teststackoverflow.com
+		- *.blogoverflow.com
 
 
 	www.teststackoverflow.com doesn't exist.
@@ -80,6 +81,7 @@
 		- meta.superuser.com
 		- stackapps.com
 		- openid.stackauth.com
+		- *.blogoverflow.com (Dec., 2014)
 
 
 	Insecure cookies are set for the following domains:
@@ -134,6 +136,9 @@
 
 	<rule from="^http://(?:www\.)?blogoverflow\.com/$"
 		to="https://stackexchange.com/blogs" />
+	
+	<rule from="^http://([^\/]+)\.blogoverflow\.com/"
+		to="https://$1.blogoverflow.com/" />
 
 	<rule from="^http://(?:(or\.)?cdn\.)?sstatic\.net/"
 		to="https://$1cdn.sstatic.net/" />


### PR DESCRIPTION
StackExchange has an SSL certificate for these now.
