### PR TITLE
toggleHttpNowhere function appeared twice in code

### DIFF
--- a/src/components/https-everywhere.js
+++ b/src/components/https-everywhere.js
@@ -870,40 +870,6 @@ HTTPSEverywhere.prototype = {
       thisBranch.setBoolPref("enabled", true);
       this.httpNowhereEnabled = true;
     }
-  },
-
-  toggleHttpNowhere: function() {
-    let prefService = Services.prefs;
-    let thisBranch =
-      prefService.getBranch("extensions.https_everywhere.http_nowhere.");
-    let securityBranch = prefService.getBranch("security.");
-
-    // Whether cert is treated as invalid when OCSP connection fails
-    let OCSP_REQUIRED = "OCSP.require";
-
-    // Branch to save original settings
-    let ORIG_OCSP_REQUIRED = "orig.ocsp.required";
-
-
-    if (thisBranch.getBoolPref("enabled")) {
-      // Restore original OCSP settings. TODO: What if user manually edits
-      // these while HTTP Nowhere is enabled?
-      let origOcspRequired = thisBranch.getBoolPref(ORIG_OCSP_REQUIRED);
-      securityBranch.setBoolPref(OCSP_REQUIRED, origOcspRequired);
-
-      thisBranch.setBoolPref("enabled", false);
-      this.httpNowhereEnabled = false;
-    } else {
-      // Save original OCSP settings in HTTP Nowhere preferences branch.
-      let origOcspRequired = securityBranch.getBoolPref(OCSP_REQUIRED);
-      thisBranch.setBoolPref(ORIG_OCSP_REQUIRED, origOcspRequired);
-
-      // Disable OCSP enforcement
-      securityBranch.setBoolPref(OCSP_REQUIRED, false);
-
-      thisBranch.setBoolPref("enabled", true);
-      this.httpNowhereEnabled = true;
-    }
   }
 };
 


### PR DESCRIPTION
Unless I'm missing something, this function shouldn't appear twice. Checked both occurrences to be exactly the same(with diff). This removes one of them.