### PR TITLE
[Chrome] Add mode to block all mixed content

### DIFF
--- a/chromium/background.js
+++ b/chromium/background.js
@@ -162,9 +162,6 @@ function onBeforeRequest(details) {
   // todo: check that this is enough
   var uri = new URI(details.url);
 
-  // Should the request be canceled?
-  var shouldCancel = (httpNowhereOn && uri.protocol() === 'http');
-
   // Normalise hosts such as "www.example.com."
   var canonical_host = uri.hostname();
   if (canonical_host.charAt(canonical_host.length - 1) == ".") {
@@ -185,6 +182,9 @@ function onBeforeRequest(details) {
     log(INFO, "Original url " + details.url + 
         " changed before processing to " + canonical_url);
   }
+
+  // Should the request be canceled?
+  var shouldCancel = (httpNowhereOn && uri.protocol() === 'http');
 
   if (details.type == "main_frame") {
     activeRulesets.removeTab(details.tabId);

--- a/chromium/background.js
+++ b/chromium/background.js
@@ -113,12 +113,16 @@ var addNewRule = function(params, cb) {
   }
 };
 
+// A record of tabs actively using https in main_frame for blocking mixed content.
+var tlsTabIds = {};
+
 function AppliedRulesets() {
   this.active_tab_rules = {};
 
   var that = this;
   chrome.tabs.onRemoved.addListener(function(tabId, info) {
     that.removeTab(tabId);
+    delete tlsTabIds[tabId];
   });
 }
 
@@ -153,9 +157,6 @@ var domainBlacklist = {};
 // redirect counter workaround
 // TODO: Remove this code if they ever give us a real counter
 var redirectCounter = {};
-
-// A record of tabs actively using https in main_frame for blocking mixed content.
-var tlsTabIds = {};
 
 function onBeforeRequest(details) {
   // get URL into canonical format

--- a/chromium/background.js
+++ b/chromium/background.js
@@ -185,9 +185,6 @@ function onBeforeRequest(details) {
     log(INFO, "Original url " + details.url + 
         " changed before processing to " + canonical_url);
   }
-  if (canonical_url in urlBlacklist) {
-    return {cancel: shouldCancel};
-  }
 
   if (details.type == "main_frame") {
     activeRulesets.removeTab(details.tabId);
@@ -195,6 +192,10 @@ function onBeforeRequest(details) {
   } else if (details.tabId !== -1) {
       // This request happened in a tab, wasn't the main_frame, so it's content.
       shouldCancel = (uri.protocol() === 'http' && (httpNowhereOn || (blockMixedContent && tlsTabIds[details.tabId])));
+  }
+
+  if (canonical_url in urlBlacklist) {
+    return {cancel: shouldCancel};
   }
 
   var rs = all_rules.potentiallyApplicableRulesets(uri.hostname());

--- a/chromium/background.js
+++ b/chromium/background.js
@@ -189,9 +189,9 @@ function onBeforeRequest(details) {
   if (details.type == "main_frame") {
     activeRulesets.removeTab(details.tabId);
     tlsTabIds[details.tabId] = (uri.protocol() === 'https');
-  } else if (details.tabId !== -1) {
-      // This request happened in a tab, wasn't the main_frame, so it's content.
-      shouldCancel = (uri.protocol() === 'http' && (httpNowhereOn || (blockMixedContent && tlsTabIds[details.tabId])));
+  } else if (blockMixedContent && details.tabId !== -1) {
+    // This request happened in a tab and wasn't the main_frame, so it's content.
+    shouldCancel = (uri.protocol() === 'http' && (httpNowhereOn || tlsTabIds[details.tabId]));
   }
 
   if (canonical_url in urlBlacklist) {

--- a/chromium/popup.html
+++ b/chromium/popup.html
@@ -18,6 +18,10 @@
   <input id="http-nowhere-checkbox" type="checkbox" value="httpNowhere"/>
   <label for="http-nowhere-checkbox">Turn on HTTP Nowhere</label>
 </section>
+<section id="BlockMixedContent" class="options">
+  <input id="mixed-content-checkbox" type="checkbox" value="blockMixedContent"/>
+  <label for="mixed-content-checkbox">Block all mixed content (images, media, etc.)</label>
+</section>
 <section>
   <a href="#" id="add-rule-link">Add a rule for this site</a>
   <div id="add-new-rule-div" style="display:none">

--- a/chromium/popup.js
+++ b/chromium/popup.js
@@ -100,6 +100,16 @@ document.addEventListener("DOMContentLoaded", function () {
     }
   });
 
+  // Set up toggle checkbox for blocking all mixed content
+  getOption_('blockMixedContent', false, function(item) {
+    var mixedContentCheckbox = document.getElementById('mixed-content-checkbox');
+    mixedContentCheckbox.addEventListener('click', toggleMixedContent, false);
+    var blockMixedContentEnabled = item.blockMixedContent;
+    if (blockMixedContentEnabled) {
+      mixedContentCheckbox.setAttribute('checked', '');
+    }
+  });
+
   // auto-translate all elements with i18n attributes
   var elem = document.querySelectorAll("[i18n]");
   for (var i=0; i < elem.length; i++) {
@@ -167,6 +177,12 @@ function addManualRule() {
 function toggleHttpNowhere() {
   getOption_('httpNowhere', false, function(item) {
     setOption_('httpNowhere', !item.httpNowhere);
+  });
+}
+
+function toggleMixedContent() {
+  getOption_('blockMixedContent', false, function(item) {
+    setOption_('blockMixedContent', !item.blockMixedContent);
   });
 }
 


### PR DESCRIPTION
Add a mode for Chrome to block all mixed content (mostly images & media content). (For issue #1297)

Unfortunately, the webRequest API doesn't provide any parent information (only information about `<iframe>` parents, it seems), so we have to do this manually. We record whether tabs are on HTTPS sites (the main_frame request is https), then block non-HTTPS requests within the same tab.

Give it a test at: https://www.bennish.net/mixed-content.html

One question: What should we do about UX here?

Right now, there's no UX change (except the hidden checkbox inside the popup extension window). It'sp probably worth changing the icon color -- since this will definitely break some sites.

There was a bit of a discussion in #760 -- of note, I'm not 100% sure RED for HTTP Nowhere mode is necessary -- Chrome is /very vocal/ when extensions break entire sites, showing this page:

![screen shot 2015-03-28 at 1 38 56 pm](https://cloud.githubusercontent.com/assets/167135/6882358/d6f4ba82-d54f-11e4-9dae-1693d8652e07.png)


