### PR TITLE
Fix tests: disable failing rulesets.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,10 @@ env:
   - DISPLAY=':99.0'
 script:
   - ./test.sh
-  - ./test-ruleset-coverage.sh
+# In test-ruleset-coverage.sh (called by test.sh), we use a git log --since
+# to test only files that changed since a certain date. Travis does a
+# shallow clone to save time. Unfortunately, the shallow clone for some reason
+# means that *all* the files under src/chrome/content/rules git listed in the
+# git log. Deepening the clone fixes it for now, but we should dig deeper.
+git:
+  depth: 300

--- a/src/chrome/content/rules/0x539-dev-group.xml
+++ b/src/chrome/content/rules/0x539-dev-group.xml
@@ -17,7 +17,7 @@ Fetch error: http://gobby.0x539.de/ => https://gobby.0x539.de/: (7, 'Failed to c
 	(www.)? doesn't exist.
 
 -->
-<ruleset name="0x539 dev group (partial)">
+<ruleset name="0x539 dev group (partial)" default_off="Needs ruleset tests">
 
 	<target host="hosting.0x539.de" />
 	<target host="gobby.0x539.de" />

--- a/src/chrome/content/rules/0xbadc0de.be.xml
+++ b/src/chrome/content/rules/0xbadc0de.be.xml
@@ -27,7 +27,7 @@
 	² Not secured by us <= mismatched
 
 -->
-<ruleset name="0xbadc0de.be">
+<ruleset name="0xbadc0de.be" default_off="Needs ruleset tests">
 
 	<target host="0xbadc0de.be" />
 	<target host="*.0xbadc0de.be" />

--- a/src/chrome/content/rules/123eHost.com.xml
+++ b/src/chrome/content/rules/123eHost.com.xml
@@ -13,7 +13,7 @@ Fetch error: http://drive7000.station030.com/ => https://drive7000.station030.co
 	* Secured by us
 
 -->
-<ruleset name="123eHost.com (partial)">
+<ruleset name="123eHost.com (partial)" default_off="Needs ruleset tests">
 
 	<target host="123ehost.com" />
 	<target host="www.123ehost.com" />

--- a/src/chrome/content/rules/123systems.xml
+++ b/src/chrome/content/rules/123systems.xml
@@ -6,7 +6,7 @@
 	* Secured by us
 
 -->
-<ruleset name="123systems.net (partial)">
+<ruleset name="123systems.net (partial)" default_off="Needs ruleset tests">
 
 	<target host="123systems.net" />
 	<target host="www.123systems.net" />

--- a/src/chrome/content/rules/1984_Hosting.com.xml
+++ b/src/chrome/content/rules/1984_Hosting.com.xml
@@ -10,7 +10,7 @@
 		- www.1984hosting.com
 
 -->
-<ruleset name="1984 Hosting.com">
+<ruleset name="1984 Hosting.com" default_off="Needs ruleset tests">
   <target host="1984hosting.com" />
   <target host="*.1984hosting.com" />
 

--- a/src/chrome/content/rules/Auto.ro.xml
+++ b/src/chrome/content/rules/Auto.ro.xml
@@ -57,7 +57,7 @@
 	³ Not secured by us <= mismatched
 
 -->
-<ruleset name="Auto.ro (partial)">
+<ruleset name="Auto.ro (partial)" default_off="Needs ruleset tests">
 
 	<target host="auto.ro" />
 	<target host="www.auto.ro" />

--- a/src/chrome/content/rules/Bitcurex.com.xml
+++ b/src/chrome/content/rules/Bitcurex.com.xml
@@ -9,7 +9,7 @@
 		- pln
 
 -->
-<ruleset name="Bitcurex.com">
+<ruleset name="Bitcurex.com" default_off="Needs ruleset tests">
 
 	<target host="bitcurex.com" />
 	<target host="*.bitcurex.com" />

