### PR TITLE
zeroC.com.xml (new rule)

### DIFF
--- a/src/chrome/content/rules/ZeroC.com.xml
+++ b/src/chrome/content/rules/ZeroC.com.xml
@@ -1,0 +1,9 @@
+<ruleset name="ZeroC.com">
+
+	<target host="*.zeroc.com" />
+
+
+	<rule from="^http://www\.zeroc\.com/"
+		to="https://www.zeroc.com/" />
+
+</ruleset>


### PR DESCRIPTION
New rule for ZeroC.com - There's an automatic redirect from plaintext to SSL/TLS across most of the site, but there's a few slips, including most prominently across the plaintext download link, which is still available. This just seals that gap.