### PR TITLE
Update MIT-mismatches.xml to include zScore

### DIFF
--- a/src/chrome/content/rules/MIT-mismatches.xml
+++ b/src/chrome/content/rules/MIT-mismatches.xml
@@ -17,12 +17,13 @@
 										-->
 		<exclusion pattern="^http://people\.mit\.edu/($|\?)" />
 	<target host="techtime.mit.edu" />
+	<target host="zscore.mit.edu" />
 
 
 	<securecookie host="^(?:3down|cluedumps)\.mit\.edu$" name=".+" />
 
 
-	<rule from="^http://(3down|calendar|cluedumps|hacks|people)\.mit\.edu/"
+	<rule from="^http://(3down|calendar|cluedumps|hacks|people|zscore)\.mit\.edu/"
 		to="https://$1.mit.edu/" />
 
 	<rule from="^http://techtime\.mit\.edu/(?:\?.*)?$"


### PR DESCRIPTION
zscore.mit.edu provides a sleep schedule analysis service. It handles sensitive and private data such as people's bedtime and wake-up time, and unfortunately do not automatically redirect to https, so it is a good idea to include it in the MIT ruleset. It is a relatively trivial change: just changing `http` to `https` will do.
