### PR TITLE
Add rules for cdninstagram.com & igcdn.com

### DIFF
--- a/src/chrome/content/rules/Cdninstagram.com.xml
+++ b/src/chrome/content/rules/Cdninstagram.com.xml
@@ -1,0 +1,8 @@
+<ruleset name="cdninstagram.com">
+  <target host="scontent.cdninstagram.com"/>
+  <target host="scontent-a.cdninstagram.com"/>
+  <target host="scontent-b.cdninstagram.com"/>
+
+  <rule from="^http:"
+    to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/Igcdn.com.xml
+++ b/src/chrome/content/rules/Igcdn.com.xml
@@ -1,0 +1,8 @@
+<ruleset name="igcdn.com">
+  <target host="scontent.igcdn.com"/>
+  <target host="scontent-a.igcdn.com"/>
+  <target host="scontent-b.igcdn.com"/>
+
+  <rule from="^http:"
+    to="https:" />
+</ruleset>


### PR DESCRIPTION
Two simple rulesets for passive (instagram) content I encountered on wired.com (the second one is just an alternate name).