### PR TITLE
If there is no adb, converting misleading fatal error to a warning

### DIFF
--- a/makexpi.sh
+++ b/makexpi.sh
@@ -182,8 +182,6 @@ else
                          -d file:///mnt/sdcard/"$XPI_NAME" \
                          -n $ANDROID_APP_ID/.App
     fi
-  else
-    echo >&2 "Warning: adb not found, no android version"
   fi
 
   if [ -n "$BRANCH" ]; then


### PR DESCRIPTION
In the current system, if there is no adb on the system (an android tool), it builds everything normally, but gives a seemingly fatal error:

Created pkg/https-everywhere-5.0development.2~0e77731-dirty.xpi
./makexpi.sh: Zeile 175: type: adb: Not found.

It is probably not the intended behavior. This changes the misleading fatal error to a warning:

Created pkg/https-everywhere-5.0development.2~0e77731-dirty.xpi
Warning: adb not found, no android version
