### PR TITLE
Don't block HSTS requests in HTTP Nowhere mode

### DIFF
--- a/src/chrome/content/code/HTTPS.js
+++ b/src/chrome/content/code/HTTPS.js
@@ -1,5 +1,8 @@
 INCLUDE('Cookie');
 
+var securityService = CC['@mozilla.org/ssservice;1']
+    .getService(CI.nsISiteSecurityService);
+
 // Hack. We only need the part of the policystate that tracks content
 // policy loading.
 const PolicyState = {
@@ -37,9 +40,11 @@ const HTTPS = {
    */
   replaceChannel: function(applicable_list, channel, httpNowhereEnabled) {
     var blob = HTTPSRules.rewrittenURI(applicable_list, channel.URI.clone());
+    var isSTS = securityService.isSecureURI(
+        CI.nsISiteSecurityService.HEADER_HSTS, channel.URI, 0);
     if (blob === null) {
       // Abort insecure requests if HTTP Nowhere is on
-      if (httpNowhereEnabled && channel.URI.schemeIs("http")) {
+      if (httpNowhereEnabled && channel.URI.schemeIs("http") && !isSTS) {
         IOUtil.abort(channel);
       }
       return false; // no rewrite

--- a/src/install.rdf
+++ b/src/install.rdf
@@ -22,7 +22,7 @@
         <em:targetApplication>
             <Description>
                 <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
-                <em:minVersion>20.0</em:minVersion>
+                <em:minVersion>26.0</em:minVersion>
                 <em:maxVersion>99.*</em:maxVersion>
             </Description>
         </em:targetApplication>
@@ -54,7 +54,7 @@
         <em:targetApplication>
           <Description>
             <em:id>{aa3c5121-dab2-40e2-81ca-7ea25febc110}</em:id>
-            <em:minVersion>21.0</em:minVersion>
+            <em:minVersion>26.0</em:minVersion>
             <em:maxVersion>99.*</em:maxVersion>
           </Description>
         </em:targetApplication>


### PR DESCRIPTION
Adds a simple detector for whether the channel URI has STS state. This will not work in Firefox <26 because of https://bugzilla.mozilla.org/show_bug.cgi?id=887052.

Fix #1219 