### PR TITLE
StackExchange: duplicated meta beta rule removed, added support to the new localized SO sites and to their metas

### DIFF
--- a/src/chrome/content/rules/Stack-Exchange.xml
+++ b/src/chrome/content/rules/Stack-Exchange.xml
@@ -164,8 +164,11 @@
 	<rule from="^http://(www\.|meta\.)?superuser\.com/"
 		to="https://$1superuser.com/" />
 
-	<rule from="^http://meta\.(\w+)\.stackexchange\.com/"
-		to="https://meta.$1.stackexchange.com/" />
+	<rule from="^http://(\w\w)\.stackoverflow\.com/"
+		to="https://$1.stackoverflow.com/" />
+
+	<rule from="^http://meta\.(\w\w)\.stackoverflow\.com/"
+		to="https://meta.$1.stackoverflow.com/" />
 
 	<rule from="^http://discuss\.area51\.stackexchange\.com/"
 		to="https://discuss.area51.stackexchange.com/" />


### PR DESCRIPTION
- remove duplicated meta beta rules
- added rules to the new localized stackoverflow sites, and to their
  metas