### PR TITLE
katasterportal.sk is disabled because the site supports only SSL3.

### DIFF
--- a/src/chrome/content/rules/SlovakGoverment.xml
+++ b/src/chrome/content/rules/SlovakGoverment.xml
@@ -1,3 +1,7 @@
+<!--
+  katasterportal.sk is disabled because the site supports only SSL3.
+-->
+
 <ruleset name="SlovakGoverment">
 
 <!-- Central Government Portal -->
@@ -109,7 +113,7 @@
   <rule from="^http://(www\.)?sav\.sk/" to="https://www.sav.sk/" />
 
   <rule from="^http://(www\.)?sutn\.sk/" to="https://www.sutn.sk/" />
-
+<!-- katasterportal.sk is supporting only SSL3.
   <rule from="^http://(www\.)?katasterportal\.sk/" to="https://www.katasterportal.sk/" />
-
+-->
 </ruleset>


### PR DESCRIPTION
SSL3 is disabled by default in Firefox.
