### PR TITLE
Disable sciencedaily

### DIFF
--- a/src/chrome/content/code/HTTPSRules.js
+++ b/src/chrome/content/code/HTTPSRules.js
@@ -605,12 +605,10 @@ const HTTPSRules = {
   // flow? Perhaps we can preload all targets from the DB into memory at startup
   // so we only hit the DB when we know there is something to be had.
   loadRulesetById: function(ruleset_id) {
-    this.log(DBUG, "Querying DB for ruleset id " + ruleset_id);
     this.queryForRuleset.params.id = ruleset_id;
 
     try {
       if (this.queryForRuleset.executeStep()) {
-        this.log(INFO, "Found ruleset in DB for id " + ruleset_id);
         RuleWriter.readFromString(this.queryForRuleset.row.contents, this, ruleset_id);
       } else {
         this.log(WARN,"Couldn't find ruleset for id " + ruleset_id);

--- a/src/chrome/content/rules/Demandware.edgesuite.net.xml
+++ b/src/chrome/content/rules/Demandware.edgesuite.net.xml
@@ -1,11 +1,13 @@
 <!--
+	Disabled per https://github.com/EFForg/https-everywhere/issues/1355,
+  breaks http://www.pacsun.com
 	For other Demandware coverage, see Demandware.xml.
 
 
 	Included on clients' domains.
 
 -->
-<ruleset name="Demandware.edgesuite.net (partial)">
+<ruleset name="Demandware.edgesuite.net (broken)" default_off="broken">
 
 	<target host="demandware.edgesuite.net" />
 		<!--

--- a/src/chrome/content/rules/ScienceDaily.com.xml
+++ b/src/chrome/content/rules/ScienceDaily.com.xml
@@ -1,4 +1,5 @@
 <!--
+	Disabled per https://github.com/EFForg/https-everywhere/issues/1359
 	For problematic rules, see ScienceDaily.com.xml.
 
 
@@ -19,7 +20,7 @@
 	* Self-signed, cert only matches www
 
 -->
-<ruleset name="ScienceDaily.com (partial)">
+<ruleset name="ScienceDaily.com (partial)" default_off="Breaks some images">
 
 	<target host="images.sciencedaily.com" />
 


### PR DESCRIPTION
Disable sciencedaily and demandware, per reports of breakage.

cc @cooperq 