--- a/src/chrome/content/rules/Bitstamp.net.xml
+++ b/src/chrome/content/rules/Bitstamp.net.xml
@@ -29,7 +29,7 @@
 		- www.bitstamp.net
 
 -->
-<ruleset name="Bitstamp.net">
+<ruleset name="Bitstamp.net" default_off="Needs ruleset tests">
 
 	<target host="bitstamp.net" />
 	<target host="*.bitstamp.net" />

--- a/src/chrome/content/rules/Bter.com.xml
+++ b/src/chrome/content/rules/Bter.com.xml
@@ -18,7 +18,7 @@
 		- old
 
 -->
-<ruleset name="Bter.com (partial)">
+<ruleset name="Bter.com (partial)" default_off="Needs ruleset tests">
 
 	<target host="bter.com" />
 	<target host="*.bter.com" />

--- a/src/chrome/content/rules/Codeplex.xml
+++ b/src/chrome/content/rules/Codeplex.xml
@@ -2,7 +2,7 @@
 	For other Microsoft coverage, see Microsoft.xml.
 
 -->
-<ruleset name="Codeplex.com (partial)">
+<ruleset name="Codeplex.com (partial)" default_off="Needs ruleset tests">
 
 	<target host="codeplex.com" />
 	<target host="*.codeplex.com" />

--- a/src/chrome/content/rules/Coinbase.xml
+++ b/src/chrome/content/rules/Coinbase.xml
@@ -39,7 +39,7 @@
 		- docs.exchange.coinbase.com
 
 -->
-<ruleset name="Coinbase (partial)">
+<ruleset name="Coinbase (partial)" default_off="Needs ruleset tests">
 
 	<target host="coinbase.com" />
 	<target host="*.coinbase.com" />

--- a/src/chrome/content/rules/Cryptonit.xml
+++ b/src/chrome/content/rules/Cryptonit.xml
@@ -1,4 +1,4 @@
-<ruleset name="cryptonit">
+<ruleset name="cryptonit" default_off="Needs ruleset tests">
 
 	<target host="cryptonit.net" />
 	<target host="*.cryptonit.net" />

--- a/src/chrome/content/rules/Facebook.xml
+++ b/src/chrome/content/rules/Facebook.xml
@@ -110,7 +110,7 @@
 		- prod.facebook.com
 
 -->
-<ruleset name="Facebook">
+<ruleset name="Facebook" default_off="Needs ruleset tests">
 
 	<target host="facebook.*" />
 	<target host="www.facebook.*" />

--- a/src/chrome/content/rules/GEANT.net.xml
+++ b/src/chrome/content/rules/GEANT.net.xml
@@ -24,7 +24,7 @@
 		- www
 
 -->
-<ruleset name="GEANT.net (partial)">
+<ruleset name="GEANT.net (partial)" default_off="Needs ruleset tests">
 
 	<target host="*.geant.net" />
 		<!--

--- a/src/chrome/content/rules/GNU.org.xml
+++ b/src/chrome/content/rules/GNU.org.xml
@@ -50,7 +50,7 @@
 		- www.gcc.gnu.org
 
 -->
-<ruleset name="GNU.org (partial)">
+<ruleset name="GNU.org (partial)" default_off="Needs ruleset tests">
 
 	<target host="gnu.org" />
 	<target host="*.gnu.org" />

--- a/src/chrome/content/rules/George-Mason-University.xml
+++ b/src/chrome/content/rules/George-Mason-University.xml
@@ -28,7 +28,7 @@
 		- policy
 
 -->
-<ruleset name="George Mason University (partial)" platform="mixedcontent">
+<ruleset name="George Mason University (partial)" platform="mixedcontent" default_off="Needs ruleset tests">
 
 	<target host="gmu.edu"/>
 	<target host="*.gmu.edu"/>

--- a/src/chrome/content/rules/Github.xml
+++ b/src/chrome/content/rules/Github.xml
@@ -64,7 +64,7 @@
 		- status.github.com
 
 -->
