### PR TITLE
New rulesets (Cheap Ass Gamer & OneExchange) and modified rulesets (City of Portland, US govt, Google.tld subdomains) available

### DIFF
--- a/src/chrome/content/rules/BitBucket.xml
+++ b/src/chrome/content/rules/BitBucket.xml
@@ -33,9 +33,9 @@
 	<securecookie host="^\.?bitbucket\.org$" name=".+" />
 
 
-	<test url="blog.bitbucket.org" />
-	<test url="status.bitbucket.org" />
-	<test url="www.bitbucket.org" />
+	<test url="http://blog.bitbucket.org/" />
+	<test url="http://status.bitbucket.org/" />
+	<test url="http://www.bitbucket.org/" />
 
 	<rule from="^http://(www\.)?bitbucket\.com/"
 		to="https://www.bitbucket.com/" />

--- a/src/chrome/content/rules/BitBucket.xml
+++ b/src/chrome/content/rules/BitBucket.xml
@@ -24,12 +24,21 @@
 -->
 <ruleset name="BitBucket (partial)">
 
+	<target host="bitbucket.com" />
+	<target host="www.bitbucket.com" />
 	<target host="bitbucket.org" />
 	<target host="*.bitbucket.org" />
 
 
 	<securecookie host="^\.?bitbucket\.org$" name=".+" />
 
+
+	<test url="blog.bitbucket.org" />
+	<test url="status.bitbucket.org" />
+	<test url="www.bitbucket.org" />
+
+	<rule from="^http://(www\.)?bitbucket\.com/"
+		to="https://www.bitbucket.com/" />
 
 	<rule from="^http://(blog\.|www\.)?bitbucket\.org/"
 		to="https://$1bitbucket.org/" />

--- a/src/chrome/content/rules/Cheap-Ass-Gamer.xml
+++ b/src/chrome/content/rules/Cheap-Ass-Gamer.xml
@@ -1,0 +1,11 @@
+<ruleset name="Cheap Ass Gamer">
+	<target host="cheapassgamer.com" />
+	<target host="cache.cheapassgamer.com" />
+	<target host="www.cheapassgamer.com" />
+
+	<securecookie host="(\.|^)cheapassgamer\.com$"
+			name=".+" />
+
+	<rule from="^http://((cache|www)\.)?cheapassgamer\.com/"
+		to="https://$1cheapassgamer.com/" />
+</ruleset>

--- a/src/chrome/content/rules/CityofPortland.xml
+++ b/src/chrome/content/rules/CityofPortland.xml
@@ -9,6 +9,8 @@
 	<securecookie host="^www\.portlandoregon\.gov$"
 			name=".+" />
 
+	<test url="https://portlandonline.com/" />
+
 	<rule from="^(http://(?:www\.)?|https://)portlandonline\.com/"
 		to="https://www.portlandonline.com/"/>
 	<rule from="^http://(www\.)?portlandoregon\.gov/"

--- a/src/chrome/content/rules/CityofPortland.xml
+++ b/src/chrome/content/rules/CityofPortland.xml
@@ -1,6 +1,16 @@
 <ruleset name="City of Portland, OR">
-  <target host="www.portlandonline.com"/>
-  <target host="portlandonline.com"/>
+	<target host="www.portlandonline.com"/>
+	<target host="portlandonline.com"/>
+	<target host="www.portlandoregon.gov"/>
+	<target host="portlandoregon.gov"/>
 
-  <rule from="^http://(?:www\.)?portlandonline\.com/" to="https://www.portlandonline.com/"/>
+	<securecookie host="^www\.portlandonline\.com$"
+			name=".+" />
+	<securecookie host="^www\.portlandoregon\.gov$"
+			name=".+" />
+
+	<rule from="^(http://(?:www\.)?|https://)portlandonline\.com/"
+		to="https://www.portlandonline.com/"/>
+	<rule from="^http://(www\.)?portlandoregon\.gov/"
+		to="https://$1portlandoregon.gov/" />
 </ruleset>

--- a/src/chrome/content/rules/Google.tld_Subdomains.xml
+++ b/src/chrome/content/rules/Google.tld_Subdomains.xml
@@ -12,6 +12,7 @@
 	-->
 	<target host="accounts.google.*" />
 	<target host="adwords.google.*" />
+	<target host="books.google.*" />
 	<target host="finance.google.*" />
 	<target host="groups.google.*" />
 	<target host="id.google.*" />
@@ -34,7 +35,7 @@
 		<test url="http://news.google.com/archivesearch" />
 		<test url="http://news.google.com.au/archivesearch" />
 
