### PR TITLE
Added trakt.xml

### DIFF
--- a/src/chrome/content/rules/trakt.xml
+++ b/src/chrome/content/rules/trakt.xml
@@ -1,0 +1,20 @@
+<ruleset name="trakt">
+
+	<target host="trakt.tv" />
+	<target host="*.trakt.tv" />
+
+	<!-- For securecookie rule below (used for some images) -->
+	<target host="*.trakt.us" />
+
+	<!--	Not secured by server:
+					-->
+	<!--securecookie host="^\.trakt\.(tv|us)$" name="^__cfduid$" /-->
+	<!--securecookie host="^trakt\.tv$" name="^(_traktsession|AWSELB|trakt_username|remember_user_token)$" /-->
+
+	<securecookie host="^(www\.|\.)?trakt\.tv$" name=".+" />
+	<securecookie host="^\.trakt\.us$" name=".+" />
+
+	<rule from="^http://(www\.)?trakt\.tv/"
+		to="https://$1trakt.tv/" />
+
+</ruleset>

--- a/src/chrome/content/rules/trakt.xml
+++ b/src/chrome/content/rules/trakt.xml
@@ -15,9 +15,6 @@
 	<!-- For securecookie rule below (host used for movie etc. images) -->
 	<target host="*.trakt.us" />
 
-	<test url="http://www.trakt.tv/" />
-	<test url="http://support.trakt.tv/" />
-
 	<!--	Not secured by server:
 					-->
 	<!--securecookie host="^\.trakt\.(tv|us)$" name="^__cfduid$" /-->

--- a/src/chrome/content/rules/trakt.xml
+++ b/src/chrome/content/rules/trakt.xml
@@ -9,7 +9,8 @@
 <ruleset name="trakt" platform="mixedcontent">
 
 	<target host="trakt.tv" />
-	<target host="*.trakt.tv" />
+	<target host="www.trakt.tv" />
+	<target host="support.trakt.tv" />
 
 	<!-- For securecookie rule below (host used for movie etc. images) -->
 	<target host="*.trakt.us" />
@@ -27,7 +28,7 @@
 	<securecookie host="^\.?support\.trakt\.tv$" name=".*" />
 	<securecookie host="^\.trakt\.us$" name=".+" />
 
-	<rule from="^http://(www\.|support\.)?trakt\.tv/"
-		to="https://$1trakt.tv/" />
+	<rule from="^http:"
+		to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/trakt.xml
+++ b/src/chrome/content/rules/trakt.xml
@@ -6,7 +6,7 @@
 			- i0.wp.com (from Gravatar)
 
 -->
-<ruleset name="trakt" platform="mixedcontent">
+<ruleset name="trakt">
 
 	<target host="trakt.tv" />
 	<target host="www.trakt.tv" />

--- a/src/chrome/content/rules/trakt.xml
+++ b/src/chrome/content/rules/trakt.xml
@@ -1,4 +1,12 @@
-<ruleset name="trakt">
+<!--
+	Mixed content on secure:
+
+		- Images, from:
+
+			- i0.wp.com (from Gravatar)
+
+-->
+<ruleset name="trakt" platform="mixedcontent">
 
 	<target host="trakt.tv" />
 	<target host="*.trakt.tv" />

--- a/src/chrome/content/rules/trakt.xml
+++ b/src/chrome/content/rules/trakt.xml
@@ -3,18 +3,23 @@
 	<target host="trakt.tv" />
 	<target host="*.trakt.tv" />
 
-	<!-- For securecookie rule below (used for some images) -->
+	<!-- For securecookie rule below (host used for movie etc. images) -->
 	<target host="*.trakt.us" />
+
+	<test url="http://www.trakt.tv/" />
+	<test url="http://support.trakt.tv/" />
 
 	<!--	Not secured by server:
 					-->
 	<!--securecookie host="^\.trakt\.(tv|us)$" name="^__cfduid$" /-->
-	<!--securecookie host="^trakt\.tv$" name="^(_traktsession|AWSELB|trakt_username|remember_user_token)$" /-->
+	<!--securecookie host="^\.?support\.trakt\.tv$" name="^_session_id$" /-->
+	<!--securecookie host="^(www\.)?trakt\.tv$" name="^(_traktsession|AWSELB|trakt_username|remember_user_token)$" /-->
 
-	<securecookie host="^(www\.|\.)?trakt\.tv$" name=".+" />
+	<securecookie host="^(\.|www\.)?trakt\.tv$" name=".+" />
+	<securecookie host="^\.?support\.trakt\.tv$" name=".*" />
 	<securecookie host="^\.trakt\.us$" name=".+" />
 
-	<rule from="^http://(www\.)?trakt\.tv/"
+	<rule from="^http://(www\.|support\.)?trakt\.tv/"
 		to="https://$1trakt.tv/" />
 
 </ruleset>


### PR DESCRIPTION
I didn't run into any mixed content issues (for instance, trakt.us is automatically accessed over HTTPS by trakt.tv if browsing it with HTTPS) whilst browsing trakt.tv with this rule on in Firefox. I tried to adhere to the common patterns I saw in other rules, but forgive me if there's any oddities.