### PR TITLE
Fixed a reg-exp example in ruleset-style.md

### DIFF
--- a/ruleset-style.md
+++ b/ruleset-style.md
@@ -38,7 +38,7 @@ plus a plain rewrite from "^http:" to "^https:".
 Prefer dashes over underscores in filenames. Dashes are easier to type.
 
 When matching an arbitrary DNS label (a single component of a hostname), prefer
-`([\w-]+)` for a single label (i.e www), or `([\w-.]+)` for multiple labels
+`([\w-]+)` for a single label (i.e www), or `([\w.-]+)` for multiple labels
 (i.e. www.beta). Avoid more visually complicated options like `([^/:@\.]+\.)?`.
 
 For `securecookie` tags, it's common to match any cookie name. For these, prefer


### PR DESCRIPTION
Using ```([\w-.]+)``` as prescribed caused the TravisCI build to fail because the dash made what's between the brackets look like a character range.