-	<rule from="^http://(accounts|adwords|finance|groups|id|lh\d|m|news|picasaweb|scholar)\.google\.((?:com?\.)?\w{2,3})/"
+	<rule from="^http://(accounts|adwords|books|finance|groups|id|lh\d|m|news|picasaweb|scholar)\.google\.((?:com?\.)?\w{2,3})/"
 			to="https://$1.google.$2/" />
 		<test url="http://accounts.google.ca/" />
 		<test url="http://accounts.google.com/" />
@@ -42,6 +43,9 @@
 		<test url="http://adwords.google.ca/" />
 		<test url="http://adwords.google.com/" />
 		<test url="http://adwords.google.com.au/" />
+		<test url="http://books.google.ca/" />
+		<test url="http://books.google.com/" />
+		<test url="http://books.google.com.au/" />
 		<test url="http://finance.google.ca/" />
 		<test url="http://finance.google.com/" />
 		<test url="http://finance.google.co.uk/" />

--- a/src/chrome/content/rules/LibraryAnywhere.xml
+++ b/src/chrome/content/rules/LibraryAnywhere.xml
@@ -1,15 +1,19 @@
-<!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://syndetics.com/ => https://secure.syndetics.com/: (56, 'SSL read: error:00000000:lib(0):func(0):reason(0), errno 104')
-Fetch error: http://www.syndetics.com/ => https://secure.syndetics.com/: (56, 'SSL read: error:00000000:lib(0):func(0):reason(0), errno 104')
--->
-<ruleset name="Library Anywhere" default_off='failed ruleset test'>
-	<target host="www.libanywhere.com"/>
-	<target host="libanywhere.com"/>
-	<target host="syndetics.com"/>
-	<target host="www.syndetics.com"/>
-	<target host="secure.syndetics.com"/>
+<ruleset name="Library Anywhere">
+	<target host="libanywhere.com" />
+	<target host="www.libanywhere.com" />
+	<target host="syndetics.com" />
+	<target host="secure.syndetics.com" />
+	<target host="www.syndetics.com" />
 
-	<rule from="^http://(?:www\.)?libanywhere\.com/" to="https://www.libanywhere.com/"/>
-	<rule from="^http://(?:www\.)?syndetics\.com/" to="https://secure.syndetics.com/"/>
+	<securecookie host="^(www\.)?libanywhere\.com"
+			name=".+" />
+
+	<test url="http://syndetics.com/index.aspx" />
+	<test url="http://secure.syndetics.com/index.aspx" />
+	<test url="http://www.syndetics.com/index.aspx" />
+
+	<rule from="^http://(www\.)?libanywhere\.com/"
+		to="https://www.libanywhere.com/" />
+	<rule from="^http://((secure|www)\.)?syndetics\.com/"
+		to="https://secure.syndetics.com/" />
 </ruleset>

--- a/src/chrome/content/rules/OneExchange.xml
+++ b/src/chrome/content/rules/OneExchange.xml
@@ -1,0 +1,10 @@
+<ruleset name="OneExchange">
+	<target host="oneexchange.com" />
+	<target host="*.oneexchange.com" />
+
+	<securecookie host="([A-Za-z0-9_])\.oneexchange\.com$"
+			name=".+" />
+
+	<rule from="^http://([A-Za-z0-9_]+\.)?oneexchange\.com/"
+		to="https://$1oneexchange.com/" />
+</ruleset>

--- a/src/chrome/content/rules/OneExchange.xml
+++ b/src/chrome/content/rules/OneExchange.xml
@@ -2,9 +2,9 @@
 	<target host="oneexchange.com" />
 	<target host="*.oneexchange.com" />
 
-	<securecookie host="([A-Za-z0-9_])\.oneexchange\.com$"
+	<securecookie host="(^|([\w-]*)\.)oneexchange\.com$"
 			name=".+" />
 
-	<rule from="^http://([A-Za-z0-9_]+\.)?oneexchange\.com/"
-		to="https://$1oneexchange.com/" />
+	<rule from="^http://"
+		to="https://" />
 </ruleset>

--- a/src/chrome/content/rules/OneExchange.xml
+++ b/src/chrome/content/rules/OneExchange.xml
@@ -5,6 +5,6 @@
 	<securecookie host="(^|([\w-]*)\.)oneexchange\.com$"
 			name=".+" />
 
-	<rule from="^http://"
-		to="https://" />
+	<rule from="^http:"
+		to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Quantix.xml
+++ b/src/chrome/content/rules/Quantix.xml
@@ -1,0 +1,28 @@
+<!--
+	Supported domains:
+
+		www.quantixtickets.com
+		(www.)?quantixtickets1.com
+		(www.)?quantixtickets8.com
+
+	Unsupported domains:
+
+		(www.)?quantixpos.com
+		quantixtickets.com
+
+-->
+<ruleset name="Quantix (partial)">
+	<target host="www.quantixtickets.com" />
+	<target host="quantixtickets1.com" />
+	<target host="www.quantixtickets1.com" />
+	<target host="quantixtickets8.com" />
+	<target host="www.quantixtickets8.com" />
+
+	<securecookie host="^www\.quantixtickets\.com$"
+			name=".+" />
+	<securecookie host="(^|\.)quantixtickets(1|8)\.com$"
+			name=".+" />
+
+	<rule from="^http://"
+		to="https://" />
+</ruleset>

