### PR TITLE
[Tmblr.co] Redirect to the right domain

### DIFF
--- a/src/chrome/content/rules/Tmblr.co.xml
+++ b/src/chrome/content/rules/Tmblr.co.xml
@@ -14,7 +14,7 @@
 
 	<!--	Redirect keeps path and args:
 						-->
-	<rule from="^http://tmblr\.co/+"
+	<rule from="^http://tmblr\.co/"
 		to="https://www.tumblr.com/" />
 
 </ruleset>

--- a/src/chrome/content/rules/Tmblr.co.xml
+++ b/src/chrome/content/rules/Tmblr.co.xml
@@ -1,14 +1,12 @@
 <!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://tmblr.co/ => https://www.tumbler.com/: (51, "SSL: certificate subject name 'www.tervis.com' does not match target host name 'www.tumbler.com'")
-	For other Tumblr coverage, see Tumbler.xml.
+	For other Tumblr coverage, see Tumblr.xml.
 
 
 	^: refused
 	www doesn't exist
 
 -->
-<ruleset name="Tmblr.co" default_off='failed ruleset test'>
+<ruleset name="Tmblr.co">
 
 	<target host="tmblr.co" />
 
@@ -16,6 +14,6 @@ Fetch error: http://tmblr.co/ => https://www.tumbler.com/: (51, "SSL: certificat
 	<!--	Redirect keeps path and args:
 						-->
 	<rule from="^http://tmblr\.co/+"
-		to="https://www.tumbler.com/" />
+		to="https://www.tumblr.com/" />
 
 </ruleset>

--- a/src/chrome/content/rules/Tmblr.co.xml
+++ b/src/chrome/content/rules/Tmblr.co.xml
@@ -10,6 +10,7 @@
 
 	<target host="tmblr.co" />
 
+	<test url="http://tmblr.co/ZE5Fby1dP0xGe" />
 
 	<!--	Redirect keeps path and args:
 						-->


### PR DESCRIPTION
It was redirecting to www.tumblEr.com instead of www.tumblr.com.

This wasn't too much of a privacy issue, since https://www.tumbler.com/ has a
mismatching cert, so a user would have to click through the warning to load it.
Besides, it's only Tumblr's URL shortener.