### PR TITLE
Add test tag to RELAX NG grammar.

### DIFF
--- a/src/chrome/content/rules/EFF.xml
+++ b/src/chrome/content/rules/EFF.xml
@@ -16,9 +16,6 @@
 
 	<target host="eff.org" />
 	<target host="*.eff.org" />
-		<exclusion pattern="^http://action\.eff\.org/" />
-	<!--	* for cross-subdomain cookie.	-->
-	<target host="*.supporters.eff.org" />
 	<target host="defendinnovation.org" />
 	<target host="www.defendinnovation.org" />
 	<target host="globalchokepoints.org" />
@@ -28,18 +25,12 @@
 	<target host="ripmixmake.org" />
 	<target host="www.ripmixmake.org" />
 
+	<test url="http://www.eff.org/" />
+	<test url="http://action.eff.org/" />
+	<test url="http://supporters.eff.org/" />
+	<test url="https://www.eff.org/sites/all/themes/frontier/images/get-https-e-chrome.png" />
 
 	<securecookie host="^.*\.eff\.org$" name=".*" />
-
-
-	<rule from="^http://secure\.eff\.org/donate"
-		to="https://secure.eff.org/site/Donation2?idb=43804189&#x26;df_id=1200" />
-
-	<rule from="^http://secure\.eff\.org/mechaposter"
-		to="https://secure.eff.org/site/Ecommerce?VIEW_PRODUCT=true&#x26;product_id=2161&#x26;store_id=2441" />
-
-	<rule from="^http://secure\.eff\.org/wiretapping"
-		to="https://secure.eff.org/site/Donation2?idb=1344423068&#x26;df_id=1220" />
 
 	<rule from="^http://([^/:@\.]+\.)?eff\.org/"
 		to="https://$1eff.org/" />
@@ -51,7 +42,6 @@
 
 	<rule from="^https://www\.eff\.org/sites/all/themes/frontier/images/get-https-e(-chrome)?.png"
 		to="https://www.eff.org/sites/all/themes/frontier/images/got-https-e$1.png" />
-
 
 	<!--
 		Other EFF websites that support HTTPS.

--- a/utils/relaxng.xml
+++ b/utils/relaxng.xml
@@ -19,6 +19,12 @@
 
   <interleave>
 
+    <zeroOrMore>
+      <element name="test">
+        <attribute name="url" />
+      </element>
+    </zeroOrMore>
+
     <oneOrMore>
       <element name="target">
         <attribute name="host">


### PR DESCRIPTION
This allows us to start adding explicit test URLs to rulesets.

cc @cooperq for review.