### PR TITLE
Patch hardcoded strings and updated Danish locale

### DIFF
--- a/src/chrome/content/about.xul
+++ b/src/chrome/content/about.xul
@@ -60,7 +60,7 @@
         onmouseover="event.target.style.cursor='pointer'"
         onmouseout="event.target.style.cursor='default'"
         onclick="window_opener('https://www.torproject.org/donate/donate.html.en')"/>
-      or
+      &https-everywhere.about.or;
       <label id="donate link2"
         value="&https-everywhere.about.donate_eff;"
         style="color: blue; cursor:hand; text-decoration:underline; font-style:bold"

--- a/src/chrome/content/toolbar_button.xul
+++ b/src/chrome/content/toolbar_button.xul
@@ -32,7 +32,7 @@
     <toolbarbutton 
       id="https-everywhere-button"
       tooltiptext="&https-everywhere.about.ext_name;"
-      label="HTTPS"
+      label="&https-everywhere.about.ext_name;"
       context="https-everywhere-context-menu"
       oncontextmenu="this.open = true;"
       oncommand="this.open = true;"

--- a/src/chrome/content/toolbar_button.xul
+++ b/src/chrome/content/toolbar_button.xul
@@ -43,7 +43,7 @@
       <menupopup id="https-everywhere-context" onpopupshowing="show_applicable_list(this)">
         <!-- entries will be written here by ApplicableList.populate_menu() -->
         <menuseparator class="hide-on-disable"/>
-        <menuitem type="checkbox" id="http-nowhere-item" label="Block all HTTP requests" 
+        <menuitem type="checkbox" id="http-nowhere-item" label="&https-everywhere.menu.blockHttpRequests;" 
           oncommand="httpsEverywhere.toolbarButton.toggleHttpNowhere()" class="hide-on-disable"/>
         <menuseparator class="hide-on-disable"/>
         <menuitem type="checkbox" id="https-everywhere-counter-item" label="&https-everywhere.menu.showCounter;" 

--- a/src/chrome/locale/ar/https-everywhere.dtd
+++ b/src/chrome/locale/ar/https-everywhere.dtd
@@ -8,12 +8,14 @@
 <!ENTITY https-everywhere.about.contribute  "إن أعجبتك إضافة HTTPS Everywhere، فكر بـ">
 <!ENTITY https-everywhere.about.donate_tor "التبرع لتور">
 <!ENTITY https-everywhere.about.tor_lang_code "en">
+<!ENTITY https-everywhere.about.or "or">
 <!ENTITY https-everywhere.about.donate_eff "التبرع للـ EFF">
 
 <!ENTITY https-everywhere.menu.about "عن  HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.observatory "خيارات مرصد SSL">
 <!ENTITY https-everywhere.menu.globalEnable "فعّل HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.globalDisable "عطّل  HTTPS Everywhere">
+<!ENTITY https-everywhere.menu.blockHttpRequests "Block all HTTP requests">
 <!ENTITY https-everywhere.menu.showCounter "أظهر العداد">
 
 <!ENTITY https-everywhere.prefs.title "خيارات  HTTPS Everywhere">

--- a/src/chrome/locale/bg/https-everywhere.dtd
+++ b/src/chrome/locale/bg/https-everywhere.dtd
@@ -8,12 +8,14 @@
 <!ENTITY https-everywhere.about.contribute  "Ако харесвате HTTPS Everywhere можете да направите">
 <!ENTITY https-everywhere.about.donate_tor "дарение към Tor">
 <!ENTITY https-everywhere.about.tor_lang_code "bg">
+<!ENTITY https-everywhere.about.or "or">
 <!ENTITY https-everywhere.about.donate_eff "дарение към EFF">
 
 <!ENTITY https-everywhere.menu.about "За HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.observatory "Настройки на SSL Observatory">
 <!ENTITY https-everywhere.menu.globalEnable "Включи HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.globalDisable "Изключи HTTPS Everywhere">
+<!ENTITY https-everywhere.menu.blockHttpRequests "Block all HTTP requests">
 <!ENTITY https-everywhere.menu.showCounter "Показване на брояч">
 
 <!ENTITY https-everywhere.prefs.title "Настройки на HTTPS Everywhere">

--- a/src/chrome/locale/ca/https-everywhere.dtd
+++ b/src/chrome/locale/ca/https-everywhere.dtd
@@ -8,12 +8,14 @@
 <!ENTITY https-everywhere.about.contribute  "Si t'agrada HTTPS Everywhere, podries considerar">
 <!ENTITY https-everywhere.about.donate_tor "Donar a Tor">
 <!ENTITY https-everywhere.about.tor_lang_code "en">
+<!ENTITY https-everywhere.about.or "or">
 <!ENTITY https-everywhere.about.donate_eff "Donar a EFF">
 
 <!ENTITY https-everywhere.menu.about "Sobre HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.observatory "Preferències de SSL Observatory">
 <!ENTITY https-everywhere.menu.globalEnable "Activar HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.globalDisable "Desactivar HTTPS Everywhere">
+<!ENTITY https-everywhere.menu.blockHttpRequests "Block all HTTP requests">
 <!ENTITY https-everywhere.menu.showCounter "Mostra el contador">
 
 <!ENTITY https-everywhere.prefs.title "Preferències de HTTPS Everywhere">

--- a/src/chrome/locale/cs/https-everywhere.dtd
+++ b/src/chrome/locale/cs/https-everywhere.dtd
@@ -8,12 +8,14 @@
 <!ENTITY https-everywhere.about.contribute  "Pokud se vám líbí HTTPS Everywhere, můžete">
 <!ENTITY https-everywhere.about.donate_tor "Přispět na Tor">
 <!ENTITY https-everywhere.about.tor_lang_code "en">
+<!ENTITY https-everywhere.about.or "or">
 <!ENTITY https-everywhere.about.donate_eff "Přispět na EFF">
 
 <!ENTITY https-everywhere.menu.about "O aplikaci HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.observatory "Nastavení SSL Observatoře">
 <!ENTITY https-everywhere.menu.globalEnable "Zapnout HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.globalDisable "Vypnout HTTPS Everywhere">
+<!ENTITY https-everywhere.menu.blockHttpRequests "Block all HTTP requests">
 <!ENTITY https-everywhere.menu.showCounter "Zobrazit počítadlo">
 
 <!ENTITY https-everywhere.prefs.title "Nastavení HTTPS Everywhere">

--- a/src/chrome/locale/da/https-everywhere.dtd
+++ b/src/chrome/locale/da/https-everywhere.dtd
@@ -1,20 +1,20 @@
 <!ENTITY https-everywhere.about.title "Om HTTPS Overalt">
 <!ENTITY https-everywhere.about.ext_name "HTTPS Overalt">
-<!ENTITY https-everywhere.about.ext_description "Kryptér nettet! Brug HTTPS-sikkerhed automatisk på mange steder.">
+<!ENTITY https-everywhere.about.ext_description "Kryptér nettet! Brug HTTPS-sikkerhed automatisk på mange netsteder.">
 <!ENTITY https-everywhere.about.version "Version">
 <!ENTITY https-everywhere.about.created_by "Oprettet af">
 <!ENTITY https-everywhere.about.librarians "Regelsæt-bibliotekarer">
 <!ENTITY https-everywhere.about.thanks "Tak til">
-<!ENTITY https-everywhere.about.contribute  "Hvis du kan lide HTTPS Overalt, så vil du måske overveje">
-<!ENTITY https-everywhere.about.donate_tor "Giv bidrag til Tor">
+<!ENTITY https-everywhere.about.contribute  "Hvis du kan lide HTTPS Overalt, så vil du måske overveje at">
+<!ENTITY https-everywhere.about.donate_tor "give bidrag til Tor">
 <!ENTITY https-everywhere.about.tor_lang_code "da">
-<!ENTITY https-everywhere.about.donate_eff "Giv bidrag til EFF">
+<!ENTITY https-everywhere.about.donate_eff "give bidrag til EFF">
 
 <!ENTITY https-everywhere.menu.about "Om HTTPS Overalt">
-<!ENTITY https-everywhere.menu.observatory "Indstillinger for SSL-observatorie">
+<!ENTITY https-everywhere.menu.observatory "Indstillinger for SSL-observatoriet">
 <!ENTITY https-everywhere.menu.globalEnable "Aktivér HTTPS Overalt">
 <!ENTITY https-everywhere.menu.globalDisable "Deaktivér HTTPS Overalt">
-<!ENTITY https-everywhere.menu.showCounter "Vis Disk">
+<!ENTITY https-everywhere.menu.showCounter "Vis tæller">
 
 <!ENTITY https-everywhere.prefs.title "Indstillinger for HTTPS Overalt">
 <!ENTITY https-everywhere.prefs.enable_all "Aktivér alle">
@@ -25,7 +25,7 @@
 <!ENTITY https-everywhere.prefs.notes "Noter">
 <!ENTITY https-everywhere.prefs.list_caption "Hvilke HTTPS-regler skal anvendes?">
 <!ENTITY https-everywhere.prefs.enabled "Aktiveret">
