### PR TITLE
Add automated coverage testing.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
 [submodule "addon-sdk"]
 	path = addon-sdk
 	url = https://github.com/mozilla/addon-sdk.git
+[submodule "https-everywhere-checker"]
+	path = https-everywhere-checker
+	url = https://github.com/jsha/https-everywhere-checker.git
+	branch = coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,13 @@ python:
 addons:
   firefox: "35.0"
 install:
-  - sudo apt-get -qq install libxml2-dev libxslt-dev python-dev
+  - sudo apt-get -qq install libxml2-dev libxslt-dev python-dev libcurl4-openssl-dev
   - pip install -r requirements.txt
+  - pip install -r https-everywhere-checker/requirements.txt
 before_script:
   - sh -e /etc/init.d/xvfb start
 env:
   - DISPLAY=':99.0'
-script: ./test.sh
+script:
+  - ./test.sh
+  - ./test-ruleset-coverage.sh

--- a/test-ruleset-coverage.sh
+++ b/test-ruleset-coverage.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#
+# Test that all rulesets modified after a certain date have sufficient test
+# coverage, according to the ruleset checker.
+#
+cd $(dirname $0)
+TMP=`mktemp`
+trap 'rm "$TMP"' EXIT
+if ! git log --name-only --date=local --since=2015-02-05 --pretty=format: \
+      src/chrome/content/rules/ | sort -u | \
+      xargs python2.7 https-everywhere-checker/src/https_everywhere_checker/check_rules.py \
+      https-everywhere-checker/checker.config.sample ; then
+  echo "Ruleset test coverage was insufficient. Please add <test url=...> tags " \
+       "to ruleset with additional HTTP URLs to test rewriting and fetching."
+  exit 1
+else
+  exit 0
+fi


### PR DESCRIPTION
This ensures that all new or changed rulesets from now on must have sufficient test URLs to cover all the rules in them.

Adds a submodule pointing to `coverage' branch of https-everywhere-checker.
Adds a script to automatically run the checker in coverage-only mode.

cc @cooperq @pde for review.