### PR TITLE
Turn on Disqus rule by default and remove unreliable flag.

### DIFF
--- a/src/chrome/content/rules/Disqus.com.xml
+++ b/src/chrome/content/rules/Disqus.com.xml
@@ -19,7 +19,7 @@
 		- realtime.services
 
 -->
-<ruleset name="Disqus (unreliable)" default_off="https://eff.org/r.5abU">
+<ruleset name="Disqus">
 
 	<target host="disqus.com" />
 	<target host="*.disqus.com" />


### PR DESCRIPTION
cc @mattrobenolt for review.

Fixes #900.