-<!ENTITY https-everywhere.prefs.ruleset_howto "Du kan lære om at skrive dine egne regelsæt (for at føje understøttelse til andre websteder)">
+<!ENTITY https-everywhere.prefs.ruleset_howto "Du kan lære, hvordan du skriver dine egne regelsæt (for at føje understøttelse til andre websteder)">
 <!ENTITY https-everywhere.prefs.here_link "her">
 <!ENTITY https-everywhere.prefs.toggle "Slå til/fra">
 <!ENTITY https-everywhere.prefs.reset_default "Nulstil til standardindstilling">
@@ -36,12 +36,12 @@
 <!ENTITY https-everywhere.source.unable_to_download "Kan ikke hente kilde">
 
 <!ENTITY https-everywhere.popup.title "HTTPS Everywhere 4.0development.11 meddelelse">
-<!ENTITY https-everywhere.popup.paragraph1 "Ups. Du anvendte den stabile version af HTTPS Everywhere, men vi har ved et uheld måske opdateret til udvikler-versionen ved den sidste opdatering.">
+<!ENTITY https-everywhere.popup.paragraph1 "Ups. Du anvendte den stabile version af HTTPS Overalt, men måske har vi ved et uheld opdateret til udvikler-versionen ved den sidste opdatering.">
 <!ENTITY https-everywhere.popup.paragraph2 "Vil du skifte tilbage til den stabile version?">
-<!ENTITY https-everywhere.popup.paragraph3 "Vi ville sætte pris på at du fortsatte med at anvende vores udvikler-version, og derved hjalp os med at gøre HTTPS Everywhere bedre! Der er optræder måske fejl her og der, som du kan rapportere på https-everywhere@eff.org, på engelsk. Vi beklager besværet. Tak fordi du anvender HTTPS Everywhere.">
+<!ENTITY https-everywhere.popup.paragraph3 "Vi ville sætte pris på, at du fortsatte med at anvende vores udvikler-version, og derved hjalp os med at gøre HTTPS Overalt bedre! Der optræder måske fejl her og der, som du kan rapportere på https-everywhere@eff.org, på engelsk. Vi beklager besværet. Tak for at du anvender HTTPS Oversalt.">
 <!ENTITY https-everywhere.popup.keep "Behold udvikler-versionen">
 <!ENTITY https-everywhere.popup.revert "Hent den seneste stabile version">
 
-<!ENTITY https-everywhere.ruleset-tests.status_title "HTTPS Overalt Regelsæt Prøver">
+<!ENTITY https-everywhere.ruleset-tests.status_title "Afprøvninger af HTTPS Overalt-regelsæt">
 <!ENTITY https-everywhere.ruleset-tests.status_cancel_button "Annullér">
 <!ENTITY https-everywhere.ruleset-tests.status_start_button "Start">

--- a/src/chrome/locale/da/https-everywhere.dtd
+++ b/src/chrome/locale/da/https-everywhere.dtd
@@ -6,14 +6,16 @@
 <!ENTITY https-everywhere.about.librarians "Regelsæt-bibliotekarer">
 <!ENTITY https-everywhere.about.thanks "Tak til">
 <!ENTITY https-everywhere.about.contribute  "Hvis du kan lide HTTPS Overalt, så vil du måske overveje at">
-<!ENTITY https-everywhere.about.donate_tor "give bidrag til Tor">
+<!ENTITY https-everywhere.about.donate_tor "give et bidrag til Tor">
 <!ENTITY https-everywhere.about.tor_lang_code "da">
-<!ENTITY https-everywhere.about.donate_eff "give bidrag til EFF">
+<!ENTITY https-everywhere.about.or "eller at">
+<!ENTITY https-everywhere.about.donate_eff "give et bidrag til EFF">
 
 <!ENTITY https-everywhere.menu.about "Om HTTPS Overalt">
 <!ENTITY https-everywhere.menu.observatory "Indstillinger for SSL-observatoriet">
 <!ENTITY https-everywhere.menu.globalEnable "Aktivér HTTPS Overalt">
 <!ENTITY https-everywhere.menu.globalDisable "Deaktivér HTTPS Overalt">
+<!ENTITY https-everywhere.menu.blockHttpRequests "Bloker alle HTTP-forespørgsler">
 <!ENTITY https-everywhere.menu.showCounter "Vis tæller">
 
 <!ENTITY https-everywhere.prefs.title "Indstillinger for HTTPS Overalt">

--- a/src/chrome/locale/da/https-everywhere.properties
+++ b/src/chrome/locale/da/https-everywhere.properties
@@ -1,8 +1,8 @@
 https-everywhere.menu.globalEnable = Aktivér HTTPS Overalt
 https-everywhere.menu.globalDisable = Deaktivér HTTPS Overalt
-https-everywhere.menu.enableDisable = Aktivér / Deaktivér regler
+https-everywhere.menu.enableDisable = Aktivér/deaktivér regler
 https-everywhere.menu.noRules = (Der er ikke opsat regler for denne side)
 https-everywhere.menu.unknownRules = (Regler for denne side ukendt)
-https-everywhere.toolbar.hint = HTTPS Everywhere er nu aktiv. De kan tænde den ved et side-ved-side basis ved at klikke på ikonet i adresse baren.
-https-everywhere.migration.notification0 = For at rette en vigtig fejl, nulstiller denne opdatering dine HTTPS Everywhere indstillinger til deres oprindelige værdier.
-https-everywhere.menu.ruleset-tests = Kør HTTPS Overalt Regelsæt Prøver
+https-everywhere.toolbar.hint = HTTPS Overalt er nu aktiv. Du kan slå den til eller fra på hver enkelt netsted ved at klikke på ikonet i adressebjælken.
+https-everywhere.migration.notification0 = For at rette en vigtig fejl nulstiller denne opdatering dine HTTPS Overalt-indstillinger til deres oprindelige værdier.
+https-everywhere.menu.ruleset-tests = Kør afprøvninger af HTTPS Overalt-regelsæt

--- a/src/chrome/locale/da/ssl-observatory.dtd
+++ b/src/chrome/locale/da/ssl-observatory.dtd
@@ -20,42 +20,41 @@ to turn it on?">-->
 <!-- Observatory preferences dialog -->
 
 <!ENTITY ssl-observatory.prefs.adv_priv_opts1
-"Dette kan trygt aktiveres, medmindre du brug et virksomhedsnetværk
-som er udsat for meget indtrængen:">
+"Dette kan trygt aktiveres, medmindre du anvender et 
+meget påtrængende virksomhedsnetværk:">
 
 <!ENTITY ssl-observatory.prefs.adv_priv_opts2
-"Sikker, medmindre du bruger et virksomhedsnetværk med skjulte intranet-servernavne:">
+"Dette er sikker, medmindre du bruger et virksomhedsnetværk med skjulte/hemmelige intranet-servernavne:">
 
 <!ENTITY ssl-observatory.prefs.alt_roots 
 "Indsend og tjek certifikater signeret af ikke-standardiserede rod-certifikat-autoriteter">
 
 <!ENTITY ssl-observatory.prefs.alt_roots_tooltip 
-"Det er sikkert (og en god ide) at aktivere denne valgmulighed, medmindre du bruger virksomhedsnetværk med meget indtrængen eller antivirus-software fra Kaspersky, der overvåger din browserbrug med en TLS-proxy og en privat rod-certifikat-autoritet.  Hvis den er aktiveret på sådan et netværk, så kan dette tilvalg risikere at udgive spor af hvilke https://-domæner som blev benyttet gennem proxy'en, som følge af de unikke certifikater den ville fremstille.  Lad den derfor være slået fra som standard.">
+"Det er sikkert (og en god idé) at aktivere denne valgmulighed, medmindre du bruger et påstrængende virksomhedsnetværk eller antivirus-software fra Kaspersky, der overvåger din browserbrug med en TLS-proxy og en privat rod-certifikat-autoritet.  Hvis den er aktiveret på sådan et netværk, så kan dette tilvalg potentielt udgive spor af hvilke https://-domæner, som blev benyttet gennem proxy'en, som følge af de unikke certifikater den ville fremstille.  Lad den derfor være slået fra som standard.">
 
 <!ENTITY ssl-observatory.prefs.anonymous "Tjek certifikater med brug af Tor for anonymitet">
 <!ENTITY ssl-observatory.prefs.anonymous_unavailable 
 "Tjek certifikater med brug af Tor for anonymitet (kræver Torbutton)">
 <!ENTITY ssl-observatory.prefs.anonymous_tooltip 
-"Dette tilvalg kræver at Tor og Torbutton er installerede.">
+"Dette tilvalg kræver, at du har installeret og startet Tor.">
 
 <!ENTITY ssl-observatory.prefs.asn 
 "Når du ser et nyt certifikat, så fortæl Observatoriet hvilken internetudbyder du er tilsluttet til">
 
 <!ENTITY ssl-observatory.prefs.asn_tooltip
-"Dette vil hente og sende det &quot;autonome systemnummer&quot; for dit netværk.  Dette vil hjælpe os med at lokalisere angreb mod HTTPS, og afgøre hvorvidt vi har observationer fra netværk fra steder som Iran og Syrien, hvor angreb set under sammenligning forekommer hyppigt.">
+"Dette vil hente og sende det &quot;autonome systemnummer&quot; for dit netværk. Dette vil hjælpe os med at lokalisere angreb mod HTTPS og afgøre, hvorvidt vi har observationer fra netværk fra steder som Iran og Syrien, hvor angreb er relativt hyppige.">
 
 <!ENTITY ssl-observatory.prefs.show_cert_warning
