### PR TITLE
Remove securecookie rule for OkCupid.com

### DIFF
--- a/src/chrome/content/rules/OkCupid.xml
+++ b/src/chrome/content/rules/OkCupid.xml
@@ -64,7 +64,7 @@
 					-->
 	<!--securecookie host="^\.okcupid\.com$" name="^(__cfuid|cf_clearance|guest)$" /-->
 
-	<securecookie host="^\.okcupid\.com$" name=".+" />
+    <!--<securecookie host="^\.okcupid\.com$" name=".+" /> -->
 
 
 	<rule from="^http:"


### PR DESCRIPTION
The securecookie rule for OkCupid.com breaks login for those users that don't have access to https on the site (puts Chrome into an infinite redirect loop). I am the CTO of OkCupid, so feel free to ask any questions, or offer suggestions for how this could be better handled, but I think just removing the rule is a good way to go here.