### PR TITLE
Add Open Computing Facility rules, rewrite most of Berkeley.edu ruleset

### DIFF
--- a/src/chrome/content/rules/University-of-California-Berkeley.xml
+++ b/src/chrome/content/rules/University-of-California-Berkeley.xml
@@ -1,248 +1,159 @@
 <!--
 	University of California, Berkeley
-
-
-	Nonfunctional domains:
-
-
-		- berkeley.edu subdomains:
-
-			- (www.)		(prints "No access to SSL site.")
-			- alumni-friends	(prints domain name; CN: asterix.berkeley.edu)
-			- gfael.are ¹
-			- areweb ²
-			- atcal-career ³
-			- awards ³
-			- builders ³
-			- cads2 ³
-			- cal-demo		(prints "a" over https; acts as atcal over http)
-			- calparents ⁴
-			- calvm	⁴
-			- campaign ³
-			- campuslife ⁵
-			- cdms			(shows cosmology; mismatched, CN: cosmology.berkeley.edu)
-			- cfr ³
-			- charterday ³
-			- compute.cnr ²
-			- naturebeta.cnr ²
-			- staff.cnr ²
-			- db.cs			(shows www-research.cs; mismatched, CN: www-research.cs.berkeley.edu)
-			- cwh ²
-			- diller ³		(403s over http)
-			- discovercal ³
-			- idsg.eecs		(data differs)
-			- environmentalsciences ²
-			- forestry ²
-			- fundraising ³
-			- hewlett ³
-			- hewlettchallenge ³	(CN: devcomm.urel)
-			- homecoming		(prints domain name)
-			- hrweb ⁵
-			- mailman.icsi		(refused)
-			- identity ³
-			- ieas
-			- ims			(400; times out over https, so status unknown)
-			- inauguration ³
-			- lawcat		(502)
-			- ls
-			- blogs.lib		(shows www.lib)
-			- mdp ²
-			- www.mip		(403)
-			- newalumnichallenge ³
-			- nst ²
-			- nutrition ²
-			- ourenvironment ²
-			- socalevents ⁵
-			- stadium ³
-			- systemstatus		(refused)
-			- tiencenter		(valid cert; "Site Temporarily Unavailable" over http, so status unknown)
-			- urel ³		(CN: devcomm.urel)
-			- devcomm.urel		(403s over http; redirects to givetocal over https)
-
-		- (www.)ucbsystems.org
-
-	¹ Times out
-	² Shows nature
-	³ Shows givetocal
-	⁴ Prints "No access to the $foo SSL site available."
-	⁵ http reply
-
-
-	Problematic subdomains:
-
-		- are *
-		- bconnected	(works; mismatched, CN: pantheon.berkeley.edu)
-		- bmail		(interrupted)
-		- cal1card	(shows services.housing; mismatched, CN: services.housing.berkeley.edu)
-		- callcenter **
-		- cio.chance	(refused)
-		- chancellor	(works; mismatched, CN: pantheon.berkeley.edu)
-		- cosmology	(works, self-signed)
-		- cs *
-		- eecs *
-		- graduation	(prints domain name; mismatched, CN: asterix.berkeley.edu)
-		- hrweb		(works; mismatched, CN: pantheon.berkeley.edu)
-		- notary.icsi	(works; mismatched, CN: *.bro.org)
-		- law *
-		- oskicat	(some [most?] pages redirect to http, scripts/ redirects to screens/ssoauth.html)
-		- ourpromise **
-		- sa		(works; mismatched, CN: *.gotpantheon.com)
-
-	* Mismatch
-	** Shows givetocal
-
-
-	Partially covered subdomains:
-
-		- alumni *
-		- blogs *
-		- callcenter	(→ givetocal)
-		- graduation	(→ commencement)
-		- ourpromise	(→ givetocal)
-
-	* At least some pages redirect to http
-
-
-	Fully covered subdomains:
-
-		- (www.)are
-		- auth
-		- auth-key
-		- beartracks
-		- beartracks-new
-		- bmail		( -> mail.google.com)
-		- cal1card	( -> services.housing)
-		- callink
-		- calmail
-		- calmessages
-		- calnet.calnet
-		- cas-p[1-4].calnet
-		- net-auth.calnet
-		- (www.)cnr
-		- nature.cnr
-		- code
-		- developer
-		- chisel.eecs
-		- hkn.eecs
-		- events
-		- givetocal
-		- as-code-prod.ist
-		- as-ezsvn-prod.ist
-		- kb
-		- (www.)law
-		- (www.)lib
-		- nature
-		- newscenter
-		- docs.ocf
-		- oskicat	(→ oskicatp)
-		- oskicatp
-		- security
-		- fortuna.security
-		- students
-		- sunsite
-		- wikihub
-		- wikihub-new
-
-
-	Covered wildcard cookies:
-
-		- .events
-		- .fortuna.security
-		- .security
-
-
-	Other wildcard cookie domains observed:
-
-		- .
-		- .blogs.lib
-		- .campuslife
-
-
-	Mixed content:
-
-		- css, on:
-
-			- bconnected from $self *
-			- chancellor from $self *
-			- chancellor from fonts.googleapis.com **
-			- hrwed from $self *
-
-		- Images, on:
-
-			- bconnected from $self *
-			- sa from $self *
-			- sa from www
-
-	* Not secured by us <= mismatched
-	** Secured by us
-
+	http://www.berkeley.edu/
 -->
 <ruleset name="Berkeley.edu (partial)">
