### PR TITLE
Updated Stack-Exchange.xml

### DIFF
--- a/src/chrome/content/rules/Stack-Exchange.xml
+++ b/src/chrome/content/rules/Stack-Exchange.xml
@@ -151,7 +151,7 @@ Fetch error: http://app.stacktack.com/ => https://s3.amazonaws.com/stacktackapp/
 	<rule from="^http://(?:www\.)?stackapps\.com/"
 		to="https://stackapps.com/" />
 
-	<rule from="^http://((?:\w+|meta\.\w+|discuss\.area51)\.)?stackexchange\.com/"
+	<rule from="^http://((?:\w+|discuss\.area51)\.)?stackexchange\.com/"
 		to="https://$1stackexchange.com/" />
 
 	<rule from="^http://((?:blog|www|meta|careers)\.)?stackoverflow\.com/"


### PR DESCRIPTION
Removed meta.*.stackexchange.com as the certificate is not valid for this pattern