### PR TITLE
#1455 - Fixes for dota2.com:

### DIFF
--- a/src/chrome/content/rules/Dota_2.com.xml
+++ b/src/chrome/content/rules/Dota_2.com.xml
@@ -43,7 +43,33 @@
 	<target host="partner.dota2.com" />
 	<target host="www.dota2.com" />
 
+	<test url="http://www.dota2.com/heroes" />
+	<test url="http://dota2.com/heroes" />
+	<test url="http://www.dota2.com/jsfeed/" />
+	<test url="http://dota2.com/jsfeed/" />
+	<test url="http://dota2.com/jsfeed/heropickerdata" />
+	<test url="http://dota2.com/jsfeed/heropediadata" />
+	<test url="http://www.dota2.com/leaderboard" />
+	<test url="http://dota2.com/leaderboard" />
+	<test url="http://www.dota2.com/public/" />
+	<test url="http://dota2.com/public/" />
+	<test url="http://www.dota2.com/public/javascript" />
+	<test url="http://dota2.com/public/javascript" />
+	<test url="http://www.dota2.com/quiz" />
+	<test url="http://dota2.com/quiz" />
+	<test url="http://www.dota2.com/workshop/" />
+	<test url="http://dota2.com/workshop/" />
+	<test url="http://www.dota2.com/store" />
+	<test url="http://dota2.com/store" />
 
+	<exclusion pattern="^http://(www\.)?dota2\.com/heroes" />
+	<exclusion pattern="^http://(www\.)?dota2\.com/jsfeed/(\w+)?" />
+	<exclusion pattern="^http://(www\.)?dota2\.com/leaderboard" />
+	<exclusion pattern="^http://(www\.)?dota2\.com/public/(\w+)?" />
+	<exclusion pattern="^http://(www\.)?dota2\.com/quiz" />
+	<exclusion pattern="^http://(www\.)?dota2\.com/store" />
+	<exclusion pattern="^http://(www\.)?dota2\.com/workshop" />
+	
 	<rule from="^http://dota2\.com/"
 		to="https://www.dota2.com/" />
 


### PR DESCRIPTION
Fixes for #1455 
- excluded a few paths that can't be accessed over https
- added corresponding tests