-"Vis en advarelse når Observatoriet finder et tilbagekaldt certifikat som ikke bliver opdaget af din browser">
+"Vis en advarsel når Observatoriet finder et tilbagekaldt certifikat, som ikke bliver opdaget af din browser">
 
 <!ENTITY ssl-observatory.prefs.show_cert_warning_tooltip
-"Dette vil kontrollerer indsendte certifikater imod en liste af kendte tilbagekaldte certifikater. Desværre kan vi ikke garanterer at vi bemærker alle tilbagekaldte certifikater, men hvis du ser en advarelse er der en god chance for at noget er galt.">
+"Dette vil sammenholde indsendte certifikater med en liste af kendte tilbagekaldte certifikater. Desværre kan vi ikke garantere, at vi bemærker alle tilbagekaldte certifikater, men hvis du ser en advarsel, er der en god chance for, at der er noget galt.">
 
 <!ENTITY ssl-observatory.prefs.done "Færdig">
 
 <!ENTITY ssl-observatory.prefs.explanation 
-"HTTPS Overalt kan benytte EFFs SSL-observatorie.  Dette indebærer to
-ting: (1) der sendes kopier af HTTPS-certifikater til observatoriet, der
-hjælper os med at registrere 'manden i midten'-angreb og forøge sikkerheden på nettet; og (2) giver os mulighed for at advare dig om usikre forbindelser eller angreb på din browser.">
+"HTTPS Overalt kan benytte EFF's SSL-observatorium. Dette indebærer to ting: (1) Der sendes kopier af HTTPS-certifikater til Observatoriet, der
+hjælper os med at registrere 'manden i midten'-angreb og derved forøge sikkerheden på nettet, og (2): Det giver os mulighed for at advare dig om usikre forbindelser eller angreb på din browser.">
 
 <!--<!ENTITY ssl-observatory.prefs.explanation2
 "When you visit https://www.example.com, the Observatory will learn that
@@ -64,16 +63,16 @@ Mouseover the options for further details:">-->
 
 <!ENTITY ssl-observatory.prefs.explanation2
 
-"Som eksempel, når du besøger https://www.etellerandet.com, så vil
-certifikatet som Observatoriet har modtaget indikere at nogen besøgte
+"For eksempel: Hvis du besøger https://www.etellerandet.com, så vil
+certifikatet, som Observatoriet har modtaget, indikere at nogen besøgte
 www.etellerandet.com, men ikke hvem som besøgte stedet, eller hvilken
-specifik side de kiggede på.  Hold musen over valgmuligheder for at flere
+specifik side de kiggede på.  Hold musen over valgmulighederne for at få flere
 detaljer:">
 
 <!ENTITY ssl-observatory.prefs.hide "Skjul avancerede valgmuligheder">
 
 <!ENTITY ssl-observatory.prefs.nonanon 
-"Tjek certifikater, selv når Tor ikke er tilgængelig">
+"Tjek certifikater, selv når Tor ikke er tilgængeligt">
 
 <!ENTITY ssl-observatory.prefs.nonanon_tooltip
 "Vi vil stadig forsøge at bevare data anonyme, men denne valgmulighed er mindre sikker">
@@ -82,20 +81,20 @@ detaljer:">
 "Indsend og tjek certifikater for DNS-navne som ikke er offentlige">
 
 <!ENTITY ssl-observatory.prefs.priv_dns_tooltip
-"Medmindre denne valgmulighed er valgt, så vil observatoriet ikke registrere certifikater for navne som den ikke kan opløse gennem DNS-systemet.">
+"Medmindre denne valgmulighed er valgt, så vil Observatoriet ikke registrere certifikater for navne, som den ikke kan slå op gennem DNS-systemet.">
 
-<!ENTITY ssl-observatory.prefs.show "Vis avanceret valgmuligheder">
+<!ENTITY ssl-observatory.prefs.show "Vis avancerede valgmuligheder">
 
 <!ENTITY ssl-observatory.prefs.title "Indstillinger for SSL-Observatoriet">
 
 <!ENTITY ssl-observatory.prefs.use "Brug Observatoriet?">
-<!ENTITY ssl-observatory.warning.title "ADVARSEL fra EFF's SSL-observatorie">
+<!ENTITY ssl-observatory.warning.title "ADVARSEL fra EFF's SSL-observatorium">
 <!ENTITY ssl-observatory.warning.showcert "Vis certifikat-kæden">
 <!ENTITY ssl-observatory.warning.okay "Jeg forstår">
-<!ENTITY ssl-observatory.warning.text "EFF's SSL-observatorie har udsted en advarsel om HTTPS-certifikaterne for  dette sted:">
-<!ENTITY ssl-observatory.warning.defense "Hvis du logger på denne side er det anbefalet at du ændre din adgangskode efter en sikker forbindelse er blevet etableret. (Disse advarsler kan slås fra i &quot;SSL-observatoriet&quot; fanen i under indstillinger for  HTTPS Overalt.)">
+<!ENTITY ssl-observatory.warning.text "EFF's SSL-observatorium har udstedt en advarsel om HTTPS-certifikaterne for dette netsted:">
+<!ENTITY ssl-observatory.warning.defense "Hvis du er logget ind på dette netsted, så kan det tilrådes, at du ændrer din adgangskode, når du har etableret en sikker forbindelse. (Disse advarsler kan slås fra i fanebladet &quot;SSL-Observatoriet&quot; under indstillinger for HTTPS Overalt.)">
 
 <!ENTITY ssl-observatory.prefs.self_signed
 "Indsend og tjek selvsignerede certifikater">
 <!ENTITY ssl-observatory.prefs.self_signed_tooltip
-"Dette er anbefalet, da kryptografiske problemer er oftere findes i selvsignerede indlejrede enheder">
+"Dette er anbefalet, da kryptografiske problemer oftere findes i selvsignerede indlejrede enheder">

--- a/src/chrome/locale/de/https-everywhere.dtd
+++ b/src/chrome/locale/de/https-everywhere.dtd
@@ -8,12 +8,14 @@
 <!ENTITY https-everywhere.about.contribute  "Wenn Sie HTTPS-Everywhere mögen, sollten Sie sich dieses ansehen">
 <!ENTITY https-everywhere.about.donate_tor "An Tor spenden">
 <!ENTITY https-everywhere.about.tor_lang_code "de">
+<!ENTITY https-everywhere.about.or "or">
 <!ENTITY https-everywhere.about.donate_eff "An EFF spenden">
 
 <!ENTITY https-everywhere.menu.about "Über HTTPS-Everywhere">
 <!ENTITY https-everywhere.menu.observatory "SSL-Observatory-Einstellungen">
 <!ENTITY https-everywhere.menu.globalEnable "HTTPS-Everywhere aktivieren">
 <!ENTITY https-everywhere.menu.globalDisable "HTTPS-Everywhere deaktivieren">
+<!ENTITY https-everywhere.menu.blockHttpRequests "Block all HTTP requests">
 <!ENTITY https-everywhere.menu.showCounter "Zähler anzeigen">
 
 <!ENTITY https-everywhere.prefs.title "HTTPS-Everywhere-Einstellungen">

--- a/src/chrome/locale/el/https-everywhere.dtd
+++ b/src/chrome/locale/el/https-everywhere.dtd
@@ -8,12 +8,14 @@
 <!ENTITY https-everywhere.about.contribute  "Αν σας αρέσει το HTTPS Everywhere, δοκιμάστε">
 <!ENTITY https-everywhere.about.donate_tor "Δωρίστε στο Tor">
 <!ENTITY https-everywhere.about.tor_lang_code "en">
+<!ENTITY https-everywhere.about.or "or">
 <!ENTITY https-everywhere.about.donate_eff "Δωρίστε στο EFF">
 
 <!ENTITY https-everywhere.menu.about "Σχετικά με το HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.observatory "Προτιμήσεις για το Παρατηρητήριο SSL">
 <!ENTITY https-everywhere.menu.globalEnable "Ενεργοποίηση του HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.globalDisable "Απενεργοποίηση του HTTPS Everywhere">
+<!ENTITY https-everywhere.menu.blockHttpRequests "Block all HTTP requests">
 <!ENTITY https-everywhere.menu.showCounter "Εμφάνιση Μετρητή">
 
 <!ENTITY https-everywhere.prefs.title "Προτιμήσεις του HTTPS Everywhere">

--- a/src/chrome/locale/en/https-everywhere.dtd
+++ b/src/chrome/locale/en/https-everywhere.dtd
@@ -8,12 +8,14 @@
 <!ENTITY https-everywhere.about.contribute  "If you like HTTPS Everywhere, you might consider">
 <!ENTITY https-everywhere.about.donate_tor "Donating to Tor">
 <!ENTITY https-everywhere.about.tor_lang_code "en">
