### PR TITLE
Remove ift.tt from Bit.ly vanity domain ruleset

### DIFF
--- a/src/chrome/content/rules/Bit.ly_vanity_domains.xml
+++ b/src/chrome/content/rules/Bit.ly_vanity_domains.xml
@@ -49,8 +49,6 @@
 	<target host="www.hub.am" />
 	<target host="huff.to" />
 	<target host="www.huff.to" />
-	<target host="ift.tt" />
-	<target host="www.ift.tt" />
 	<target host="ind.pn" />
 	<target host="www.ind.pn" />
 	<target host="iti.ms" />
@@ -170,9 +168,6 @@
 	<!--rule from="^http://(www\.)?huff\.to/+($|\?.*)"
 		to="https://www.huffingtonpost.com/" /-->
 
-	<rule from="^http://(?:www\.)?ift\.tt/+(?:$|\?.*)"
-		to="https://ifttt.com/" />
-
 	<rule from="^http://(?:www\.)?iti\.ms/+(?:$|\?.*)"
 		to="https://www.irishtimes.com/" />
 
@@ -269,7 +264,7 @@
 	<!--	Domains for which both !www and www
 		exist and both are bit.ly aliases:
 							-->
-	<rule from="^http://(?:www\.)?(?:1tw\.org|7ny\.tv|alj\.am|abcn\.ws|atfp\.co|brook\.gs|buff\.ly|bzfd\.it|cbsn\.ws|ccwc\.me|cnb\.cx|cnnmon\.ie|curbed\.cc|econ\.st|fxn\.ws|glo\.bo|hub\.am|huff\.to|ind\.pn|iti\.ms|ift\.tt|jrnl\.(?:ie|to)|mzl\.la|nbcnews\.to|nydn\.us|pewrsr\.ch|polho\.me|politi\.co|propub\.ca|rbl\.ms|reut\.rs|specc\.ie|stanford\.io|sun-tim\.es|tcrn\.ch|tek\.io|thebea\.st|ti\.me|wcas\.nu|wmk\.me|zd\.net)/"
+	<rule from="^http://(?:www\.)?(?:1tw\.org|7ny\.tv|alj\.am|abcn\.ws|atfp\.co|brook\.gs|buff\.ly|bzfd\.it|cbsn\.ws|ccwc\.me|cnb\.cx|cnnmon\.ie|curbed\.cc|econ\.st|fxn\.ws|glo\.bo|hub\.am|huff\.to|ind\.pn|iti\.ms|jrnl\.(?:ie|to)|mzl\.la|nbcnews\.to|nydn\.us|pewrsr\.ch|polho\.me|politi\.co|propub\.ca|rbl\.ms|reut\.rs|specc\.ie|stanford\.io|sun-tim\.es|tcrn\.ch|tek\.io|thebea\.st|ti\.me|wcas\.nu|wmk\.me|zd\.net)/"
 		to="https://bit.ly/" />
 
 	<rule from="^http://(?:4mn\.ca|a21\.tv|apne\.ws|bbc\.in|bitly\.is|bloom\.bg|on\.cfr\.org|cs\.is|dico\.im|do\.co|dly\.do|lat\.ms|on\.mash\.to|on\.msnbc\.com|n\.pr|go\.nasa\.gov|nym\.ag|nyti\.ms|sm\.ohchr\.org|to\.pbs\.org|seati\.ms|sched\.co|slate\.me|theatln\.tc|ucla\.in|ubm\.io|1\.usa\.gov|usat\.ly|vrge\.co|wapo\.st|on\.wsj\.com)/"


### PR DESCRIPTION
Ahead of a more permanent fix for #1309, this should fix the issues affecting ift.tt URLs.