### PR TITLE
fix "NameError: name 'unicode' is not defined"

### DIFF
--- a/utils/merge-rulesets.sh
+++ b/utils/merge-rulesets.sh
@@ -4,6 +4,6 @@
 # prevents inodes from wasting disk space, but more importantly, works around
 # the fact that zip does not perform well on a pile of small files.
 
-python ./utils/merge-rulesets.py
+python2.7 ./utils/merge-rulesets.py
 
 RULESETS=chrome/content/rules/default.rulesets


### PR DESCRIPTION
error happens while running `./makecrx.sh`
because `python` is python3 on some systems
and python 3 renamed the `unicode` type to `str`,
the old `str` type has been replaced by `bytes`.

```bash
Removing whitespaces and comments...
Traceback (most recent call last):
  File "./utils/merge-rulesets.py", line 77, in <module>
    for rfile in sorted(xml_ruleset_files):
  File "./utils/merge-rulesets.py", line 25, in normalize
    f = unicodedata.normalize('NFC', unicode(f, 'utf-8')).encode('utf-8')
NameError: name 'unicode' is not defined
```
