### PR TITLE
Fix tests.

### DIFF
--- a/src/chrome/content/rules/Linuxlovers.at.xml
+++ b/src/chrome/content/rules/Linuxlovers.at.xml
@@ -23,21 +23,11 @@
 	<target host="jabber.linuxlovers.at" />
 	<target host="mb.linuxlovers.at" />
 	<target host="tools.linuxlovers.at" />
-	<target host="wiki.linuxlovers.at" />
 	<target host="www.linuxlovers.at" />
-		<!--
-			Avoid false/broken MCB:
-						-->
-		<exclusion pattern="^http://wiki\.linuxlovers\.at/+(?!lib/)" />
-
-			<test url="http://wiki.linuxlovers.at/favicon.ico" />
-			<test url="http://wiki.linuxlovers.at/w/" />
-
 
 	<!--	Secured by server:
 					-->
 	<!--securecookie host="^git\.linuxlovers\.at$" name="^_gitlab_session$" /-->
-	<!--securecookie host="^wiki\.linuxlovers\.at$" name="^DokuWiki$" /-->
 	<!--
 		Not secured by server:
 					-->

--- a/src/chrome/content/rules/Shaklee.xml
+++ b/src/chrome/content/rules/Shaklee.xml
@@ -17,7 +17,7 @@
 	* Some pages redirect to http
 
 -->
-<ruleset name="Shaklee (partial)">
+<ruleset name="Shaklee (partial)" default_off="Needs ruleset tests">
 
 	<target host="myshaklee.com" />
 	<target host="www.myshaklee.com" />


### PR DESCRIPTION
wiki.linuxlovers.at was duplicated in Linuxlovers.at-falsemixed.xml,
so I removed the references in Linuxlovers.at.xml.

Shaklee still failed the ruleset coverage checker with:

Not enough tests (0 vs 1) for <Exclusion pattern '^http://member\.myshaklee\.com/\w\w/\w\w/article/'>
Not enough tests (1 vs 4) for <Exclusion pattern '^http://shaklee\.com/(?:/\w\w/\w\w/)?(?:$|\?)'>

cc @cooperq @2d1 for code review.

Merging as TBR (To Be Reviewed) since this fixes tests.