+<!ENTITY https-everywhere.about.or "or">
 <!ENTITY https-everywhere.about.donate_eff "Donating to EFF">
 
 <!ENTITY https-everywhere.menu.about "About HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.observatory "SSL Observatory Preferences">
 <!ENTITY https-everywhere.menu.globalEnable "Enable HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.globalDisable "Disable HTTPS Everywhere">
+<!ENTITY https-everywhere.menu.blockHttpRequests "Block all HTTP requests">
 <!ENTITY https-everywhere.menu.showCounter "Show Counter">
 
 <!ENTITY https-everywhere.prefs.title "HTTPS Everywhere Preferences">

--- a/src/chrome/locale/es/https-everywhere.dtd
+++ b/src/chrome/locale/es/https-everywhere.dtd
@@ -8,12 +8,14 @@
 <!ENTITY https-everywhere.about.contribute  "Si le agrada HTTPS Everywhere (HTTPS en cualquier sitio), podría considerar">
 <!ENTITY https-everywhere.about.donate_tor "Donar a Tor">
 <!ENTITY https-everywhere.about.tor_lang_code "es">
+<!ENTITY https-everywhere.about.or "or">
 <!ENTITY https-everywhere.about.donate_eff "donar a la Fundación Fronteras Electrónicas (EFF)">
 
 <!ENTITY https-everywhere.menu.about "Acerca de HTTPS Everywhere (HTTPS en cualquier sitio)">
 <!ENTITY https-everywhere.menu.observatory "Opciones del Observatorio SSL">
 <!ENTITY https-everywhere.menu.globalEnable "Activar HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.globalDisable "Desactivar HTTPS Everywhere">
+<!ENTITY https-everywhere.menu.blockHttpRequests "Block all HTTP requests">
 <!ENTITY https-everywhere.menu.showCounter "Mostrar contador">
 
 <!ENTITY https-everywhere.prefs.title "Preferencias de HTTPS Everywhere">

--- a/src/chrome/locale/et/https-everywhere.dtd
+++ b/src/chrome/locale/et/https-everywhere.dtd
@@ -8,12 +8,14 @@
 <!ENTITY https-everywhere.about.contribute  "Kui sulle meeldib HTTPS Everywhere, võiksid kaaluda">
 <!ENTITY https-everywhere.about.donate_tor "Annetust Tor-ile">
 <!ENTITY https-everywhere.about.tor_lang_code "et">
+<!ENTITY https-everywhere.about.or "or">
 <!ENTITY https-everywhere.about.donate_eff "Annetust EFF-ile">
 
 <!ENTITY https-everywhere.menu.about "HTTPS Everywhere-ist">
 <!ENTITY https-everywhere.menu.observatory "SSL Jälgija Eelistused">
 <!ENTITY https-everywhere.menu.globalEnable "Luba HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.globalDisable "Keela HTTPS Everywhere">
+<!ENTITY https-everywhere.menu.blockHttpRequests "Block all HTTP requests">
 <!ENTITY https-everywhere.menu.showCounter "Näita loendurit">
 
 <!ENTITY https-everywhere.prefs.title "HTTPS Everywhere Eelistused">

--- a/src/chrome/locale/eu/https-everywhere.dtd
+++ b/src/chrome/locale/eu/https-everywhere.dtd
@@ -8,12 +8,14 @@
 <!ENTITY https-everywhere.about.contribute  "HTTPS Everywhere gustoko baduzu, kontutan har zenezake">
 <!ENTITY https-everywhere.about.donate_tor "Torera dohaintza eman">
 <!ENTITY https-everywhere.about.tor_lang_code "en">
+<!ENTITY https-everywhere.about.or "or">
 <!ENTITY https-everywhere.about.donate_eff "EFFra dohaintza eman">
 
 <!ENTITY https-everywhere.menu.about "HTTPS Everywhere buruz">
 <!ENTITY https-everywhere.menu.observatory "SSL Behatokiaren Hobespenak">
 <!ENTITY https-everywhere.menu.globalEnable "HTTPS Everywhere gaitu">
 <!ENTITY https-everywhere.menu.globalDisable "HTTPS Everywhere ezgaitu">
+<!ENTITY https-everywhere.menu.blockHttpRequests "Block all HTTP requests">
 <!ENTITY https-everywhere.menu.showCounter "Kopurua erakutsi">
 
 <!ENTITY https-everywhere.prefs.title "HTTPS Everywhere Hobespenak">

--- a/src/chrome/locale/fa/https-everywhere.dtd
+++ b/src/chrome/locale/fa/https-everywhere.dtd
@@ -8,12 +8,14 @@
 <!ENTITY https-everywhere.about.contribute  "اگر شما از HTTPS همه‌جا راضی هستید، پیشنهاد می‌کنیم">
 <!ENTITY https-everywhere.about.donate_tor "به Tor کمک مالی کنید.">
 <!ENTITY https-everywhere.about.tor_lang_code "fa">
+<!ENTITY https-everywhere.about.or "or">
 <!ENTITY https-everywhere.about.donate_eff "به EFF کمک مالی کنید.">
 
 <!ENTITY https-everywhere.menu.about "درباره‌ی HTTPS همه‌جا">
 <!ENTITY https-everywhere.menu.observatory "تنظیم‌های رصدخانه‌ی SSL">
 <!ENTITY https-everywhere.menu.globalEnable "HTTPS همه‌جا را فعال کنید">
 <!ENTITY https-everywhere.menu.globalDisable "HTTPS همه‌جا را غیرفعال کنید">
+<!ENTITY https-everywhere.menu.blockHttpRequests "Block all HTTP requests">
 <!ENTITY https-everywhere.menu.showCounter "نمایش شمارنده">
 
 <!ENTITY https-everywhere.prefs.title "تنظیم‌های HTTPS همه‌جا">

--- a/src/chrome/locale/fi/https-everywhere.dtd
+++ b/src/chrome/locale/fi/https-everywhere.dtd
@@ -8,12 +8,14 @@
 <!ENTITY https-everywhere.about.contribute  "Jos pidät HTTPS Everywheresta, voit harkita">
 <!ENTITY https-everywhere.about.donate_tor "Lahjoita Torille.">
 <!ENTITY https-everywhere.about.tor_lang_code "en">
+<!ENTITY https-everywhere.about.or "or">
 <!ENTITY https-everywhere.about.donate_eff "Lahjoita EFFille">
 
 <!ENTITY https-everywhere.menu.about "Tietoja HTTPS Everywheresta">
 <!ENTITY https-everywhere.menu.observatory "SSL Observatoryn asetukset">
 <!ENTITY https-everywhere.menu.globalEnable "Ota HTTPS Everywhere käyttöön">
 <!ENTITY https-everywhere.menu.globalDisable "Poista HTTPS Everywhere käytöstä">
+<!ENTITY https-everywhere.menu.blockHttpRequests "Block all HTTP requests">
 <!ENTITY https-everywhere.menu.showCounter "Näytä laskuri">
 
 <!ENTITY https-everywhere.prefs.title "HTTPS Everywheren asetukset">

--- a/src/chrome/locale/fo/https-everywhere.dtd
+++ b/src/chrome/locale/fo/https-everywhere.dtd
@@ -8,12 +8,14 @@
 <!ENTITY https-everywhere.about.contribute  "Dámar tær HTTPS Allastaðni, átti tú at">
 <!ENTITY https-everywhere.about.donate_tor "latið Tor eitt oyra">
 <!ENTITY https-everywhere.about.tor_lang_code "fo">
+<!ENTITY https-everywhere.about.or "or">
 <!ENTITY https-everywhere.about.donate_eff "Letur EFF eitt oyra">
 
 <!ENTITY https-everywhere.menu.about "Um HTTPS Allastaðni">
 <!ENTITY https-everywhere.menu.observatory "Stillingar fyri SSL Observatory">
 <!ENTITY https-everywhere.menu.globalEnable "Gilda HTTPS Allastaðni">
 <!ENTITY https-everywhere.menu.globalDisable "Ógilda HTTPS Allastaðni">
+<!ENTITY https-everywhere.menu.blockHttpRequests "Block all HTTP requests">
 <!ENTITY https-everywhere.menu.showCounter "Vís teljara">
 
 <!ENTITY https-everywhere.prefs.title "Stillingar fyri HTTPS Allastaðni">

--- a/src/chrome/locale/fr/https-everywhere.dtd
+++ b/src/chrome/locale/fr/https-everywhere.dtd
@@ -8,12 +8,14 @@
 <!ENTITY https-everywhere.about.contribute  "Si vous aimez HTTPS Everywhere, vous devriez considérer">
 <!ENTITY https-everywhere.about.donate_tor "Faire un Don à Tor">
 <!ENTITY https-everywhere.about.tor_lang_code "en">
+<!ENTITY https-everywhere.about.or "or">
 <!ENTITY https-everywhere.about.donate_eff "Faire un Don à EFF">
 
 <!ENTITY https-everywhere.menu.about "À propos de HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.observatory "Préférences de l'Observatoire SSL ">
 <!ENTITY https-everywhere.menu.globalEnable "Activer HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.globalDisable "Désactiver HTTPS Everywhere">
+<!ENTITY https-everywhere.menu.blockHttpRequests "Block all HTTP requests">
 <!ENTITY https-everywhere.menu.showCounter "Show Counter">
 
 <!ENTITY https-everywhere.prefs.title "Préférences de HTTPS Everywhere">