-<ruleset name="GitHub">
+<ruleset name="GitHub" default_off="Needs ruleset tests">
 
 	<target host="github.com" />
 	<target host="*.github.com" />

--- a/src/chrome/content/rules/IAS.edu.xml
+++ b/src/chrome/content/rules/IAS.edu.xml
@@ -49,7 +49,7 @@
 		- rt.ias.edu
 
 -->
-<ruleset name="IAS.edu (partial)">
+<ruleset name="IAS.edu (partial)" default_off="Needs ruleset tests">
 
 	<target host="ias.edu" />
 	<target host="*.ias.edu" />

--- a/src/chrome/content/rules/Instagram.xml
+++ b/src/chrome/content/rules/Instagram.xml
@@ -100,7 +100,7 @@
 		- badges.instagram.com
 
 -->
-<ruleset name="Instagram (partial)">
+<ruleset name="Instagram (partial)" default_off="Needs ruleset tests">
 
 	<target host="instagr.am" />
 	<target host="instagram.com" />

--- a/src/chrome/content/rules/Launchpad.xml
+++ b/src/chrome/content/rules/Launchpad.xml
@@ -54,7 +54,7 @@
 	² Secured by us
 
 -->
-<ruleset name="Launchpad">
+<ruleset name="Launchpad" default_off="Needs ruleset tests">
     <target host="launchpad.net" />
     <target host="*.launchpad.net" />
     <target host="launchpadlibrarian.net" />

--- a/src/chrome/content/rules/OKCoin.com.xml
+++ b/src/chrome/content/rules/OKCoin.com.xml
@@ -7,7 +7,7 @@
 		- www.img.okcoin.com
 
 -->
-<ruleset name="OKCoin.com">
+<ruleset name="OKCoin.com" default_off="Needs ruleset tests">
 
 	<target host="okcoin.com" />
 	<target host="*.okcoin.com" />

--- a/src/chrome/content/rules/OverClockers.xml
+++ b/src/chrome/content/rules/OverClockers.xml
@@ -6,7 +6,7 @@
 	* Dropped
 
 -->
-<ruleset name="OverClockers.co.uk (partial)">
+<ruleset name="OverClockers.co.uk (partial)" default_off="Needs ruleset tests">
 
 	<target host="overclockers.co.uk" />
 	<target host="*.overclockers.co.uk" />

--- a/src/chrome/content/rules/Postscapes.xml
+++ b/src/chrome/content/rules/Postscapes.xml
@@ -5,7 +5,7 @@
 		- d3uifzcxlzuvqz.cloudfront.net
 
 -->
-<ruleset name="Postscapes" platform="mixedcontent">
+<ruleset name="Postscapes" platform="mixedcontent" default_off="Needs ruleset tests">
 
 	<target host="postscapes.com" />
 	<target host="*.postscapes.com" />

--- a/src/chrome/content/rules/RobotShop.xml
+++ b/src/chrome/content/rules/RobotShop.xml
@@ -1,4 +1,4 @@
-<ruleset name="RobotShop (partial)" platform="mixedcontent">
+<ruleset name="RobotShop (partial)" platform="mixedcontent" default_off="Needs ruleset tests">
 
 	<target host="robotshop.com" />
 	<target host="*.robotshop.com" />

--- a/src/chrome/content/rules/Sitestat.xml
+++ b/src/chrome/content/rules/Sitestat.xml
@@ -14,7 +14,7 @@
 		- fr.sitestat.com
 
 -->
-<ruleset name="Sitestat.com (partial)">
+<ruleset name="Sitestat.com (partial)" default_off="Needs ruleset tests">
 
 	<target host="*.sitestat.com" />
 

--- a/src/chrome/content/rules/StackSocial.xml
+++ b/src/chrome/content/rules/StackSocial.xml
@@ -20,7 +20,7 @@
 		- beta
 
 -->
