### PR TITLE
Disable Politiken.dk.

### DIFF
--- a/src/chrome/content/rules/Politiken.dk.xml
+++ b/src/chrome/content/rules/Politiken.dk.xml
@@ -40,7 +40,7 @@
 	* Secured by us
 
 -->
-<ruleset name="Politiken.dk (partial)">
+<ruleset name="Politiken.dk (partial)" default_off="Breaks streaming video">
 
 	<target host="multimedia.pol.dk" />
 	<target host="politiken.dk" />


### PR DESCRIPTION
Per report in IRC, rule breaks streaming video.

Possible fix at https://github.com/EFForg/https-everywhere/pull/1170,
but not tested.

cc @cooperq @diracdeltas for code review.