### PR TITLE
Secure aihdownload.adobe.com

### DIFF
--- a/src/chrome/content/rules/Adobe.xml
+++ b/src/chrome/content/rules/Adobe.xml
@@ -73,6 +73,7 @@
 	Fully covered subdomains:
 
 		- (www.)
+		- aihdownload
 		- entitlement.auth
 		- sp.auth
 		- bugbase
@@ -167,7 +168,7 @@
 	<rule from="^http://adobe\.com/"
 		to="https://www.adobe.com/" />
 
-	<rule from="^http://((?:entitlement|sp)\.auth|blogs|bugbase|community|cookbooks|(?:\w\w\.)?creative|edexchange|cem\.events|forums|fpdownload|get3?|helpx|images-tv|kuler|max|adobeid-na1\.services|sstats|store1|success|thumbnails-tv|tv|verify|www|wwwimages2)\.adobe\.com/"
+	<rule from="^http://(aihdownload|(?:entitlement|sp)\.auth|blogs|bugbase|community|cookbooks|(?:\w\w\.)?creative|edexchange|cem\.events|forums|fpdownload|get3?|helpx|images-tv|kuler|max|adobeid-na1\.services|sstats|store1|success|thumbnails-tv|tv|verify|www(?:images2)?)\.adobe\.com/"
 		to="https://$1.adobe.com/" />
 
 	<rule from="^http://get2\.adobe\.com/"


### PR DESCRIPTION
Download URL for Flash player.

Also, combining www and wwwimages2 should make the pattern a little more efficient.