-<ruleset name="StackSocial (partial)">
+<ruleset name="StackSocial (partial)" default_off="Needs ruleset tests">
 
 	<target host="stacksocial.com" />
 	<target host="*.stacksocial.com" />

--- a/src/chrome/content/rules/Techdirt.xml
+++ b/src/chrome/content/rules/Techdirt.xml
@@ -9,7 +9,7 @@
 			- Equivalent to cdn.techdirt.com
 
 -->
-<ruleset name="Techdirt">
+<ruleset name="Techdirt" default_off="Needs ruleset tests">
 
 	<target host="techdirt.com" />
 	<target host="*.techdirt.com" />

--- a/src/chrome/content/rules/Terena.org.xml
+++ b/src/chrome/content/rules/Terena.org.xml
@@ -74,7 +74,7 @@
 		- www.terena.org
 
 -->
-<ruleset name="Terena.org (partial)">
+<ruleset name="Terena.org (partial)" default_off="Needs ruleset tests">
 
 	<target host="terena.org" />
 	<target host="*.terena.org" />

--- a/src/chrome/content/rules/Tradepub.com.xml
+++ b/src/chrome/content/rules/Tradepub.com.xml
@@ -53,7 +53,7 @@
 	³ Unsecurable
 
 -->
-<ruleset name="tradepub.com (partial)">
+<ruleset name="tradepub.com (partial)" default_off="Needs ruleset tests">
 
 	<target host="tradepub.com" />
 	<target host="*.tradepub.com" />

--- a/src/chrome/content/rules/TrueLife.com.xml
+++ b/src/chrome/content/rules/TrueLife.com.xml
@@ -66,7 +66,7 @@
 	³ Unsecurable <= 403
 
 -->
-<ruleset name="TrueLife.com (partial)">
+<ruleset name="TrueLife.com (partial)" default_off="Needs ruleset tests">
 
 	<target host="truelife.com" />
 	<target host="home.truelife.com" />

--- a/src/chrome/content/rules/Ubuntu.xml
+++ b/src/chrome/content/rules/Ubuntu.xml
@@ -113,7 +113,7 @@
 	* Unsecurable, doesn't trip MCB
 
 -->
-<ruleset name="Ubuntu (partial)">
+<ruleset name="Ubuntu (partial)" default_off="Needs ruleset tests">
 
 	<target host="*.ubuntu.com" />
 		<!--

--- a/src/chrome/content/rules/Ukash.com.xml
+++ b/src/chrome/content/rules/Ukash.com.xml
@@ -14,7 +14,7 @@
 		- www.ukash.com
 
 -->
-<ruleset name="Ukash.com">
+<ruleset name="Ukash.com" default_off="Needs ruleset tests">
 
 	<target host="ukash.com" />
 	<target host="direct.ukash.com" />

--- a/src/chrome/content/rules/University-of-Maryland.xml
+++ b/src/chrome/content/rules/University-of-Maryland.xml
@@ -113,7 +113,7 @@
 	* Secured by us
 
 -->
-<ruleset name="UMd.edu (partial)">
+<ruleset name="UMd.edu (partial)" default_off="Needs ruleset tests">
 
 	<target host="umd.edu" />
 	<target host="*.umd.edu" />

--- a/src/chrome/content/rules/University-of-Minnesota.xml
+++ b/src/chrome/content/rules/University-of-Minnesota.xml
@@ -36,7 +36,7 @@
 	* Secured by us
 
 -->
-<ruleset name="University of Minnesota (partial)">
+<ruleset name="University of Minnesota (partial)" default_off="Needs ruleset tests">
 
 	<target host="*.umn.edu" />
 		<!--exclusion pattern="^http://mirror\.cs\.umn\.edu/" /-->

--- a/src/chrome/content/rules/Yandex.by.xml
+++ b/src/chrome/content/rules/Yandex.by.xml
@@ -195,7 +195,7 @@
 	² Unsecurable <= dropped
 
 -->