--- a/src/chrome/content/rules/SVN-Lab.xml
+++ b/src/chrome/content/rules/SVN-Lab.xml
@@ -1,0 +1,13 @@
+<ruleset name="SVN Lab">
+	<target host="svnlab.com" />
+	<target host="app.svnlab.com" />
+	<target host="www.svnlab.com" />
+
+	<securecookie host="^(app|www)\.svnlab\.com$"
+			name=".+" />
+
+	<rule from="^http://svnlab\.com/"
+		to="https://www.svnlab.com/" />
+	<rule from="^http://(app|www)\.svnlab\.com/"
+		to="https://$1.svnlab.com/" />
+</ruleset>

--- a/src/chrome/content/rules/SchoolForge.xml
+++ b/src/chrome/content/rules/SchoolForge.xml
@@ -1,0 +1,17 @@
+<ruleset name="SchoolForge">
+	<target host="schoolforge.net" />
+	<target host="www.schoolforge.net" />
+
+	<securecookie host="(^|\.)schoolforge\.net$"
+			name=".+" />
+
+	<test url="http://schoolforge.net/" />
+	<test url="http://www.schoolforge.net/" />
+	<test url="https://schoolforge.net/" />
+	<test url="https://www.schoolforge.net/" />
+
+	<!-- Certificate is valid for schoolforge.net
+		but not www.schoolforge.net -->
+	<rule from="^(http://(www\.)?|https://www\.)schoolforge\.net/"
+		to="https://schoolforge.net/" />
+</ruleset>

--- a/src/chrome/content/rules/US-government.xml
+++ b/src/chrome/content/rules/US-government.xml
@@ -213,7 +213,7 @@ Fetch error: http://wtr.nhtsa.gov/ => https://wtr.nhtsa.gov/: (7, 'Failed to con
 
 	<securecookie host="^questions\.cms\.gov$" name=".*"/>
 	<securecookie host="^safeharbor\.export\.gov$" name=".*"/>
-	<securecookie host="^(?:.*\.)?(?:census|(my)?medicare|usajobs)\.gov$" name=".*"/>
+	<securecookie host="^(?:.*\.)?(?:census|medicare|mymedicare|usajobs)\.gov$" name=".*"/>
 	<securecookie host="^intelligence\.house\.gov$" name=".*"/>
 	<securecookie host="^wtr\.nhtsa\.gov$" name=".+" />
 

--- a/src/chrome/content/rules/US-government.xml
+++ b/src/chrome/content/rules/US-government.xml
@@ -9,31 +9,44 @@ Fetch error: http://wtr.nhtsa.gov/ => https://wtr.nhtsa.gov/: (7, 'Failed to con
 		- Ashland_Fiber.net.xml
 		- Bonneville_Power_Administration.xml
 		- California_Department_of_Justice.xml
+		- California-Department-of-Motor-Vehicles.xml
+		- California-Franchise-Tax-Board.xml
 		- California_Legislative_Information.xml
+		- CA-State-Board-of-Equalization.xml
 		- Catalog-of-Domestic-Federal-Assistance.xml
 		- Central_Intelligence_Agency.xml
 		- City-of-Chicago.xml
 		- City_of_Mountain_View.xml
+		- CityofPortland.xml
 		- City_of_Seattle.xml
 		- City-of-Sedona.xml
 		- ClinicalTrials.gov.xml
 		- Colorado_Secretary_of_State.xml
 		- Commodity_Futures_Trading_Commission.xml
 		- Consumer.gov.xml
+		- CuidadoDeSalud.gov.xml
 		- CPSC.xml
 		- Defense_Nuclear_Facilities_Safety_Board.xml
+		- Disability.gov.xml
 		- Distraction.xml
 		- ED.gov.xml
+		- Employeeexpress.gov.xml
 		- Energy.gov.xml
 		- EnergyStar.xml
+		- Epls.gov.xml
 		- Federal_Aviation_Administration.xml
+		- Federal-Bureau-of-Investigation.xml
 		- Federal_Business_Opportunities.xml
 		- Federal-Communications-Commission.xml
 		- Federal-Deposit-Insurance-Corporation.xml
+		- Federal_Emergency_Management_Agency.xml
+		- Federal-Office-for-Information-Security.xml
+		- Federal_Reserve.xml
 		- Federal_Trade_Commission.xml
 		- Fermi_National_Accelerator_Laboratory.xml
 		- FoodSafety.gov.xml
 		- Fuel_Economy.xml
