### PR TITLE
qtio: broaden rule for downloads/bugreporting links

### DIFF
--- a/src/chrome/content/rules/Qt.io.xml
+++ b/src/chrome/content/rules/Qt.io.xml
@@ -5,10 +5,11 @@
 <ruleset name="Qt.io">
 
 	<target host="qt.io" />
+	<target host="download.qt.io" />
+	<target host="bugreports.qt.io" />
 	<target host="www.qt.io" />
 
-
-	<rule from="^http://(www\.)?qt\.io/"
-		to="https://$1qt.io/" />
+	<rule from="^http:"
+		to="https:" />
 
 </ruleset>


### PR DESCRIPTION
Just broadens the Qt.io rule a bit to include the download link, which doesn't autoredirect to SSL/TLS, and the bug reporting link, which does.