+	<target host="airbears.berkeley.edu" />
+	<target host="asterix.berkeley.edu" />
+	<target host="atcal.berkeley.edu" />
+	<target host="auth-key.berkeley.edu" />
+	<target host="auth.berkeley.edu" />
+	<target host="beartracks-new.berkeley.edu" />
+	<target host="beartracks.berkeley.edu" />
+	<target host="blu.berkeley.edu" />
+	<target host="blu.is.berkeley.edu" />
+	<target host="bmail.berkeley.edu" />
+	<target host="boinc.berkeley.edu" />
+	<target host="bcourses.berkeley.edu" />
+	<target host="bspace.berkeley.edu" />
+	<target host="cal.berkeley.edu" />
+	<target host="cal1card.berkeley.edu" />
+	<target host="calcentral.berkeley.edu" />
+	<target host="calfutures.berkeley.edu" />
+	<target host="callcenter.berkeley.edu" />
+	<target host="callink.berkeley.edu" />
+	<target host="calmail.berkeley.edu" />
+	<target host="calmessages.berkeley.edu" />
+	<target host="career.berkeley.edu" />
+	<target host="ccc.berkeley.edu" />
+	<target host="code.berkeley.edu" />
+	<target host="commencement.berkeley.edu" />
+	<target host="convio.berkeley.edu" />
+	<target host="developer.berkeley.edu" />
+	<target host="eureka.berkeley.edu" />
+	<target host="events.berkeley.edu" />
+	<target host="fellowship.berkeley.edu" />
+	<target host="foundation.berkeley.edu" />
+	<target host="givetocal.berkeley.edu" />
+	<target host="graduation.berkeley.edu" />
+	<target host="haasawards.berkeley.edu" />
+	<target host="ihouseonline.berkeley.edu" />
+	<target host="inews.berkeley.edu" />
+	<target host="international.berkeley.edu" />
+	<target host="journalism.berkeley.edu" />
+	<target host="kb.berkeley.edu" />
+	<target host="mirrors.berkeley.edu" />
+	<target host="nature.berkeley.edu" />
+	<target host="netreg.berkeley.edu" />
+	<target host="newscenter.berkeley.edu" />
+	<target host="newstudents.berkeley.edu" />
+	<target host="or.berkeley.edu" />
+	<target host="oskicatp.berkeley.edu" />
+	<target host="scholarship.berkeley.edu" />
+	<target host="seniors.berkeley.edu" />
+	<target host="services.housing.berkeley.edu" />
+	<target host="students.berkeley.edu" />
+	<target host="wikihub-new.berkeley.edu" />
+	<target host="wikihub.berkeley.edu" />
 
-	<target host="*.berkeley.edu" />
-		<!--
-			These paths 302s to http:
+	<!-- Open Computing Facility -->
+	<target host="ocf.berkeley.edu" />
+	<target host="accounts.ocf.berkeley.edu" />
+	<target host="accounts-dev.ocf.berkeley.edu" />
+	<target host="docs.ocf.berkeley.edu" />
+	<target host="mirrors.ocf.berkeley.edu" />
+	<target host="pma.ocf.berkeley.edu" />
+	<target host="puppet.ocf.berkeley.edu" />
+	<target host="rt.ocf.berkeley.edu" />
+	<target host="ssh.ocf.berkeley.edu" />
+	<target host="wiki.ocf.berkeley.edu" />
+	<target host="www.ocf.berkeley.edu" />
 
