### PR TITLE
Mibbit: Add wiki subdomain to https rules.

### DIFF
--- a/src/chrome/content/rules/Mibbit.xml
+++ b/src/chrome/content/rules/Mibbit.xml
@@ -8,7 +8,6 @@
 
 		- a *
 		- blog		(shows www, valid cert)
-		- wiki *
 
 	* 401, valid cert
 
@@ -28,6 +27,7 @@
 		- widget
 		- widget0[1-4]
 		- widgetmanager
+		- wiki
 
 -->
 <ruleset name="Mibbit">
@@ -39,7 +39,7 @@
 	<securecookie host="^(?:.*\.)?mibbit.com$" name=".+" />
 
 
-	<rule from="^http://((?:chat|(?:02|client01)\.chat|data|search|widget(?:0\d|manager)?|www)\.)?mibbit\.com/"
+	<rule from="^http://((?:chat|(?:02|client01)\.chat|data|search|widget(?:0\d|manager)?|wiki|www)\.)?mibbit\.com/"
 		to="https://$1mibbit.com/" />
 
 </ruleset>


### PR DESCRIPTION
HTTPS on the wiki subdomain now works without a 401.

Also, it seems to be working on the blog subdomain but I'm not sure what your comment means `(show www, valid cert)` so not going to change that.