+		- G5.gov.xml
 		- GSA.gov.xml
 		- Harry_S_Truman_Library_and_Museum.xml
 		- Hawaii.gov.xml
@@ -50,6 +63,7 @@ Fetch error: http://wtr.nhtsa.gov/ => https://wtr.nhtsa.gov/: (7, 'Failed to con
 		- National-Institutes-of-Health.xml
 		- National_Oceanic_and_Atmospheric_Administration.xml
 		- National_Park_Service.xml
+		- National-Renewable-Energy-Laboratory.xml
 		- National-Science-Foundation.xml
 		- National-Security-Agency.xml
 		- National_Transport_Safety_Board.xml
@@ -59,6 +73,7 @@ Fetch error: http://wtr.nhtsa.gov/ => https://wtr.nhtsa.gov/: (7, 'Failed to con
 		- Not_Alone.gov.xml
 		- Oak-Ridge-National-Laboratory.xml
 		- OnGuard_Online.xml
+		- OSHA.gov.xml
 		- Pay.gov
 		- Sandia-National-Laboratories.xml
 		- Senate.gov.xml
@@ -67,11 +82,14 @@ Fetch error: http://wtr.nhtsa.gov/ => https://wtr.nhtsa.gov/: (7, 'Failed to con
 		- State_of_Alaska.xml
 		- State_of_Delaware.xml
 		- State_of_Oregon.xml
+		- StudentLoans.gov.xml
 		- Texas-Department-of-State-Health-Services.xml
+		- Treasurydirect.gov.xml
 		- United-States-Department-of-Agriculture.xml
 		- United-States-Department-of-Energy.xml
 		- United-States-Nuclear-Regulatory-Commission.xml
 		- USA.gov
+		- US-CBO.gov.xml
 		- Us-cert.gov.xml
 		- US_Citizenship_and_Immigration_Services.xml
 		- US_Courts.gov.xml
@@ -83,10 +101,13 @@ Fetch error: http://wtr.nhtsa.gov/ => https://wtr.nhtsa.gov/: (7, 'Failed to con
 		- US_Geological_Survey.xml
 		- US-government-mismatches.xml
 		- US-Immigration-and-Customs-Enforcement.xml
+		- US-Internet-Crime-Complaint-Ctr.xml
 		- US_Mission.gov.xml
 		- US_Patent_and_Trademark_Office.xml
 		- US-Securities-and-Exchange-Commission.xml
+		- US-Selective-Service-System.xml
 		- US_State_Department.xml
+		- Weather.gov.xml
 
 
 	CDN buckets:
@@ -179,6 +200,8 @@ Fetch error: http://wtr.nhtsa.gov/ => https://wtr.nhtsa.gov/: (7, 'Failed to con
 	<target host="wwws.loc.gov" />
 	<target host="medicare.gov"/>
 	<target host="*.medicare.gov"/>
+	<target host="mymedicare.gov"/>
+	<target host="*.mymedicare.gov"/>
 	<target host="wtr.nhtsa.gov" />
 	<target host="usajobs.gov"/>
 	<target host="*.usajobs.gov"/>
@@ -190,7 +213,7 @@ Fetch error: http://wtr.nhtsa.gov/ => https://wtr.nhtsa.gov/: (7, 'Failed to con
 
 	<securecookie host="^questions\.cms\.gov$" name=".*"/>
 	<securecookie host="^safeharbor\.export\.gov$" name=".*"/>
-	<securecookie host="^(?:.*\.)?(?:census|medicare|usajobs)\.gov$" name=".*"/>
+	<securecookie host="^(?:.*\.)?(?:census|(my)?medicare|usajobs)\.gov$" name=".*"/>
 	<securecookie host="^intelligence\.house\.gov$" name=".*"/>
 	<securecookie host="^wtr\.nhtsa\.gov$" name=".+" />
 
@@ -221,6 +244,12 @@ Fetch error: http://wtr.nhtsa.gov/ => https://wtr.nhtsa.gov/: (7, 'Failed to con
 
 	<rule from="^http://wwws\.loc\.gov/"
 		to="https://wwws.loc.gov/" />
+
+	<rule from="^http://plancompare\.medicare\.gov/"
+		to="https://plancompare.medicare.gov/" />
+
+	<rule from="^http://(www\.)?mymedicare\.gov/"
+		to="https://$1mymedicare.gov/" />
 
 	<rule from="^http://wtr\.nhtsa\.gov/"
 		to="https://wtr.nhtsa.gov/" />


### PR DESCRIPTION
Two new rulesets for Cheap Ass Gamer and OneExchange, along with modified rulesets for the City of Portland (Oregon), the US government, and Google.tld subdomains are available at https://github.com/galenide/https-everywhere