### PR TITLE
events.jquery.org, brand.jquery.org, www.qunitjs.com

### DIFF
--- a/src/chrome/content/rules/JQuery.org.xml
+++ b/src/chrome/content/rules/JQuery.org.xml
@@ -8,16 +8,15 @@
 
 	Nonfunctional subdomains:
 
-		- events	(refused)
+		nil
 
 
 	Problematic subdomains:
 
-		- brand *
-		- www	(refused)
-
-	* Works; mismatched, CN: jquery.org
-
+		nil
+	
+	Notes:
+		- www redirects to $
 -->
 <ruleset name="jQuery.org (partial)">
 
@@ -25,7 +24,7 @@
 	<target host="*.jquery.org" />
 
 
-	<rule from="^http://(?:(contribute\.|irc\.)|www\.)?jquery\.org/"
+	<rule from="^http://(?:(contribute\.|irc\.|events\.|brand\.)|www\.)?jquery\.org/"
 		to="https://$1jquery.org/" />
 
 </ruleset>

--- a/src/chrome/content/rules/QUnit_JS.com.xml
+++ b/src/chrome/content/rules/QUnit_JS.com.xml
@@ -8,10 +8,10 @@
 <ruleset name="QUnit JS.com">
 
 	<target host="qunitjs.com" />
-	<target host="api.qunitjs.com" />
+	<target host="*.qunitjs.com" />
 
 
-	<rule from="^http://(api\.)?qunitjs\.com/"
+	<rule from="^http://(?:(api\.)|www\.)?qunitjs\.com/"
 		to="https://$1qunitjs.com/" />
 
 </ruleset>


### PR DESCRIPTION
events.jquery.org, brand.jquery.org now work.
Redirect www.qunitjs.com -> qunitjs.com as www is not supported.