### PR TITLE
Remove bogus INCLUDE(md5). Was replaced by calls to Firefox MD5 API.

### DIFF
--- a/src/components/ssl-observatory.js
+++ b/src/components/ssl-observatory.js
@@ -57,7 +57,6 @@ INCLUDE('Root-CAs');
 INCLUDE('sha256');
 INCLUDE('X509ChainWhitelist');
 INCLUDE('NSS');
-INCLUDE('md5');
 
 function SSLObservatory() {
   this.prefs = CC["@mozilla.org/preferences-service;1"]


### PR DESCRIPTION
cc @cooperq for review