### PR TITLE
Update Disqus.com.xml

### DIFF
--- a/src/chrome/content/rules/Disqus.com.xml
+++ b/src/chrome/content/rules/Disqus.com.xml
@@ -4,34 +4,13 @@
 
 	Nonfunctional domains:
 
-		disqus.com subdomains:
-
-			- blog		(tumblr)
-			- community     (tumblr)
-
-	Fully covered subdomains:
-
-		- go
-		- juggler.services
-		- realtime.services
+		- none
 
 -->
 <ruleset name="Disqus (unreliable)" default_off="https://www.eff.org/r.5abU">
 
 	<target host="disqus.com" />
 	<target host="*.disqus.com" />
-		<!--
-			https://trac.torproject.org/projects/tor/ticket/5496
-
-			https://mail1.eff.org/pipermail/https-everywhere-rules/2012-May/001176.html
-
-		<exclusion pattern="^http://disqus\.com/next/lounge/client\.html" />
-		<exclusion pattern="^http://\w+\.disqus\.com/\d+/build/system/embed\.js"/>
-
-			See comments at top.
-							-->
-		<exclusion pattern="^http://(?:blog|community)\.disqus\.com/" />
-
 
 	<rule from="^http://(?:www\.)?disqus\.com/"
 		to="https://disqus.com/" />


### PR DESCRIPTION
We now have https on {blog,community}.disqus.com

This should now cover every *.disqus.com and disqus.com property. :sparkling_heart: 