### PR TITLE
[GNU.org] replace *.gnu.org, use ^http: → https:

### DIFF
--- a/src/chrome/content/rules/GNU.org.xml
+++ b/src/chrome/content/rules/GNU.org.xml
@@ -50,10 +50,20 @@
 		- www.gcc.gnu.org
 
 -->
-<ruleset name="GNU.org (partial)" default_off="Needs ruleset tests">
+<ruleset name="GNU.org (partial)">
 
-	<target host="gnu.org" />
-	<target host="*.gnu.org" />
+	<target host=            "gnu.org" />
+	<target host="audio-video.gnu.org" />
+	<target host=    "debbugs.gnu.org" />
+	<target host=       "elpa.gnu.org" />
+	<target host=        "ftp.gnu.org" />
+	<target host=        "gcc.gnu.org" />
+	<target host=      "lists.gnu.org" />
+	<target host=       "mail.gnu.org" />
+	<target host=   "savannah.gnu.org" />
+	<target host=        "www.gnu.org" />
+	<target host=      "classpath.org" />
+	<target host=  "www.classpath.org" />
 
 
 	<!--	Secured by server:
@@ -70,10 +80,9 @@
 	<rule from="^http://(?:www\.)?classpath\.org/$"
 		to="https://www.gnu.org/software/classpath/" />
 
-        <rule from="^http://((?:audio-video|debbugs|elpa|ftp|gcc|lists|savannah|www)\.)?gnu\.org/"
-		to="https://$1gnu.org/" />
-
 	<rule from="^http://mail\.gnu\.org/"
 		to="https://lists.gnu.org/" />
 
+	<rule from="^http:"
+		to="https:" />
 </ruleset>


### PR DESCRIPTION
remove GNU.org's default_off originating from #1117 (jsha/disable-uncovered-rulesets)