### PR TITLE
Add Dom.bg.xml.

### DIFF
--- a/src/chrome/content/rules/Dom.bg.xml
+++ b/src/chrome/content/rules/Dom.bg.xml
@@ -1,0 +1,10 @@
+<ruleset name="Dom.bg">
+  <target host="dom.bg" />
+  <target host="www.dom.bg" />
+
+  <test url= "http://dom.bg/whois.html" />
+  <test url= "http://www.dom.bg/whois.html" />
+
+   <rule from="^http:"
+           to="https:" />
+</ruleset>


### PR DESCRIPTION
Dom.bg is a major Bulgarian domain registrar and hosting provider. The URLs on the site are host-independent, so the rewriting rule is pretty simple.