### PR TITLE
[Messagingengine] use new "fastmail.com" domain

### DIFF
--- a/src/chrome/content/rules/Messagingengine.com.xml
+++ b/src/chrome/content/rules/Messagingengine.com.xml
@@ -11,7 +11,7 @@
 	<!--	Redirect keeps path but not args:
 							-->
 	<rule from="^http://(?:www\.)?messagingengine\.com/+([^?]*)(?:\?.*)?"
-		to="https://www.fastmail.fm/$1" />
+		to="https://www.fastmail.com/$1" />
 
 	<rule from="^http://mail\.messagingengine\.com/"
 		to="https://mail.messagingengine.com/" />


### PR DESCRIPTION
Fastmail got a new domain name!

Related to 442cf252829565105fb703a2a5b4aebae3b209a7.
