### PR TITLE
Don't exclude bugs.mysql.com

### DIFF
--- a/src/chrome/content/rules/MySQL.xml
+++ b/src/chrome/content/rules/MySQL.xml
@@ -26,7 +26,7 @@
 	<target host="mysql.com"/>
 	<target host="*.mysql.com"/>
     <!-- forums works but is a cert mismatch -->
-		<exclusion pattern="^http://(bugs|cdn|downloads|forge|lists|planet|wb|forums)\.mysql\.com/"/>
+		<exclusion pattern="^http://(cdn|downloads|forge|lists|planet|wb|forums)\.mysql\.com/"/>
 	<target host="mysql.de"/>
 	<target host="www.mysql.de"/>
 	<target host="mysql.fr"/>


### PR DESCRIPTION
The MySQL Bugs website now also has SSL:
https://bugs.mysql.com/bug.php?id=73457

But there is no http->https redirect and the http url is still used in
email notifications:
https://bugs.mysql.com/bug.php?id=75367