### PR TITLE
Idea/suggestion: Include total count when some rules are inactive

### DIFF
--- a/src/chrome/content/toolbar_button.js
+++ b/src/chrome/content/toolbar_button.js
@@ -181,21 +181,29 @@ httpsEverywhere.toolbarButton = {
     }
     // Make sure the list is up to date
     alist.populate_list();
-
-    var counter = 0;
+    
+    var totalCounter = 0;
+    for (var x in alist.all) {
+      ++totalCounter;
+    }
+    var activeCounter = 0;
     for (var x in alist.active) {
       if (!(x in alist.breaking)) {
-        ++counter;
+        ++activeCounter;
       }
     }
     for (var x in alist.moot) {
       if (!(x in alist.active)) {
-        ++counter;
+        ++activeCounter;
       }
     }
-
-    toolbarbutton.setAttribute('rulesetsApplied', counter);
-    HTTPSEverywhere.log(INFO, 'Setting icon counter to: ' + counter);
+    if (totalCounter != 0) {
+      var counterLabel = activeCounter + '/' + totalCounter;
+    } else {
+      var counterLabel = 0;
+    }
+    toolbarbutton.setAttribute('rulesetsApplied', counterLabel);
+    HTTPSEverywhere.log(INFO, 'Setting icon counter to: ' + counterLabel);
   },
 
   /**

--- a/src/chrome/content/toolbar_button.js
+++ b/src/chrome/content/toolbar_button.js
@@ -197,10 +197,10 @@ httpsEverywhere.toolbarButton = {
         ++activeCounter;
       }
     }
-    if (totalCounter != 0) {
+    if (totalCounter != activeCounter) {
       var counterLabel = activeCounter + '/' + totalCounter;
     } else {
-      var counterLabel = 0;
+      var counterLabel = totalCounter;
     }
     toolbarbutton.setAttribute('rulesetsApplied', counterLabel);
     HTTPSEverywhere.log(INFO, 'Setting icon counter to: ' + counterLabel);


### PR DESCRIPTION
One thing that has bugged me a few times is that there's no way to tell if one is browsing a site that supports a ruleset which is disabled per default. These commits fix this by adding the total count of rules, in the case where some are inactive. [See this screenshot](https://hallon.fuglede.dk/dump/https-e-counter.png).

Pro:
- Makes it easier to identify the possibility of activating rules that are otherwise hidden in the toolbar button menu.

Some cons:
- Only really useful to people who don't mind experimenting with broken rulesets
- Clutters the interface ever so slightly. This is mitigated by only changing the label when the total count differs from the active count.

(Also, a question: does the ApplicableList have a counter itself?)