### PR TITLE
Revert "Update Disqus.com.xml"

### DIFF
--- a/src/chrome/content/rules/Disqus.com.xml
+++ b/src/chrome/content/rules/Disqus.com.xml
@@ -4,13 +4,34 @@
 
 	Nonfunctional domains:
 
-		- none
+		disqus.com subdomains:
+
+			- blog		(tumblr)
+			- community     (tumblr)
+
+	Fully covered subdomains:
+
+		- go
+		- juggler.services
+		- realtime.services
 
 -->
 <ruleset name="Disqus (unreliable)" default_off="https://www.eff.org/r.5abU">
 
 	<target host="disqus.com" />
 	<target host="*.disqus.com" />
+		<!--
+			https://trac.torproject.org/projects/tor/ticket/5496
+
+			https://mail1.eff.org/pipermail/https-everywhere-rules/2012-May/001176.html
+
+		<exclusion pattern="^http://disqus\.com/next/lounge/client\.html" />
+		<exclusion pattern="^http://\w+\.disqus\.com/\d+/build/system/embed\.js"/>
+
+			See comments at top.
+							-->
+		<exclusion pattern="^http://(?:blog|community)\.disqus\.com/" />
+
 
 	<rule from="^http://(?:www\.)?disqus\.com/"
 		to="https://disqus.com/" />


### PR DESCRIPTION
As it turns out, Tumblr shut is down for doing this. I had to revert what we did to get https in front of our blogs.

I just routed traffic through our load balancers, which was terminating SSL, then passing the traffic back along to them and it worked fine. They apparently didn't like that and our blogs started 404ing today. Their service requires validating that the DNS record is pointed to `domains.tumblr.com`, and if it's not, they apparently just turn it off.

Any help from Tumblr here would be cool if possible. Fortunately, we're moving this away from Tumblr probably this quarter.

:(