### PR TITLE
Re-enable Demandware.

### DIFF
--- a/src/chrome/content/rules/Demandware.edgesuite.net.xml
+++ b/src/chrome/content/rules/Demandware.edgesuite.net.xml
@@ -1,13 +1,7 @@
 <!--
-	Disabled per https://github.com/EFForg/https-everywhere/issues/1355,
-	breaks http://www.pacsun.com, http://www.saba.com.au and http://www.sportscraft.com.au
-	For other Demandware coverage, see Demandware.xml.
-
-
 	Included on clients' domains.
-
 -->
-<ruleset name="Demandware.edgesuite.net (broken)" default_off="broken">
+<ruleset name="Demandware.edgesuite.net (broken)">
 
 	<target host="demandware.edgesuite.net" />
 		<!--
@@ -22,10 +16,6 @@
 			These are unique per clients => unpredictable:
 									-->
 		<!--exclusion pattern="^http://demandware\.edgesuite\.net/+aaei_prd/on/demandware\.static/Sites-Private-Site/-/default/v\d+/css/\w+/" /-->
-
-
-	<rule from="^http://demandware\.edgesuite\.net/aabl_prd/on/demandware\.static/"
-		to="https://labs.demandware.com/on/demandware.static/"/>
 
 	<rule from="^http://demandware\.edgesuite\.net/(?!aaei_prd/on/demandware\.static/Sites-Private-Site/-/default/v\d+/)"
 		to="https://a248.e.akamai.net/f/248/1/1/demandware.edgesuite.net/" />


### PR DESCRIPTION
Remove rule for aabl_prod bucket. This path seems like it should be covered
correctly by the subsequent rule, and I couldn't find any examples to test.

@2d1 for review.