### PR TITLE
Fix MySQL rule.

### DIFF
--- a/src/chrome/content/rules/MySQL.xml
+++ b/src/chrome/content/rules/MySQL.xml
@@ -12,6 +12,14 @@
 	Problematic subdomains:
 
 		- cdn	(akamai)
+        cdn
+        downloads
+        forge
+        lists
+        planet
+        wb
+        forums
+        labs
 
 
 	Nonfunctional subdomains:
@@ -24,17 +32,9 @@
 <ruleset name="MySQL">
 
 	<target host="mysql.com"/>
-	<target host="*.mysql.com"/>
-    <!-- forums works but is a cert mismatch -->
-		<exclusion pattern="^http://(?:cdn|downloads|forge|lists|planet|wb|forums|labs)\.mysql\.com/"/>
-        <test url="http://cdn.mysql.com/"/>
-        <test url="http://downloads.mysql.com/"/>
-        <test url="http://forge.mysql.com/"/>
-        <test url="http://lists.mysql.com/"/>
-        <test url="http://planet.mysql.com/"/>
-        <test url="http://wb.mysql.com/"/>
-        <test url="http://forums.mysql.com/"/>
-        <test url="http://labs.mysql.com/"/>
+	<target host="dev.mysql.com"/>
+	<target host="www-jp.mysql.com"/>
+	<target host="repo.mysql.com"/>
 	<target host="mysql.de"/>
 	<target host="www.mysql.de"/>
 	<target host="mysql.fr"/>
@@ -58,16 +58,11 @@
 							-->
 	<securecookie host="^\.mysql\.\w{2,3}$" name="^MySQL_S$"/>
 
-
-
-	<rule from="^http://([^/:@\.]+\.)?mysql\.com/"
-		to="https://$1mysql.com/"/>
-        <test url="http://foo.mysql.com/"/>
-        <test url="http://bar.mysql.com/"/>
-        <test url="http://baz.mysql.com/"/>
-
 	<!--	Cert doesn't match !www		-->
-	<rule from="^http://(?:www\.)?mysql\.(\w\w)/"
+	<rule from="^http://mysql\.(\w\w)/"
 		to="https://www.mysql.$1/"/>
+
+	<rule from="^http:"
+		to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/MySQL.xml
+++ b/src/chrome/content/rules/MySQL.xml
@@ -35,6 +35,7 @@
 	<target host="dev.mysql.com"/>
 	<target host="www-jp.mysql.com"/>
 	<target host="repo.mysql.com"/>
+	<target host="bugs.mysql.com"/>
 	<target host="mysql.de"/>
 	<target host="www.mysql.de"/>
 	<target host="mysql.fr"/>

--- a/src/chrome/content/rules/Oracle-mismatches.xml
+++ b/src/chrome/content/rules/Oracle-mismatches.xml
@@ -4,14 +4,6 @@
 -->
 <ruleset name="Oracle (mismatches)" default_off="mismatch">
 
-	<!--	Cert: www.mysql.com	-->
-	<target host="bugs.mysql.com" />
-	<target host="downloads.mysql.com" />
-	<target host="forge.mysql.com" />
-	<target host="forums.mysql.com" />
-	<target host="labs.mysql.com" />
-	<target host="lists.mysql.com" />
-	<target host="planet.mysql.com" />
 	<!--	Akamai	-->
 	<target host="events.oracle.com" />
 	<!--	cert: forums.netbeans.org	-->


### PR DESCRIPTION
foo.mysql.com and similar test URLs failed the fetch test. Also there were more
exclusions than inclusions, so turned the rule into an explicit list of good
subdomains.

cc @cooperq for review