-				- $
-				- community$
-				- donate$
-				- donate/new-alumni-challenge$
-				- events$
-				- join$
-						-->
-		<exclusion pattern="^http://alumni\.berkeley\.edu/(?!sites/)" />
-		<exclusion pattern="^http://blogs\.berkeley\.edu/(?:.+/)?(?:$|\?)" />
+	<!-- Security -->
+	<target host="fortuna.security.berkeley.edu" />
+	<target host="security.berkeley.edu" />
+
+	<!-- IST -->
+	<target host="as-ezsvn-prod.ist.berkeley.edu" />
+	<target host="ist.berkeley.edu" />
 
 
-	<!--	Secured by server:
-					-->
-	<!--securecookie host="^auth\.berkeley\.edu$" name="^JSESSIONID$" /-->
-	<!--securecookie host="^auth-key\.berkeley\.edu$" name="^JSESSIONID$" /-->
-	<!--securecookie host="^calmail\.berkeley\.edu$" name="^SQMSESSID$" /-->
-	<!--securecookie host="^\.security\.berkeley\.edu$" name="^SSESS[\da-f]{32}$" /-->
-	<!--securecookie host="^students\.berkeley\.edu$" name="^%5FCookieCheck$" /-->
-	<!--
-		Not secured by server:
-					-->
-	<!--securecookie host="^cal\.berkeley\.edu$" name="^PHPSESSID$" /-->
-	<!--securecookie host="^calnet\.calnet\.berkeley\.edu$" name="^_calnet-myi_session_id$" /-->
-	<!--securecookie host="^givetocal\.berkeley\.edu$" name="^(CFID|CFTOKEN)$" /-->
-	<!--securecookie host="^services\.housing\.berkeley\.edu$" name="^ASPSESSIONID\w{8}$" /-->
-	<!--securecookie host="^\.inews\.berkeley\.edu$" name="^SESS[\da-f]{32}$" /-->
-	<!--securecookie host="^\.ist\.berkeley\.edu$" name="^SESS[\da-f]{32}$" /-->
-	<!--securecookie host="^security\.berkeley\.edu$" name="^cas_login_checked$" /-->
-	<!--securecookie host="^students\.berkeley\.edu$" name="^ASPSESSIONID\w{8}$" /-->
-	<!--securecookie host="^wikihub\.berkeley\.edu$" name="^JSESSIONID$" /-->
+	<!-- University Relations -->
+	<target host="urshare-prod1.urel.berkeley.edu" />
+	<target host="wiki.urel.berkeley.edu" />
+
+	<!-- Department of Agriculture and Resource Economics -->
+	<target host="are.berkeley.edu" />
+	<target host="www.are.berkeley.edu" />
+
+	<!-- College of Natural Resources -->
+	<target host="cnr.berkeley.edu" />
+	<target host="nature.cnr.berkeley.edu" />
+	<target host="www.cnr.berkeley.edu" />
+
+	<!-- EECS and CS -->
+	<target host="autoconfig.cs.berkeley.edu" />
+	<target host="autoconfig.eecs.berkeley.edu" />
+	<target host="autodiscover.cs.berkeley.edu" />
+	<target host="autodiscover.eecs.berkeley.edu" />
+	<target host="buffy.eecs.berkeley.edu" />
+	<target host="chisel.eecs.berkeley.edu" />
+	<target host="cs.berkeley.edu" />
+	<target host="eecs.berkeley.edu" />
+	<target host="hkn.eecs.berkeley.edu" />
+	<target host="www.cs.berkeley.edu" />
+	<target host="www.eecs.berkeley.edu" />
 
 	<securecookie host="^(?:\w.*|\.events|(?:\.fortuna)?\.security)\.berkeley\.edu$" name=".+" />
 
+	<!-- Only the root of these subdomains is guaranteed compatible with a
+		 HTTPS redirect, so we exclude other paths. -->
+	<test url="http://cs.berkeley.edu/no/path/is/matched" />
+	<test url="http://cs.berkeley.edu/?hello" />
+	<test url="http://eecs.berkeley.edu/no/path/is/matched" />
+	<test url="http://eecs.berkeley.edu/~cs70/" />
+	<exclusion pattern="^http://(?:www\.)?(cs|eecs)\.berkeley\.edu/.+" />
 
