### PR TITLE
[PeerJ] Remove unmatched $2

### DIFF
--- a/src/chrome/content/rules/PeerJ.xml
+++ b/src/chrome/content/rules/PeerJ.xml
@@ -14,6 +14,6 @@
 
 
 	<rule from="^http://(www\.)?peerj\.com/"
-		to="https://$1peerj.com/$2" />
+		to="https://$1peerj.com/" />
 
 </ruleset>


### PR DESCRIPTION
The backreference $2 has no corresponding capturing group, so gets appended to the URL as `$2`.