### PR TITLE
Fix Webs.com's rulesets

### DIFF
--- a/src/chrome/content/rules/Webs-MixedContent.xml
+++ b/src/chrome/content/rules/Webs-MixedContent.xml
@@ -1,0 +1,15 @@
+<!--
+	See Webs.xml for domain information
+
+	This file contains resources that are problematic with a Mixed Content Blocker
+-->
+<ruleset name="Webs (Mixed Content)" platform="mixedcontent">
+
+	<target host="members.webs.com" />
+
+	<securecookie host="^members\.webs\.com$" name=".+" />
+
+	<rule from="^http:"
+	        to="https:" />
+
+</ruleset>

--- a/src/chrome/content/rules/Webs.xml
+++ b/src/chrome/content/rules/Webs.xml
@@ -57,8 +57,7 @@
 	<target host="static.websimages.com" />
 
 
-	<securecookie host="^\.?members\.webm\.com$" name=".+" />
-
+	<securecookie host="^\.?members\.webs\.com$" name=".+" />
 
 	<rule from="^http://((?:es\.)?premium\.)?members\.webs\.com/"
 		to="https://$1members.webs.com/"/>

--- a/src/chrome/content/rules/Webs.xml
+++ b/src/chrome/content/rules/Webs.xml
@@ -53,16 +53,17 @@
 <ruleset name="Webs (partial)">
 
 	<target host="images.freewebs.com" />
-	<target host="*.webs.com"/>
+	<target host="images.webs.com"/>
 	<target host="static.websimages.com" />
-
-
-	<securecookie host="^\.?members\.webs\.com$" name=".+" />
+	<target host="secure.websimages.com" />
+	<target host="origin.images.webs.com" />
 
 	<rule from="^http://((?:es\.)?premium\.)?members\.webs\.com/"
 		to="https://$1members.webs.com/"/>
 
 	<rule from="^http://(images\.(?:free)?web|static\.websimage)s\.com/"
 		to="https://a248.e.akamai.net/f/1129/8333/3m/$1s.com/" />
-
+	<rule from="^http:"
+	        to="https:" />
+	
 </ruleset>


### PR DESCRIPTION
Webs.com triggers a bunch of Mixed Content Blocker failures. Therefore, this patch series rewrites Webs.xml to use way less wildcards (which means test coverage \o/) and also adds Webs-MixedContent.xml to cover platforms that disable the MCB.