-	<rule from="^http://(airbears|alumni|asterix|atcal|atcal-dev|auth|auth-key|beartracks(?:-new)?|blogs|blu|bspace|cal|calagenda|cal-dev|calfutures|callink|calmail|calmessages|(?:[\w-]+\.)?calnet|career|ccc|ccc-dev|cnr|(nature|www)\.cnr|commencement|convio|code|auto(?:config|discover)\.(?:ee)?cs|developer|(?:auth|buffy|chisel|hkn)\.eecs|egiving|eureka|events|fellowship|foundation(?:-dev)?|givetocal|haasawards|services\.housing|ihouseonline|inews|international|blu\.is|as-(?:code|ezsvn)-prod\.ist|ist|journalism|kb|lib|www\.lib|nature|newscenter|docs\.ocf|or|oskicatp|scholarship|(?:fortuna\.)?security|seniors|(?:new)?students|sunsite|(?:urshare-prod1|wiki)\.urel|wikihub(?:-new)?)\.berkeley\.edu/"
-		to="https://$1.berkeley.edu/" />
-
-	<rule from="^http://(?:www\.)?(are|boinc)\.berkeley\.edu/"
-		to="https://$1.berkeley.edu/" />
+	<test url="http://graduation.berkeley.edu/no/path/is/matched" />
+	<test url="http://graduation.berkeley.edu/?some+query+string" />
+	<exclusion pattern="^http://graduation\.berkeley\.edu/.+" />
 
 	<!--	Redirect drops forward slash, path, and args:
 								-->
+	<test url="http://bmail.berkeley.edu/path/is/dropped" />
 	<rule from="^http://bmail\.berkeley\.edu/.*"
 		to="https://mail.google.com/a/berkeley.edu" />
 
 	<!--	Redirect drops forward slash and args, but not path:
 									-->
-	<rule from="^http://cal1card\.berkeley\.edu/+([^?])(?:\?.*)?"
+	<test url="http://cal1card.berkeley.edu/has/a/path?query-string-dropped" />
+	<rule from="^http://cal1card\.berkeley\.edu/([^?]*)(?:\?.*)?"
 		to="https://services.housing.berkeley.edu/c1c/$1" />
 
 	<rule from="^http://callcenter\.berkeley\.edu/$"
-		to="https://givetocal.berkeley.edu/browse/?u=191" />
-
-	<rule from="^http://(?:www\.)?(cs|eecs|law)\.berkeley\.edu/"
-		to="https://www.$1.berkeley.edu/" />
+		to="https://give.berkeley.edu/browse/index.cfm?u=191" />
 
 	<rule from="^http://graduation\.berkeley\.edu/$"
 		to="https://commencement.berkeley.edu/" />
 
-	<rule from="^http://ourpromise\.berkeley\.edu/$"
-		to="https://givetocal.berkeley.edu/browse/?u=174" />
+	<rule from="^http://mirrors\.berkeley\.edu/$"
+		to="https://mirrors.ocf.berkeley.edu/" />
 
+	<!-- These domains must redirect to the www. version -->
+	<test url="http://ocf.berkeley.edu/" />
+	<test url="http://cs.berkeley.edu/" />
+	<test url="http://eecs.berkeley.edu/" />
+
+	<rule from="^http(?:s)?://(?:www\.)?(cs|eecs|ocf)\.berkeley\.edu/"
+		to="https://www.$1.berkeley.edu/" />
+
+	<!-- These domains must *not* redirect to the www. version -->
+	<test url="http://are.berkeley.edu/" />
+	<test url="http://www.are.berkeley.edu/" />
+
+	<rule from="^http(?:s)?://(?:www\.)?(are)\.berkeley\.edu/"
+		to="https://$1.berkeley.edu/" />
+
+	<!-- Default rule -->
+	<rule from="^http:" to="https:" />
 </ruleset>


### PR DESCRIPTION
This is a followup to #1336, where I attempted to add some rules for the UC Berkeley Open Computing Facility, but realized I'd first need to essentially rewrite the berkeley.edu rules (or write a hundred tests :-)).

The main changes I've made are to use more specific targets (and add a few tests where needed for the things that need a regex). Unfortunately berkeley.edu is a rather large domain with many subdomains that don't support HTTPS. I think the specific target approach is preferred over a blanket target and long regex.

This also includes a few changes and fixes to the berkeley.edu rules:

* Add rules for some new subdomains:
    - {accounts{,-dev},mirrors,pma,rt,puppet,ssh,wiki,www}.ocf.b.e
    - calcentral.b.e
    - netreg.b.e
    - bcourses.b.e

* Rewrite http://ocf.b.e/ -> https://www.ocf.b.e/

* Rewrite http://mirrors.b.e/ -> https://mirrors.ocf.b.e/

* Remove rewrite for several no-longer-existing hostnames, and some that show cert errors

* Fix cal1card.b.e rewrite regex to properly match the domain (previously, it wasn't working at all in most cases due to a regex error)

* Removed list of working subdomains; it was already missing some domains that the regex matched. The new <target> rules are just as easy to read and much less likely to go out-of-date.

Thanks for your work on this extension! Let me know if there's anything I can do to help get this merged.