### PR TITLE
install-dev-dependencies.sh fails after cloning

### DIFF
--- a/install-dev-dependencies.sh
+++ b/install-dev-dependencies.sh
@@ -11,13 +11,16 @@ elif type brew >/dev/null ; then
     echo '/usr/local/bin not found in $PATH, please add it.'
   fi
 fi
+
+# Get the addon SDK submodule and rule checker
+git submodule init
+git submodule update
+
+# Install Python packages
 pip install --user --no-allow-insecure --no-allow-external -r requirements.txt
 cd https-everywhere-checker
 pip install --user -r requirements.txt
 cd -
-# Get the addon SDK submodule
-git submodule init
-git submodule update
 
 # Install a hook to run tests before pushing.
 ln -sf ../../test.sh .git/hooks/pre-push


### PR DESCRIPTION
Fix: install-dev-dependencies.sh fails if run just after cloning due to missing https-everywhere-checker/requirements.txt. This file is created when the corresponding submodule is updated.