### PR TITLE
Fix ruleset National-Security-Agency.xml by removing non-resolving host

### DIFF
--- a/src/chrome/content/rules/National-Security-Agency.xml
+++ b/src/chrome/content/rules/National-Security-Agency.xml
@@ -1,13 +1,8 @@
-<!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://nsa.gov/ => https://nsa.gov/: (6, 'Could not resolve host: nsa.gov')
--->
-<ruleset name="National Security Agency" platform="mixedcontent" default_off='failed ruleset test'>
+<ruleset name="National Security Agency" platform="mixedcontent">
 
-	<target host="nsa.gov" />
 	<target host="www.nsa.gov" />
 
-	<rule from="^http://(www\.)?nsa\.gov/"
-		to="https://$1nsa.gov/" />
+	<rule from="^http:"
+		to="https:" />
 
 </ruleset>


### PR DESCRIPTION
Yes, "nsa.gov" really doesn't resolve. "www.nsa.gov" works.

By the way, I suspect the website no longer has the mixed-content issues it used to, but I can't say for certain and don't know how to test.