-<ruleset name="Yandex.by (partial)">
+<ruleset name="Yandex.by (partial)" default_off="Needs ruleset tests">
 
 	<target host="yandex.by" />
 	<target host="*.yandex.by" />

--- a/src/chrome/content/rules/Yandex.net.xml
+++ b/src/chrome/content/rules/Yandex.net.xml
@@ -137,7 +137,7 @@
 	* Secured by us
 
 -->
-<ruleset name="Yandex.net (partial)">
+<ruleset name="Yandex.net (partial)" default_off="Needs ruleset tests">
 
 	<target host="yandex.net" />
 	<target host="*.yandex.net" />

--- a/src/chrome/content/rules/Yandex.ua.xml
+++ b/src/chrome/content/rules/Yandex.ua.xml
@@ -132,7 +132,7 @@
 	² Unsecurable <= dropped
 
 -->
-<ruleset name="Yandex.ua (partial)">
+<ruleset name="Yandex.ua (partial)" default_off="Needs ruleset tests">
 
 	<target host="yandex.ua" />
 	<target host="*.yandex.ua" />

--- a/src/chrome/content/rules/Yandex.xml
+++ b/src/chrome/content/rules/Yandex.xml
@@ -494,7 +494,7 @@
 	² Unsecurable <= dropped
 
 -->
-<ruleset name="Yandex">
+<ruleset name="Yandex" default_off="Needs ruleset tests">
 
 	<target host="yandex.ru" />
 	<target host="*.yandex.ru" />

--- a/src/chrome/content/rules/ZZounds.com.xml
+++ b/src/chrome/content/rules/ZZounds.com.xml
@@ -37,7 +37,7 @@
 		- delivery
 
 -->
-<ruleset name="zZounds.com">
+<ruleset name="zZounds.com" default_off="Needs ruleset tests">
 
 	<target host="zzounds.com" />
 	<target host="*.zzounds.com" />

--- a/src/chrome/content/rules/Zscaler.xml
+++ b/src/chrome/content/rules/Zscaler.xml
@@ -25,7 +25,7 @@
 
 	* Secured by us
 -->
-<ruleset name="Zscaler (partial)">
+<ruleset name="Zscaler (partial)" default_off="Needs ruleset tests">
   <target host="blog.zscaler.com" />
 
 		<!--	Avoid broken MCB:

--- a/src/chrome/content/rules/Zynga.xml
+++ b/src/chrome/content/rules/Zynga.xml
@@ -17,7 +17,7 @@
 		- support	(cert: slotmatching7.salesforce.com; 301s to http)
 
 -->
-<ruleset name="Zynga (partial)">
+<ruleset name="Zynga (partial)" default_off="Needs ruleset tests">
 
 	<target host="userimages.static.zgncdn.com" />
 	<target host="zynga.com" />

--- a/src/chrome/content/rules/ylilauta.xml
+++ b/src/chrome/content/rules/ylilauta.xml
@@ -2,7 +2,7 @@
 Disabled by https-everywhere-checker because:
 Fetch error: http://boards.ylilauta.org/ => https://boards.ylilauta.org/: (6, 'Could not resolve host: boards.ylilauta.org')
 -->
-<ruleset name="Ylilauta">
+<ruleset name="Ylilauta" default_off="Needs ruleset tests">
   <target host="*.ylilauta.org" />
   <target host="ylilauta.org" />
   <target host="static.ylilauta.org" />

--- a/test.sh
+++ b/test.sh
@@ -59,4 +59,5 @@ fi
 
 popd
 
+bash test-ruleset-coverage.sh
 echo -e "Git commit `git rev-parse HEAD`\nsha256sum  `sha256sum $XPI_NAME`"


### PR DESCRIPTION
These rulesets were updated after the test coverage cutoff date,
but don't have sufficient test coverage. Disabling them for now.

Also, add test-ruleset-coverage.sh to test.sh and remove from .travis.yml.

Also, increase clone depth in .travis.yml as a short-term fix.

cc @cooperq @2d1 for code review.