### PR TITLE
Fix user rules in Chromium.

### DIFF
--- a/chromium/rules.js
+++ b/chromium/rules.js
@@ -116,9 +116,12 @@ RuleSets.prototype = {
     if (!(params.host in this.targets)) {
       this.targets[params.host] = [];
     }
-    ruleCache.remove(params.host);
+    this.ruleCache.remove(params.host);
     // TODO: maybe promote this rule?
     this.targets[params.host].push(new_rule_set);
+    if (new_rule_set.name in this.ruleActiveStates) {
+      new_rule_set.active = (this.ruleActiveStates[new_rule_set.name] == "true");
+    }
     log(INFO, 'done adding rule');
     return true;
   },


### PR DESCRIPTION
An undefined reference was preventing them from saving.

Also, addUserRule was not correctly checking active status on reload, meaning
that rules would not stay disabled across restarts.

Fixes #741 