### PR TITLE
Add andrewmunsell.com Rules

### DIFF
--- a/src/chrome/content/rules/Andrew-Munsell.xml
+++ b/src/chrome/content/rules/Andrew-Munsell.xml
@@ -1,0 +1,9 @@
+<ruleset name="Andrew Munsell">
+
+	<target host="andrewmunsell.com" />
+	<target host="www.andrewmunsell.com" />
+
+	<rule from="^http://(?:www\.)?andrewmunsell\.com/"
+		to="https://www.andrewmunsell.com/" />
+
+</ruleset>

--- a/src/chrome/content/rules/Andrew-Munsell.xml
+++ b/src/chrome/content/rules/Andrew-Munsell.xml
@@ -3,7 +3,7 @@
 	<target host="andrewmunsell.com" />
 	<target host="www.andrewmunsell.com" />
 
-	<rule from="^http://(?:www\.)?andrewmunsell\.com/"
+	<rule from="^http://(www\.)?andrewmunsell\.com/"
 		to="https://www.andrewmunsell.com/" />
 
 </ruleset>


### PR DESCRIPTION
Adds `www.andrewmunsell.com` and `andrewmunsell.com` to HTTPS Everywhere. HSTS is also enabled for these two domains.