### PR TITLE
HTML cleanup and a couple modifications

### DIFF
--- a/docs/rulesets.html
+++ b/docs/rulesets.html
@@ -6,7 +6,7 @@ body {
 <p>
   This page describes how to write rulesets for
    <a href="https://eff.org/https-everywhere">HTTPS Everywhere</a>,
-  the Firefox add-on that switches sites over from HTTP
+  the Firefox and Chrom* add-on that switches sites over from HTTP
   to HTTPS automatically. HTTPS Everywhere comes with
    <a href="http://www.eff.org/https-everywhere/atlas/">thousands</a>
   of rulesets that tell HTTPS Everywhere which sites it should switch
@@ -28,8 +28,8 @@ body {
 </p>
 
 <pre>
-&lt;ruleset name="RabbitMQ"&gt;
-        &lt;target host="rabbitmq.com" /&gt;
+&lt;ruleset name=&quot;RabbitMQ&quot;&gt;
+        &lt;target host=&quot;rabbitmq.com&quot; /&gt;
         &lt;target host="www.rabbitmq.com" /&gt;
 
         &lt;rule from="^http:"
@@ -41,12 +41,12 @@ body {
   The <tt>target</tt> tag specifies which web sites the ruleset applies
   to. The <tt>rule</tt> tag specifies how URLs on those web sites should be
   rewritten. This rule says that any URLs on <tt>rabbitmq.com</tt> and
-  <tt>www.rabbitmq.com</tt> should be modified by replacing "http:" with
-  "https:".
+  <tt>www.rabbitmq.com</tt> should be modified by replacing &quot;http:&quot; with
+  &quot;https:&quot;.
 </p>
 
 <p>
-  When Firefox loads a URL, HTTPS Everywhere takes the host
+  When the browser loads a URL, HTTPS Everywhere takes the host
   name (e.g. <tt>www.rabbitmq.com</tt>) and searches its ruleset database for
   rulesets that match that host name.
 </p>
@@ -64,14 +64,14 @@ body {
 </a>
 
 <p>
-  To cover all of a domain's subdomains, you may want to specify
+  To cover all of a domain&apos;s subdomains, you may want to specify
   a wildcard target like <tt>*.twitter.com</tt>. Specifying
   this type of left-side wildcard matches any host name with
   <tt>.twitter.com</tt> as a suffix, e.g.  <tt>www.twitter.com</tt>
   or <tt>urls.api.twitter.com</tt>. You can also specify a
   right-side wildcard like <tt>www.google.*</tt>. Right-side
   wildcards, unlike left-side wildcards, apply only one level
-  deep. So if you want to cover all countries you'll generally
+  deep. So if you want to cover all countries you&apos;ll generally
   need to specify <tt>www.google.*</tt>, <tt>www.google.co.*</tt>,
   and <tt>www.google.com.*</tt> to cover domains like
   <tt>www.google.co.uk</tt> or <tt>www.google.com.au</tt>. You should
@@ -88,16 +88,16 @@ body {
   The <tt>rule</tt> tags do the actual rewriting work. The <tt>from</tt> attribute of
   each rule is a <a href="http://www.regular-expressions.info/quickstart.html"
   >regular expression</a> matched against a full URL. You can use rules to rewrite
-  URLs in simple or complicated ways. Here's a simplified (and now obsolete) example
+  URLs in simple or complicated ways. Here&apos;s a simplified (and now obsolete) example
   for Wikipedia:
 </p>
 
 <pre>
-&lt;ruleset name="Wikipedia"&gt;
-  &lt;target host="*.wikipedia.org" /&gt;
+&lt;ruleset name=&quot;Wikipedia&quot;&gt;
+  &lt;target host=&quot;*.wikipedia.org&quot; /&gt;
 
-  &lt;rule from="^http://(\w{2})\.wikipedia\.org/wiki/"
-          to="https://secure.wikimedia.org/wikipedia/$1/wiki/"/&gt;
+  &lt;rule from=&quot;^http://(\w{2})\.wikipedia\.org/wiki/&quot;
+          to=&quot;https://secure.wikimedia.org/wikipedia/$1/wiki/&quot;/&gt;
 &lt;/ruleset&gt;
 </pre>
 
@@ -112,7 +112,7 @@ body {
   <tt>http://fr.wikipedia.org/wiki/Chose</tt> to
   <tt>https://secure.wikimedia.org/wikipedia/fr/wiki/Chose</tt>. Notice,
   again, that the target is allowed to contain (just one) * as a wildcard
-  meaning "any".
+  meaning &quot;any&quot;.
 </p>
 
 <p>
@@ -141,12 +141,12 @@ body {
 </p>
 
 <pre>
-&lt;exclusion pattern="^http://(?:\w+\.)?stack(?:exchange|overflow)\.com/users/authenticate/" /&gt;
+&lt;exclusion pattern=&quot;^http://(?:\w+\.)?stack(?:exchange|overflow)\.com/users/authenticate/&quot; /&gt;
 </pre>
 
 <p>
   Exclusions are always evaluated before rules in a given ruleset. Matching any
-  exclusion means that a URL won't match any rules within the same ruleset.
+  exclusion means that a URL won&apos;t match any rules within the same ruleset.
   However, if other rulesets match the same target hosts, the rules in those
   rulesets will still be tried.
 </p>
@@ -157,7 +157,7 @@ body {
 
 <p>
 There are many different ways you can write a ruleset, or regular expression
-within the ruleset. It's easier for everyone to understand the rulesets if they
+within the ruleset. It&apos;s easier for everyone to understand the rulesets if they
 follow similar practices. You should read and follow the
 <a href="https://github.com/EFForg/https-everywhere/blob/master/ruleset-style.md">Ruleset
 style guide</a>. Some of the guidelines in that document are intended to make <a
@@ -176,17 +176,17 @@ flag</a> on authentication and/or tracking cookies. HTTPS
 Everywhere provides a facility for turning this flag on. For instance:
 </p>
 
-<pre>&lt;securecookie host="^market\.android\.com$" name=".+" /&gt;</pre>
+<pre>&lt;securecookie host=&quot;^market\.android\.com$&quot; name=&quot;.+&quot; /&gt;</pre>
 
 <p>
-The "host" parameter is a regexp specifying which domains
-should have their cookies secured; the "name" parameter is a
+The &quot;host&quot; parameter is a regexp specifying which domains
+should have their cookies secured; the &quot;name&quot; parameter is a
 regexp specifying which cookies should be secured. For a cookie to be secured,
 it must be sent by a target host for that ruleset. It must also be sent over
 HTTPS and match the name regexp. For cookies set by Javascript in a web page,
-the Firefox extension can't tell which host set the cookie and instead uses
+the Firefox extension can&apos;t tell which host set the cookie and instead uses
 the domain attribute of the cookie to check against target hosts. A cookie whose
-domain attribute starts with a "." (the default, if not specified by
+domain attribute starts with a &quot;.&quot; (the default, if not specified by
 Javascript) will be matched as if it was sent from a host
 name made by stripping the leading dot.
 </p>
@@ -205,7 +205,7 @@ enough test URLs to cover all the various types of URL covered by your rules.
 And each of those test URLs must load, both before rewriting and after
 rewriting. Every target host tag generates an implicit test URL unless it
 contains a wildcard. You can add additional test URLs manually using the
-<tt>&lt;test url="..."/&gt;</tt> tag. The test URLs you add this way should be
+<tt>&lt;test url=&quot;...&quot;/&gt;</tt> tag. The test URLs you add this way should be
 real pages loaded from the site, or real images, CSS, and Javascript if you have rules that
 specifically affect those resources.
 </p>
@@ -221,7 +221,7 @@ HTTPS.
 </p>
 
 <p>
-  If you've tested your rule and are sure it would
+  If you&apos;ve tested your rule and are sure it would
   be of use to the world at large, submit it as a <a
   href="https://help.github.com/articles/using-pull-requests/">pull
   request</a> on our <a
@@ -239,7 +239,7 @@ As an alternative to writing rules by hand, there are scripts you
 can run from a Unix command line to automate the process of creating
 a simple rule for a specified domain. These scripts are not included
 with HTTPS Everywhere releases but are available in our development
-repository and are described in <a href="development">our development
+repository and are described in <a href="https://www.eff.org/https-everywhere/development">our development
 documentation</a>.
 
 <a name="default-off" href="#default-off">
@@ -247,16 +247,16 @@ documentation</a>.
 </a>
 <p>
 Sometimes rulesets are useful or interesting, but cause problems
-that make them unsuitable for being enabled by default in everyone's
+that make them unsuitable for being enabled by default in everyone&apos;s
 browsers. Typically when a ruleset has problems we will disable it by
 default until someone has time to fix it. You can do this by adding
 a <tt>default_off</tt> attribute to the ruleset element, with a value
 explaining why the rule is off.
 </p>
 <pre>
-&lt;ruleset name="Amazon (buggy)" default_off="breaks site"&gt;
-   &lt;target host="www.amazon.*" /&gt;
-   &lt;target host="amazon.*" /&gt;
+&lt;ruleset name=&quot;Amazon (buggy)&quot; default_off=&quot;breaks site&quot;&gt;
+   &lt;target host=&quot;www.amazon.*&quot; /&gt;
+   &lt;target host=&quot;amazon.*&quot; /&gt;
 &lt;/ruleset&gt;
 </pre>
 
@@ -275,13 +275,13 @@ file.
   href="https://trac.torproject.org/projects/tor/ticket/6975">Chrome</a> and
   Firefox, before HTTPS Everywhere has a chance to rewrite the URLs to an HTTPS
   version. This generally breaks the site.
-  However, the Tor Browser doesn't block mixed content, in order to allow HTTPS
-  Everywhere to try andrewrite the URLs to an HTTPS version.
+  However, the Tor Browser doesn&apos;t block mixed content, in order to allow HTTPS
+  Everywhere to try and rewrite the URLs to an HTTPS version.
 </p>
 
 <p>
   To enable a rule only on platforms that allow mixed content (currently
-  only the Tor Browser), you can add a <tt>platform="mixedcontent"</tt>
+  only the Tor Browser), you can add a <tt>platform=&quot;mixedcontent&quot;</tt>
   attribute to the ruleset element.
 </p>
 
@@ -296,6 +296,6 @@ file.
   links to resources which do not exist on the HTTPS part of the site.
   This is very rare, especially because these resources will typically be blocked
   by <a href="#mixed-content">Mixed Content Blocking</a>. If it necessary, you can
-  add a <tt>downgrade="1"</tt> attribute to the rule to make it easier to audit
+  add a <tt>downgrade=&quot;1&quot;</tt> attribute to the rule to make it easier to audit
   the ruleset library for such rules.
 </p>


### PR DESCRIPTION
- Specified at the beginning that HTTPS-Everywhere is not a Firefox
extension, but a "Firefox and Chrom*" extension.
- Corrected a typo (missing whitespace)
- Replaced ' with &apos; and " with &quot;