### PR TITLE
[dhl.de] Multiple subdomains + test coverage

### DIFF
--- a/src/chrome/content/rules/DHL.de.xml
+++ b/src/chrome/content/rules/DHL.de.xml
@@ -10,11 +10,6 @@
 
   <securecookie host="^(?:.*\.)?dhl\.de$" name=".*" />
 
-  <rule from="^http://(?:www\.)?dhl\.de/" to="https://www.dhl.de/"/>
-  <rule from="^http://mobile\.dhl\.de/" to="https://mobile.dhl.de/"/>
-  <rule from="^http://nolp\.dhl\.de/" to="https://nolp.dhl.de/"/>
-  <rule from="^http://nolb\.dhl\.de/" to="https://nolb.dhl.de/"/>
-  <rule from="^http://partner\.dhl\.de/" to="https://partner.dhl.de/"/>
-  <rule from="^http://entwickler\.dhl\.de/" to="https://entwickler.dhl.de/"/>
-  <rule from="^http://fcm\.dhl\.de/" to="https://fcm.dhl.de/"/>
+  <rule from="^http:"
+    to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/DHL.de.xml
+++ b/src/chrome/content/rules/DHL.de.xml
@@ -1,9 +1,20 @@
 <ruleset name="DHL.de" platform="mixedcontent">
   <target host="dhl.de"/>
-  <target host="*.dhl.de"/>
+  <target host="www.dhl.de"/>
+  <target host="mobile.dhl.de"/>
+  <target host="nolp.dhl.de"/>
+  <target host="nolb.dhl.de"/>
+  <target host="partner.dhl.de"/>
+  <target host="entwickler.dhl.de"/>
+  <target host="fcm.dhl.de"/>
 
   <securecookie host="^(?:.*\.)?dhl\.de$" name=".*" />
 
   <rule from="^http://(?:www\.)?dhl\.de/" to="https://www.dhl.de/"/>
+  <rule from="^http://mobile\.dhl\.de/" to="https://mobile.dhl.de/"/>
   <rule from="^http://nolp\.dhl\.de/" to="https://nolp.dhl.de/"/>
+  <rule from="^http://nolb\.dhl\.de/" to="https://nolb.dhl.de/"/>
+  <rule from="^http://partner\.dhl\.de/" to="https://partner.dhl.de/"/>
+  <rule from="^http://entwickler\.dhl\.de/" to="https://entwickler.dhl.de/"/>
+  <rule from="^http://fcm\.dhl\.de/" to="https://fcm.dhl.de/"/>
 </ruleset>

--- a/src/chrome/content/rules/DHL.de.xml
+++ b/src/chrome/content/rules/DHL.de.xml
@@ -5,4 +5,5 @@
   <securecookie host="^(?:.*\.)?dhl\.de$" name=".*" />
 
   <rule from="^http://(?:www\.)?dhl\.de/" to="https://www.dhl.de/"/>
+  <rule from="^http://nolp\.dhl\.de/" to="https://nolp.dhl.de/"/>
 </ruleset>


### PR DESCRIPTION
Already supports HSTS, but currently doesn't default to https.
The official account-page on paket.de for example links from https to http which prevents HSTS from working.