### PR TITLE
sources.debian.net, not source.debian.net

### DIFF
--- a/src/chrome/content/rules/Debian.xml
+++ b/src/chrome/content/rules/Debian.xml
@@ -130,7 +130,7 @@
 	<rule from="^http://security\.debian\.org/+(?=$|\?)"
 		to="https://www.debian.org/security/" />
 
-	<rule from="^http://(france|paste|screenshots|source|codesearch)\.debian\.net/"
+	<rule from="^http://(france|paste|screenshots|sources|codesearch)\.debian\.net/"
 		to="https://$1.debian.net/" />
 
 	<rule from="^http://(buildd)\.debian-ports\.org/"


### PR DESCRIPTION
fix typo
