### PR TITLE
Use system python-lxml in Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,10 @@ python:
   - "2.7"
 addons:
   firefox: "35.0"
+virtualenv:
+  system_site_packages: true
 install:
-  - sudo apt-get -qq install libxml2-dev libxslt-dev python-dev libcurl4-openssl-dev
-  - pip install -r requirements.txt
+  - sudo apt-get -qq install libxml2-dev libxslt-dev python-dev libcurl4-openssl-dev python-lxml
   - pip install -r https-everywhere-checker/requirements.txt
 before_script:
   - sh -e /etc/init.d/xvfb start


### PR DESCRIPTION
This avoids having to 'pip install' lxml, which takes a long time because it
compiles the package each time. Instead we install the precompiled version from
apt-get and tell virtualenv it's okay to use it. Note that this works for Python
2.7 only.

This brings test times from ~3 minutes to ~1 minute.