--- a/src/chrome/locale/fr_CA/https-everywhere.dtd
+++ b/src/chrome/locale/fr_CA/https-everywhere.dtd
@@ -8,12 +8,14 @@
 <!ENTITY https-everywhere.about.contribute  "Si vous aimez HTTPS partout, vous devriez considérer">
 <!ENTITY https-everywhere.about.donate_tor "Faire un don à Tor">
 <!ENTITY https-everywhere.about.tor_lang_code "en">
+<!ENTITY https-everywhere.about.or "or">
 <!ENTITY https-everywhere.about.donate_eff "Faire un don à EFF">
 
 <!ENTITY https-everywhere.menu.about "À propos de HTTPS partout">
 <!ENTITY https-everywhere.menu.observatory "Préférences de l'observatoire SSL ">
 <!ENTITY https-everywhere.menu.globalEnable "Activer HTTPS partout">
 <!ENTITY https-everywhere.menu.globalDisable "Désactiver HTTPS partout">
+<!ENTITY https-everywhere.menu.blockHttpRequests "Block all HTTP requests">
 <!ENTITY https-everywhere.menu.showCounter "Afficher le compteur">
 
 <!ENTITY https-everywhere.prefs.title "Préférences de HTTPS partout">

--- a/src/chrome/locale/he/https-everywhere.dtd
+++ b/src/chrome/locale/he/https-everywhere.dtd
@@ -8,12 +8,14 @@
 <!ENTITY https-everywhere.about.contribute  "אם אהבת את HTTPS בכל מקום, אולי תרצה">
 <!ENTITY https-everywhere.about.donate_tor "לתרום ל-Tor">
 <!ENTITY https-everywhere.about.tor_lang_code "אנגלית">
+<!ENTITY https-everywhere.about.or "or">
 <!ENTITY https-everywhere.about.donate_eff "תרומה לEFF">
 
 <!ENTITY https-everywhere.menu.about "אודות HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.observatory "העדפות SSL Observatory">
 <!ENTITY https-everywhere.menu.globalEnable "הפעל את HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.globalDisable "השבת את HTTPS Everywhere">
+<!ENTITY https-everywhere.menu.blockHttpRequests "Block all HTTP requests">
 <!ENTITY https-everywhere.menu.showCounter "הצג מדד">
 
 <!ENTITY https-everywhere.prefs.title "הגדרות HTTPS Everywhere">

--- a/src/chrome/locale/hr_HR/https-everywhere.dtd
+++ b/src/chrome/locale/hr_HR/https-everywhere.dtd
@@ -8,12 +8,14 @@
 <!ENTITY https-everywhere.about.contribute  "Ako Vam se sviđa HTTPS Svuda, mogli biste razmotriti">
 <!ENTITY https-everywhere.about.donate_tor "doniranje Toru">
 <!ENTITY https-everywhere.about.tor_lang_code "en">
+<!ENTITY https-everywhere.about.or "or">
 <!ENTITY https-everywhere.about.donate_eff "doniranje EFF-u">
 
 <!ENTITY https-everywhere.menu.about "O proširenju HTTPS Svuda">
 <!ENTITY https-everywhere.menu.observatory " Podešavanje SSL Opservatorija">
 <!ENTITY https-everywhere.menu.globalEnable "Omogući HTTPS Svuda">
 <!ENTITY https-everywhere.menu.globalDisable "Onemogući HTTPS Svuda">
+<!ENTITY https-everywhere.menu.blockHttpRequests "Block all HTTP requests">
 <!ENTITY https-everywhere.menu.showCounter "Prikaži brojač">
 
 <!ENTITY https-everywhere.prefs.title "Podešavanje HTTPS Svuda">

--- a/src/chrome/locale/hu/https-everywhere.dtd
+++ b/src/chrome/locale/hu/https-everywhere.dtd
@@ -8,12 +8,14 @@
 <!ENTITY https-everywhere.about.contribute  "Ha tetszik a HTTPS Everywhere, talán megfontolja a következőket:">
 <!ENTITY https-everywhere.about.donate_tor "A Tor támogatása">
 <!ENTITY https-everywhere.about.tor_lang_code "en">
+<!ENTITY https-everywhere.about.or "or">
 <!ENTITY https-everywhere.about.donate_eff "Az EFF támogatása">
 
 <!ENTITY https-everywhere.menu.about "A HTTPS Everywhere névjegye">
 <!ENTITY https-everywhere.menu.observatory "SSL Observatory Beállítások">
 <!ENTITY https-everywhere.menu.globalEnable "HTTPS Everywhere bekapcsolása">
 <!ENTITY https-everywhere.menu.globalDisable "HTTPS Everywhere kikapcsolása">
+<!ENTITY https-everywhere.menu.blockHttpRequests "Block all HTTP requests">
 <!ENTITY https-everywhere.menu.showCounter "Mutassa a számlálót">
 
 <!ENTITY https-everywhere.prefs.title "HTTPS Everywhere Preferences">

--- a/src/chrome/locale/it/https-everywhere.dtd
+++ b/src/chrome/locale/it/https-everywhere.dtd
@@ -8,12 +8,14 @@
 <!ENTITY https-everywhere.about.contribute  "Se ti piace HTTPS Everywhere, considera anche">
 <!ENTITY https-everywhere.about.donate_tor "Donazioni a Tor">
 <!ENTITY https-everywhere.about.tor_lang_code "it">
+<!ENTITY https-everywhere.about.or "or">
 <!ENTITY https-everywhere.about.donate_eff "Donazioni a EFF">
 
 <!ENTITY https-everywhere.menu.about "Informazioni su HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.observatory "Preferenze Osservatorio SSL">
 <!ENTITY https-everywhere.menu.globalEnable "Abilita HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.globalDisable "Disabilita HTTPS Everywhere">
+<!ENTITY https-everywhere.menu.blockHttpRequests "Block all HTTP requests">
 <!ENTITY https-everywhere.menu.showCounter "Mostra contatore">
 
 <!ENTITY https-everywhere.prefs.title "Preferenze di HTTPS Everywhere">

--- a/src/chrome/locale/ja/https-everywhere.dtd
+++ b/src/chrome/locale/ja/https-everywhere.dtd
@@ -8,12 +8,14 @@
 <!ENTITY https-everywhere.about.contribute  "HTTPS Everywhereが好きなら、検討してください">
 <!ENTITY https-everywhere.about.donate_tor "Torに寄付する">
 <!ENTITY https-everywhere.about.tor_lang_code "英語">
+<!ENTITY https-everywhere.about.or "or">
 <!ENTITY https-everywhere.about.donate_eff "EFFに寄付する">
 
 <!ENTITY https-everywhere.menu.about "HTTPS Everywhereについて">
 <!ENTITY https-everywhere.menu.observatory "ssl Observatoryの設定">
 <!ENTITY https-everywhere.menu.globalEnable "HTTPS Everywhereを有効化">
 <!ENTITY https-everywhere.menu.globalDisable "HTTPS Everywhereを無効化">
+<!ENTITY https-everywhere.menu.blockHttpRequests "Block all HTTP requests">
 <!ENTITY https-everywhere.menu.showCounter "カウンターを表示">
 
 <!ENTITY https-everywhere.prefs.title "HTTPS Everywhereの設定">

--- a/src/chrome/locale/km/https-everywhere.dtd
+++ b/src/chrome/locale/km/https-everywhere.dtd
@@ -8,12 +8,14 @@
 <!ENTITY https-everywhere.about.contribute  "ប្រសិនបើ​អ្នក​ចូលចិត្ត HTTPS Everywhere, អ្នក​អាច​ពិចារណា">
 <!ENTITY https-everywhere.about.donate_tor "ឧបត្ថម្ភ​​ដល់ Tor">
 <!ENTITY https-everywhere.about.tor_lang_code "en">
+<!ENTITY https-everywhere.about.or "or">
 <!ENTITY https-everywhere.about.donate_eff "ឧបត្ថម្ភ​​ដល់  EFF">
 
 <!ENTITY https-everywhere.menu.about "អំពី HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.observatory "ចំណូលចិត្ត SSL Observatory">
 <!ENTITY https-everywhere.menu.globalEnable "បើក HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.globalDisable "បិទ HTTPS Everywhere">
+<!ENTITY https-everywhere.menu.blockHttpRequests "Block all HTTP requests">
 <!ENTITY https-everywhere.menu.showCounter "បង្ហាញ Counter">
 
 <!ENTITY https-everywhere.prefs.title "ចំណូលចិត្ត HTTPS Everywhere">

--- a/src/chrome/locale/ko/https-everywhere.dtd
+++ b/src/chrome/locale/ko/https-everywhere.dtd
@@ -1,5 +1,4 @@
-<!ENTITY https-everywhere.about.title "HTTPS Everywhere에 대하여
-">
+<!ENTITY https-everywhere.about.title "HTTPS Everywhere에 대하여">
 <!ENTITY https-everywhere.about.ext_name "HTTPS Everywhere">
 <!ENTITY https-everywhere.about.ext_description "웹 암호화! 자동으로 여러 사이트에 HTTPS 보안을 사용합니다.">
 <!ENTITY https-everywhere.about.version "Version">
