### PR TITLE
Fix some Google-related rulesets

### DIFF
--- a/src/chrome/content/code/HTTPSRules.js
+++ b/src/chrome/content/code/HTTPSRules.js
@@ -109,7 +109,11 @@ RuleSet.prototype = {
     for (i = 0; i < this.rules.length; ++i) {
       // This is just for displaying inactive rules
       returl = urispec.replace(this.rules[i].from_c, this.rules[i].to);
-      if (returl != urispec) return returl;
+      if (returl != urispec) {
+        // we rewrote the uri
+        this.log(DBUG, "Rewrote " + urispec + " -> " + returl + " using " + this.xmlName + ": " + this.rules[i].from_c + " -> " + this.rules[i].to);
+        return returl;
+      }
     }
 
     return null;
@@ -515,8 +519,6 @@ const HTTPSRules = {
       } 
       blob.newuri = rs[i].transformURI(uri);
       if (blob.newuri) {
-        // we rewrote the uri
-        this.log(DBUG, "Rewrote "+input_uri.spec);
         if (alist) {
           if (uri.spec in https_everywhere_blacklist) 
             alist.breaking_rule(rs[i]);

--- a/src/chrome/content/rules/Google.xml
+++ b/src/chrome/content/rules/Google.xml
@@ -116,7 +116,7 @@
 		<test url="http://www.google.com.au/custom" />
 		
 	<!--   Paths that 404 on .ccltd, but work on .com:   -->
-	<rule from="^https?://(?:www\.)?google\.(?:com?\.)?\w{2,3}/(?=calendar|dictionary|foobar|ideas|partners|powermeter|url|webdesigner)"
+	<rule from="^https?://(?:www\.)?google\.(?:com?\.)?\w{2,3}/(?=calendar|dictionary|foobar|ideas|partners|powermeter|webdesigner)"
 		 	to="https://www.google.com/" />
 		<test url="http://www.google.ca/calendar" />
 		<test url="http://www.google.com/calendar" />
@@ -136,9 +136,6 @@
 		<test url="http://www.google.ca/powermeter" />
 		<test url="http://www.google.com/powermeter" />
 		<test url="http://www.google.com.au/powermeter" />
-		<test url="http://www.google.ca/url" />
-		<test url="http://www.google.com/url" />
-		<test url="http://www.google.com.au/url" />
 		<test url="http://www.google.ca/webdesigner" />
 		<test url="http://www.google.com/webdesigner" />
 		<test url="http://www.google.com.au/webdesigner" />

--- a/src/chrome/content/rules/GoogleVideos.xml
+++ b/src/chrome/content/rules/GoogleVideos.xml
@@ -1,4 +1,4 @@
-<ruleset name="Google Videos">
+<ruleset name="Google Videos" default_off="Needs ruleset tests">
   <target host="*.google.com" />
   <target host="google.com" />
   <target host="www.google.com.*" />
@@ -10,8 +10,6 @@
 
   <rule from="^http://(?:www\.)?google\.com/videohp"
 	  to="https://www.google.com/videohp" />
-  <rule from="^http://(images|www|encrypted)\.google\.com/(.*tbm=isch)"
-          to="https://$1.google.com/$1" />
 
   <rule
    from="^http://(?:www\.)?google\.(?:com?\.)?(?:au|ca|gh|ie|in|jm|ke|lk|my|na|ng|nz|pk|rw|sl|sg|ug|uk|za|zw)/videohp"

--- a/src/chrome/content/rules/YouTube.xml
+++ b/src/chrome/content/rules/YouTube.xml
@@ -1,12 +1,5 @@
 <!--
 Disabled by https-everywhere-checker because:
-Fetch error: http://youtube.dz/ => https://youtube.dz/: (6, 'Could not resolve host: youtube.dz')
-Fetch error: http://www.youtube.dz/ => https://www.youtube.dz/: (6, 'Could not resolve host: www.youtube.dz')
-Fetch error: http://youtube.ye/ => https://youtube.ye/: (6, 'Could not resolve host: youtube.ye')
-Fetch error: http://www.youtube.ye/ => https://www.youtube.ye/: (6, 'Could not resolve host: www.youtube.ye')
-Fetch error: http://youtube.com.ye/ => https://youtube.com.ye/: (6, 'Could not resolve host: youtube.com.ye')
-Fetch error: http://www.youtube.com.ye/ => https://www.youtube.com.ye/: (6, 'Could not resolve host: www.youtube.com.ye')
-Fetch error: http://youtube-nocookie.com/ => https://youtube-nocookie.com/: (35, 'Unknown SSL protocol error in connection to youtube-nocookie.com:443 ')
 -->
 <ruleset name="YouTube" default_off='failed ruleset test'>
 
@@ -58,9 +51,6 @@ Fetch error: http://youtube-nocookie.com/ => https://youtube-nocookie.com/: (35,
 	<target host="www.youtube.de"/>
 	<target host="youtube.dk"/>
 	<target host="www.youtube.dk"/>
-	<target host="youtube.dz"/>
-	<target host="www.youtube.dz"/>
-	<target host="youtube.ee"/>
 	<target host="www.youtube.ee"/>
 	<target host="youtube.com.ee"/>
 	<target host="www.youtube.com.ee"/>
@@ -218,17 +208,12 @@ Fetch error: http://youtube-nocookie.com/ => https://youtube-nocookie.com/: (35,
 	<target host="www.youtube.co.ug"/>
 	<target host="youtube.co.uk"/>
 	<target host="www.youtube.co.uk"/>
-	<target host="youtube.ye"/>
-	<target host="www.youtube.ye"/>
-	<target host="youtube.com.ye"/>
-	<target host="www.youtube.com.ye"/>
 	<target host="youtube.co.za"/>
 	<target host="www.youtube.co.za"/>
 
 
         <!-- Alternate domains -->
 	<target host="youtu.be" />
-	<target host="youtube-nocookie.com"/>
 	<target host="www.youtube-nocookie.com"/>
 
 
@@ -244,22 +229,7 @@ Fetch error: http://youtube-nocookie.com/ => https://youtube-nocookie.com/: (35,
 	<securecookie host="^\.youtube\.com" name=".*"/>
 
 
-	<rule from="^http://([^/@:]+\.)?youtube\.com/"
-		to="https://$1youtube.com/"/>
-
-	<rule from="^http://([^/@:]+)\.ytimg\.com/"
-		to="https://$1.ytimg.com/"/>
-
-	<rule from="^http://([^/@:]+)\.googlevideo\.com/"
-		to="https://$1.googlevideo.com/"/>
-
-        <rule from="^http://(www\.)?youtube\.((?:com?\.)?\w\w)/"
-		to="https://$1youtube.$2/"/>
-
-	<rule from="^http://youtu\.be/"
-		to="https://youtu.be/"/>
-
-	<rule from="^http://(www\.)?youtube-nocookie\.com/"
-		to="https://$1youtube-nocookie.com/"/>
+	<rule from="^http:"
+		to="https:"/>
 
 </ruleset>


### PR DESCRIPTION
Re-enable Youtube ruleset.
Remove broken rule within GoogleVideos ruleset, and disable the ruleset because it needs ruleset tests.
Remove /url from list of paths that fail on cctld and need to be redirected to .com.

cc @2d1 @reedy @StevenRoddis could one of you code review this? Cooper and Peter are unavailable for reviews currently. Thanks!