### PR TITLE
Disabled tvline.com, because it has no valid certificate

### DIFF
--- a/src/chrome/content/rules/TVLine.com.xml
+++ b/src/chrome/content/rules/TVLine.com.xml
@@ -1,4 +1,4 @@
-<ruleset name="TVLine.com">
+<ruleset name="TVLine.com" default_off="invalid certificate">
 
 	<target host="tvline.com" />
 	<target host="www.tvline.com" />


### PR DESCRIPTION
Fixes #1457.