@@ -9,12 +8,14 @@
 <!ENTITY https-everywhere.about.contribute  "모든곳에서 HTTPS를 사용하려면, 고려해 보십시오">
 <!ENTITY https-everywhere.about.donate_tor "Tor에 기부하기">
 <!ENTITY https-everywhere.about.tor_lang_code "영어">
+<!ENTITY https-everywhere.about.or "or">
 <!ENTITY https-everywhere.about.donate_eff "EFF에 기부하기">
 
 <!ENTITY https-everywhere.menu.about "HTTPS Everywhere에 대하여">
 <!ENTITY https-everywhere.menu.observatory "SSL 관측 환경 설정">
 <!ENTITY https-everywhere.menu.globalEnable "모든곳에서 HTTPS 사용">
 <!ENTITY https-everywhere.menu.globalDisable "모든곳에서 HTTPS 사용 안 함">
+<!ENTITY https-everywhere.menu.blockHttpRequests "Block all HTTP requests">
 <!ENTITY https-everywhere.menu.showCounter "카운터 보기">
 
 <!ENTITY https-everywhere.prefs.title "HTTPS 모든곳 사용 환경 설정">

--- a/src/chrome/locale/lt/https-everywhere.dtd
+++ b/src/chrome/locale/lt/https-everywhere.dtd
@@ -8,12 +8,14 @@
 <!ENTITY https-everywhere.about.contribute  "Jei Jums patinka HTTPS Everywhere, galbūt norėsite">
 <!ENTITY https-everywhere.about.donate_tor "Paaukoti Tor projektui">
 <!ENTITY https-everywhere.about.tor_lang_code "lt">
+<!ENTITY https-everywhere.about.or "or">
 <!ENTITY https-everywhere.about.donate_eff "Paaukoti EFF">
 
 <!ENTITY https-everywhere.menu.about "Apie HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.observatory "SSL Observatorijos nustatymai">
 <!ENTITY https-everywhere.menu.globalEnable "Įgalinti HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.globalDisable "Išjungti HTTPS Everywhere">
+<!ENTITY https-everywhere.menu.blockHttpRequests "Block all HTTP requests">
 <!ENTITY https-everywhere.menu.showCounter "Rodyti Skaitiklį">
 
 <!ENTITY https-everywhere.prefs.title "HTTPS Everywhere nustatymai">

--- a/src/chrome/locale/lv/https-everywhere.dtd
+++ b/src/chrome/locale/lv/https-everywhere.dtd
@@ -8,12 +8,14 @@
 <!ENTITY https-everywhere.about.contribute  "ja Jums patīk HTTPS Everywhere, iespējams vēlaties">
 <!ENTITY https-everywhere.about.donate_tor "ziedot Tor'am">
 <!ENTITY https-everywhere.about.tor_lang_code "an">
+<!ENTITY https-everywhere.about.or "or">
 <!ENTITY https-everywhere.about.donate_eff "ziedot EFF'am">
 
 <!ENTITY https-everywhere.menu.about "Par HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.observatory "SSL Observatory preferences">
 <!ENTITY https-everywhere.menu.globalEnable "Iespējot HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.globalDisable "Atspējot HTTPS Everywhere">
+<!ENTITY https-everywhere.menu.blockHttpRequests "Block all HTTP requests">
 <!ENTITY https-everywhere.menu.showCounter "Rādījumu skaitītājs">
 
 <!ENTITY https-everywhere.prefs.title "HTTPS Everywhere preferences">

--- a/src/chrome/locale/ms_MY/https-everywhere.dtd
+++ b/src/chrome/locale/ms_MY/https-everywhere.dtd
@@ -8,12 +8,14 @@
 <!ENTITY https-everywhere.about.contribute  "Sekiranya anda menyukai HTTPS Everywhere, anda mungkin ingin mempertimbangkan untuk">
 <!ENTITY https-everywhere.about.donate_tor "Menderma kepada Tor">
 <!ENTITY https-everywhere.about.tor_lang_code "ms-MY">
+<!ENTITY https-everywhere.about.or "or">
 <!ENTITY https-everywhere.about.donate_eff "Menderma kepada EFF">
 
 <!ENTITY https-everywhere.menu.about "Mengenai HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.observatory "Tetapan Pemantau SSL">
 <!ENTITY https-everywhere.menu.globalEnable "Pengaktifan HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.globalDisable "Nyah-aktifkan HTTPS Everywhere">
+<!ENTITY https-everywhere.menu.blockHttpRequests "Block all HTTP requests">
 <!ENTITY https-everywhere.menu.showCounter "Tunjukkan Kaunter">
 
 <!ENTITY https-everywhere.prefs.title "Tetapan HTTPS Everywhere">

--- a/src/chrome/locale/nb/https-everywhere.dtd
+++ b/src/chrome/locale/nb/https-everywhere.dtd
@@ -8,12 +8,14 @@
 <!ENTITY https-everywhere.about.contribute  "Hvis du liker HTTPS Everywhere, vurder å">
 <!ENTITY https-everywhere.about.donate_tor "Donére til Tor">
 <!ENTITY https-everywhere.about.tor_lang_code "en">
+<!ENTITY https-everywhere.about.or "eller">
 <!ENTITY https-everywhere.about.donate_eff "Donére til EFF">
 
 <!ENTITY https-everywhere.menu.about "Om HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.observatory "SSL Observatory Innstillinger">
 <!ENTITY https-everywhere.menu.globalEnable "Aktiver HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.globalDisable "Deaktiver HTTPS Everywhere">
+<!ENTITY https-everywhere.menu.blockHttpRequests "Block all HTTP requests">
 <!ENTITY https-everywhere.menu.showCounter "Vis teller">
 
 <!ENTITY https-everywhere.prefs.title "HTTPS Everywhere Innstillinger">

--- a/src/chrome/locale/nl/https-everywhere.dtd
+++ b/src/chrome/locale/nl/https-everywhere.dtd
@@ -8,12 +8,14 @@
 <!ENTITY https-everywhere.about.contribute  "Als HTTPS Everywhere u bevalt, kunt u overwegen">
 <!ENTITY https-everywhere.about.donate_tor "te doneren aan Tor">
 <!ENTITY https-everywhere.about.tor_lang_code "en">
+<!ENTITY https-everywhere.about.or "or">
 <!ENTITY https-everywhere.about.donate_eff "te doneren aan het EFF">
 
 <!ENTITY https-everywhere.menu.about "Over HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.observatory "SSL-observatoriumvoorkeuren">
 <!ENTITY https-everywhere.menu.globalEnable "HTTPS Everywhere inschakelen">
 <!ENTITY https-everywhere.menu.globalDisable "HTTPS Everywhere uitschakelen">
+<!ENTITY https-everywhere.menu.blockHttpRequests "Block all HTTP requests">
 <!ENTITY https-everywhere.menu.showCounter "Toon Teller">
 
 <!ENTITY https-everywhere.prefs.title "HTTPS Everywhere-voorkeuren">

--- a/src/chrome/locale/pl/https-everywhere.dtd
+++ b/src/chrome/locale/pl/https-everywhere.dtd
@@ -8,12 +8,14 @@
 <!ENTITY https-everywhere.about.contribute  "Jeżeli lubisz HTTPS Everywhere, możesz rozważyć ">
 <!ENTITY https-everywhere.about.donate_tor "Dotacje dla Tora">
 <!ENTITY https-everywhere.about.tor_lang_code "en">
+<!ENTITY https-everywhere.about.or "or">
 <!ENTITY https-everywhere.about.donate_eff "Dotacje dla Electronic Frontier Foundation">
 
 <!ENTITY https-everywhere.menu.about "O HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.observatory "Ustawienia SSL Observatory">
 <!ENTITY https-everywhere.menu.globalEnable "Włącz HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.globalDisable "Wyłącz HTTPS Everywhere">
+<!ENTITY https-everywhere.menu.blockHttpRequests "Block all HTTP requests">
 <!ENTITY https-everywhere.menu.showCounter "Pokaż Licznik">
 
 <!ENTITY https-everywhere.prefs.title "Ustawienia HTTPS Everywhere">

--- a/src/chrome/locale/pt/https-everywhere.dtd
+++ b/src/chrome/locale/pt/https-everywhere.dtd
@@ -8,12 +8,14 @@
 <!ENTITY https-everywhere.about.contribute  "Se gosta de HTTPS Everywhere, pode pensar em">
 <!ENTITY https-everywhere.about.donate_tor "Doar ao Tor">
 <!ENTITY https-everywhere.about.tor_lang_code "pt">
+<!ENTITY https-everywhere.about.or "or">
 <!ENTITY https-everywhere.about.donate_eff "Doar à EFF">
 
 <!ENTITY https-everywhere.menu.about "Sobre o HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.observatory "Preferências do SSL Observatory">
 <!ENTITY https-everywhere.menu.globalEnable "Ativar HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.globalDisable "Desativar HTTPS Everywhere">
+<!ENTITY https-everywhere.menu.blockHttpRequests "Block all HTTP requests">
 <!ENTITY https-everywhere.menu.showCounter "Mostrar Contador">
 
 <!ENTITY https-everywhere.prefs.title "Preferências do HTTPS Everywhere">

