### PR TITLE
Garfield.com now redirects back to HTTP

### DIFF
--- a/src/chrome/content/rules/Garfield.com.xml
+++ b/src/chrome/content/rules/Garfield.com.xml
@@ -1,8 +1,5 @@
 <ruleset name="Garfield.com">
-  <target host="garfield.com" />
-  <target host="www.garfield.com" />
   <target host="licensee.garfield.com" />
 
-  <rule from="^http://(?:www\.)?garfield\.com/" to="https://garfield.com/" />
   <rule from="^http://licensee\.garfield\.com/" to="https://licensee.garfield.com/" />
 </ruleset>


### PR DESCRIPTION
Licensee.Garfield.com is still working, though.