--- a/src/chrome/locale/pt_BR/https-everywhere.dtd
+++ b/src/chrome/locale/pt_BR/https-everywhere.dtd
@@ -8,12 +8,14 @@
 <!ENTITY https-everywhere.about.contribute  "Se você gostar do HTTPS Everywhere, considere">
 <!ENTITY https-everywhere.about.donate_tor "Fazer uma doação para o Tor">
 <!ENTITY https-everywhere.about.tor_lang_code "pt_BR">
+<!ENTITY https-everywhere.about.or "or">
 <!ENTITY https-everywhere.about.donate_eff "Fazer uma doação ao EFF">
 
 <!ENTITY https-everywhere.menu.about "Sobre o HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.observatory "Preferências do Observatório SSL">
 <!ENTITY https-everywhere.menu.globalEnable "Habilitar HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.globalDisable "Desabilitar HTTPS Everywhere">
+<!ENTITY https-everywhere.menu.blockHttpRequests "Block all HTTP requests">
 <!ENTITY https-everywhere.menu.showCounter "Mostrar o contador">
 
 <!ENTITY https-everywhere.prefs.title "Preferências do HTTPS Everywhere ">

--- a/src/chrome/locale/ro/https-everywhere.dtd
+++ b/src/chrome/locale/ro/https-everywhere.dtd
@@ -8,12 +8,14 @@
 <!ENTITY https-everywhere.about.contribute  "Dacă îți place HTTPS Oriunde, poți considera">
 <!ENTITY https-everywhere.about.donate_tor "Să donezi către Tor">
 <!ENTITY https-everywhere.about.tor_lang_code "ro">
+<!ENTITY https-everywhere.about.or "or">
 <!ENTITY https-everywhere.about.donate_eff "Să donezi către EFF">
 
 <!ENTITY https-everywhere.menu.about "Despre HTTPS Oriunde">
 <!ENTITY https-everywhere.menu.observatory "Preferințele pentru Observatorul SSL">
 <!ENTITY https-everywhere.menu.globalEnable "Activează HTTPS Oriunde">
 <!ENTITY https-everywhere.menu.globalDisable "Dezactivează HTTPS Oriunde">
+<!ENTITY https-everywhere.menu.blockHttpRequests "Block all HTTP requests">
 <!ENTITY https-everywhere.menu.showCounter "Afișează contorul">
 
 <!ENTITY https-everywhere.prefs.title "Preferințe HTTPS Oriunde">

--- a/src/chrome/locale/ru/https-everywhere.dtd
+++ b/src/chrome/locale/ru/https-everywhere.dtd
@@ -8,12 +8,14 @@
 <!ENTITY https-everywhere.about.contribute  "Если Вам нравится HTTPS Everywhere, возможно, Вы хотели бы сделать">
 <!ENTITY https-everywhere.about.donate_tor "пожертвование Tor">
 <!ENTITY https-everywhere.about.tor_lang_code "ru">
+<!ENTITY https-everywhere.about.or "or">
 <!ENTITY https-everywhere.about.donate_eff "пожертвование EFF">
 
 <!ENTITY https-everywhere.menu.about "О HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.observatory "Настройки SSL Observatory">
 <!ENTITY https-everywhere.menu.globalEnable "Включить HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.globalDisable "Выключить HTTPS Everywhere">
+<!ENTITY https-everywhere.menu.blockHttpRequests "Block all HTTP requests">
 <!ENTITY https-everywhere.menu.showCounter "Показать счётчик">
 
 <!ENTITY https-everywhere.prefs.title "Настройки HTTPS Everywhere">

--- a/src/chrome/locale/si_LK/https-everywhere.dtd
+++ b/src/chrome/locale/si_LK/https-everywhere.dtd
@@ -8,12 +8,14 @@
 <!ENTITY https-everywhere.about.contribute  "HTTPS Everywhere පිලිබඳව ඔබ කැමතිනම් මේවා සලකා බැලිය යුතුය">
 <!ENTITY https-everywhere.about.donate_tor "Tor වලට ආධාර කිරීම">
 <!ENTITY https-everywhere.about.tor_lang_code "ඉංග්‍රීසි">
+<!ENTITY https-everywhere.about.or "or">
 <!ENTITY https-everywhere.about.donate_eff " EFF වලට ආධාර කරන්න">
 
 <!ENTITY https-everywhere.menu.about "HTTPS Everywhere පිලිබඳව">
 <!ENTITY https-everywhere.menu.observatory "SSL නිරික්ෂණාගාර මනාප ">
 <!ENTITY https-everywhere.menu.globalEnable "HTTPS Everywhere ක්‍රියාකරවන්න">
 <!ENTITY https-everywhere.menu.globalDisable "HTTPS Everywhere ක්‍රියාවිරහිත කරවන්න">
+<!ENTITY https-everywhere.menu.blockHttpRequests "Block all HTTP requests">
 <!ENTITY https-everywhere.menu.showCounter "Show Counter">
 
 <!ENTITY https-everywhere.prefs.title "HTTPS Everywhere මනාප ">

--- a/src/chrome/locale/sk/https-everywhere.dtd
+++ b/src/chrome/locale/sk/https-everywhere.dtd
@@ -8,12 +8,14 @@
 <!ENTITY https-everywhere.about.contribute  "Ak sa Vám páči HTTPS Everywhere, môžno by ste mohli">
 <!ENTITY https-everywhere.about.donate_tor "Prispieť na Tor">
 <!ENTITY https-everywhere.about.tor_lang_code "sk">
+<!ENTITY https-everywhere.about.or "or">
 <!ENTITY https-everywhere.about.donate_eff "Prispieť na EFF">
 
 <!ENTITY https-everywhere.menu.about "O HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.observatory "Nastavenia SSL Observatory">
 <!ENTITY https-everywhere.menu.globalEnable "Povoliť HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.globalDisable "Zakázať HTTPS Everywhere">
+<!ENTITY https-everywhere.menu.blockHttpRequests "Block all HTTP requests">
 <!ENTITY https-everywhere.menu.showCounter "Zobraziť počítadlo">
 
 <!ENTITY https-everywhere.prefs.title "Nastavenia HTTPS Everywhere">

--- a/src/chrome/locale/sk_SK/https-everywhere.dtd
+++ b/src/chrome/locale/sk_SK/https-everywhere.dtd
@@ -8,12 +8,14 @@
 <!ENTITY https-everywhere.about.contribute  "Ak sa vám HTTPS Everywhere páči, zvážte">
 <!ENTITY https-everywhere.about.donate_tor "Dar pre Tor">
 <!ENTITY https-everywhere.about.tor_lang_code "sk">
+<!ENTITY https-everywhere.about.or "or">
 <!ENTITY https-everywhere.about.donate_eff "Dar pre EEF">
 
 <!ENTITY https-everywhere.menu.about "O HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.observatory "Nastavenia SSL Observatory">
 <!ENTITY https-everywhere.menu.globalEnable "Zapnúť HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.globalDisable "Vypnúť HTTPS Everywhere">
+<!ENTITY https-everywhere.menu.blockHttpRequests "Block all HTTP requests">
 <!ENTITY https-everywhere.menu.showCounter "Zobraziť počítadlo">
 
 <!ENTITY https-everywhere.prefs.title "Nastavenia HTTPS Everywhere">

--- a/src/chrome/locale/sl/https-everywhere.dtd
+++ b/src/chrome/locale/sl/https-everywhere.dtd
@@ -8,12 +8,14 @@
 <!ENTITY https-everywhere.about.contribute  "Če vam je HTTPS Everywhere všeč, razmislite o">
 <!ENTITY https-everywhere.about.donate_tor "donaciji za Tor">
 <!ENTITY https-everywhere.about.tor_lang_code "en">
+<!ENTITY https-everywhere.about.or "or">
 <!ENTITY https-everywhere.about.donate_eff "donaciji za EFF">
 
 <!ENTITY https-everywhere.menu.about "O HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.observatory "Nastavitve SSL Observatorija">
 <!ENTITY https-everywhere.menu.globalEnable "Omogoči HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.globalDisable "Onemogoči HTTPS Everywhere">
+<!ENTITY https-everywhere.menu.blockHttpRequests "Block all HTTP requests">
 <!ENTITY https-everywhere.menu.showCounter "Prikaži števec">
 
 <!ENTITY https-everywhere.prefs.title "Nastavitve HTTPS Everywhere">

--- a/src/chrome/locale/sl_SI/https-everywhere.dtd
+++ b/src/chrome/locale/sl_SI/https-everywhere.dtd
@@ -8,12 +8,14 @@
 <!ENTITY https-everywhere.about.contribute  "Če vam je všeč HTTPS Povsod, boste morda premislili o">
 <!ENTITY https-everywhere.about.donate_tor "Doniranju Tor-a">
 <!ENTITY https-everywhere.about.tor_lang_code "en">
+<!ENTITY https-everywhere.about.or "or">
 <!ENTITY https-everywhere.about.donate_eff "Doniranju EFF">
 
 <!ENTITY https-everywhere.menu.about "O HTTPS Povsod">
 <!ENTITY https-everywhere.menu.observatory "Izbire SSL Opazovalnice">
 <!ENTITY https-everywhere.menu.globalEnable "Omogoči HTTPS Povsod">
 <!ENTITY https-everywhere.menu.globalDisable "Onemogoči HTTPS Povsod">
+<!ENTITY https-everywhere.menu.blockHttpRequests "Block all HTTP requests">
 <!ENTITY https-everywhere.menu.showCounter "Prikaži števec">
 
 <!ENTITY https-everywhere.prefs.title "HTTPS Povsod Ugodnosti">

--- a/src/chrome/locale/sr/https-everywhere.dtd
+++ b/src/chrome/locale/sr/https-everywhere.dtd
@@ -8,12 +8,14 @@
 <!ENTITY https-everywhere.about.contribute  "Ako vam se svida HTTPS, mogli bi ste da razmislite o">
 <!ENTITY https-everywhere.about.donate_tor "donaciji za Tor">
 <!ENTITY https-everywhere.about.tor_lang_code "en">
+<!ENTITY https-everywhere.about.or "or">
 <!ENTITY https-everywhere.about.donate_eff "doniranju EFF-u">
 
 <!ENTITY https-everywhere.menu.about "O HTTPS svuda">
 <!ENTITY https-everywhere.menu.observatory "SSL observatorij postavki">
 <!ENTITY https-everywhere.menu.globalEnable "Omoguci HTTPS svuda">
 <!ENTITY https-everywhere.menu.globalDisable "Onemoguci HTTPS svuda">
+<!ENTITY https-everywhere.menu.blockHttpRequests "Block all HTTP requests">
 <!ENTITY https-everywhere.menu.showCounter "Prikazi brojac">
 
 <!ENTITY https-everywhere.prefs.title "HTTPS svuda - postavke">

--- a/src/chrome/locale/sv/https-everywhere.dtd
+++ b/src/chrome/locale/sv/https-everywhere.dtd
@@ -8,12 +8,14 @@
 <!ENTITY https-everywhere.about.contribute  "Om du gillar HTTPS Everywhere, kanske du kan tänka dig">
 <!ENTITY https-everywhere.about.donate_tor "Donera till Tor">
 <!ENTITY https-everywhere.about.tor_lang_code "en">
+<!ENTITY https-everywhere.about.or "eller">
 <!ENTITY https-everywhere.about.donate_eff "Donera till EFF">
 
 <!ENTITY https-everywhere.menu.about "Om HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.observatory "Inställningar för SSL Observatoriet">
 <!ENTITY https-everywhere.menu.globalEnable "Aktivera HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.globalDisable "Inaktivera HTTPS Everywhere">
+<!ENTITY https-everywhere.menu.blockHttpRequests "Blockera alla HTTP-förfrågningar">
 <!ENTITY https-everywhere.menu.showCounter "Visa räknare">
 
 <!ENTITY https-everywhere.prefs.title "Inställningar för HTTPS Everywhere">

--- a/src/chrome/locale/th/https-everywhere.dtd
+++ b/src/chrome/locale/th/https-everywhere.dtd
@@ -8,12 +8,14 @@
 <!ENTITY https-everywhere.about.contribute  "ถ้าคุณชอบ HTTPS Everywhere คุณอาจพิจารณา">
 <!ENTITY https-everywhere.about.donate_tor "บริจาคให้กับ Tor">
 <!ENTITY https-everywhere.about.tor_lang_code "en">
+<!ENTITY https-everywhere.about.or "or">
 <!ENTITY https-everywhere.about.donate_eff "บริจาคให้กับ EFF">
 
 <!ENTITY https-everywhere.menu.about "เกี่ยวกับ HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.observatory "ปรับแต่งหอสำรวจ SSL">
 <!ENTITY https-everywhere.menu.globalEnable "เปิดใช้ HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.globalDisable "ปิดใช้ HTTPS Everywhere">
+<!ENTITY https-everywhere.menu.blockHttpRequests "Block all HTTP requests">
 <!ENTITY https-everywhere.menu.showCounter "แสดงตัวนับ">
 
 <!ENTITY https-everywhere.prefs.title "ปรับแต่ง HTTPS Everywhere">

--- a/src/chrome/locale/tr/https-everywhere.dtd
+++ b/src/chrome/locale/tr/https-everywhere.dtd
@@ -8,12 +8,14 @@
 <!ENTITY https-everywhere.about.contribute  "Eğer HTTPS Everywhere'i sevdiyseniz, siz de destek olabilirsiniz">
 <!ENTITY https-everywhere.about.donate_tor "Tor'a Bağış Yapmak">
 <!ENTITY https-everywhere.about.tor_lang_code "tr">
+<!ENTITY https-everywhere.about.or "or">
 <!ENTITY https-everywhere.about.donate_eff "EFF'ye Bağış Yapmak">
 
 <!ENTITY https-everywhere.menu.about "HTTPS Her Yerde Hakkında">
 <!ENTITY https-everywhere.menu.observatory "SSL Gözlemcisi Tercihleri">
 <!ENTITY https-everywhere.menu.globalEnable "HTTPS Her Yerde'yi etkinleştir">
 <!ENTITY https-everywhere.menu.globalDisable "HTTPS Her Yerde'yi Devre Dışı Bırak">
+<!ENTITY https-everywhere.menu.blockHttpRequests "Block all HTTP requests">
 <!ENTITY https-everywhere.menu.showCounter "Sayacı Göster">
 
 <!ENTITY https-everywhere.prefs.title "HTTPS Her Yerde Tercihleri">

--- a/src/chrome/locale/uk/https-everywhere.dtd
+++ b/src/chrome/locale/uk/https-everywhere.dtd
@@ -8,12 +8,14 @@
 <!ENTITY https-everywhere.about.contribute  "Якщо Вам подобається HTTPS Everywhere, можливо, Ви хотіли б зробити">
 <!ENTITY https-everywhere.about.donate_tor "Пожертвуйте Tor">
 <!ENTITY https-everywhere.about.tor_lang_code "en">
+<!ENTITY https-everywhere.about.or "or">
 <!ENTITY https-everywhere.about.donate_eff "Пожертвування EFF">
 
 <!ENTITY https-everywhere.menu.about "O HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.observatory "Налаштування SSL Observatory">
 <!ENTITY https-everywhere.menu.globalEnable "Увімкнути HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.globalDisable "Вимкнути HTTPS Everywhere">
+<!ENTITY https-everywhere.menu.blockHttpRequests "Block all HTTP requests">
 <!ENTITY https-everywhere.menu.showCounter "Показати Лічильник">
 
 <!ENTITY https-everywhere.prefs.title "Налаштування HTTPS Everywhere">

--- a/src/chrome/locale/zh-CN/https-everywhere.dtd
+++ b/src/chrome/locale/zh-CN/https-everywhere.dtd
@@ -8,12 +8,14 @@
 <!ENTITY https-everywhere.about.contribute  "如果喜欢 HTTPS Everywhere，您可以考虑">
 <!ENTITY https-everywhere.about.donate_tor "捐助 Tor">
 <!ENTITY https-everywhere.about.tor_lang_code "zh_CN">
+<!ENTITY https-everywhere.about.or "or">
 <!ENTITY https-everywhere.about.donate_eff "捐助电子前线基金会 (EFF)">
 
 <!ENTITY https-everywhere.menu.about "关于 HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.observatory "SSL Observatory 首选项">
 <!ENTITY https-everywhere.menu.globalEnable "启用 HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.globalDisable "禁用 HTTPS Everywhere">
+<!ENTITY https-everywhere.menu.blockHttpRequests "Block all HTTP requests">
 <!ENTITY https-everywhere.menu.showCounter "显示计数器">
 
 <!ENTITY https-everywhere.prefs.title "HTTPS Everywhere 首选项">

--- a/src/chrome/locale/zh_TW/https-everywhere.dtd
+++ b/src/chrome/locale/zh_TW/https-everywhere.dtd
@@ -8,12 +8,14 @@
 <!ENTITY https-everywhere.about.contribute  "若您喜歡 HTTPS Everywhere，您或許可以考慮">
 <!ENTITY https-everywhere.about.donate_tor "贊助 Tor">
 <!ENTITY https-everywhere.about.tor_lang_code "zh-TW">
+<!ENTITY https-everywhere.about.or "or">
 <!ENTITY https-everywhere.about.donate_eff "贊助 EFF">
 
 <!ENTITY https-everywhere.menu.about "關於 HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.observatory "SSL 觀測站偏好設定">
 <!ENTITY https-everywhere.menu.globalEnable "啟用 HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.globalDisable "停用 HTTPS Everywhere">
+<!ENTITY https-everywhere.menu.blockHttpRequests "Block all HTTP requests">
 <!ENTITY https-everywhere.menu.showCounter "顯示計數器">
 
 <!ENTITY https-everywhere.prefs.title "HTTPS Everywhere 偏好設定">


### PR DESCRIPTION
Added a few new strings to https-everywhere.dtd, cf. issue #960 and #961. I feel like there was probably an easier way to do this by using Transifex?

Moreover, updated the Danish localisation. Most of the strings were already fine but a few recent ones contained some common misspellings.