### PR TITLE
Exclude get.newrelic.com

### DIFF
--- a/install-dev-dependencies.sh
+++ b/install-dev-dependencies.sh
@@ -6,7 +6,8 @@ if type apt-get >/dev/null ; then
   sudo apt-get install libxml2-dev libxml2-utils libxslt1-dev python-dev \
     firefox chromium-browser zip sqlite3 python-pip libcurl4-openssl-dev
 elif type brew >/dev/null ; then
-  brew install python libxml2 gnu-sed
+  brew list python &>/dev/null || brew install python
+  brew install libxml2 gnu-sed
   if ! echo $PATH | grep -ql /usr/local/bin ; then
     echo '/usr/local/bin not found in $PATH, please add it.'
   fi

--- a/src/chrome/content/rules/New-Relic.xml
+++ b/src/chrome/content/rules/New-Relic.xml
@@ -79,4 +79,7 @@
 	<rule from="^http://([\w-]+\.)?newrelic\.com/"
 		to="https://$1newrelic.com/" />
 
+	<test url="http://blog-assets.newrelic.com/wp-includes/js/jquery/jquery.js" />
+	<test url="http://rpm.newrelic.com/" />
+
 </ruleset>

--- a/src/chrome/content/rules/New-Relic.xml
+++ b/src/chrome/content/rules/New-Relic.xml
@@ -19,6 +19,7 @@
 	Problematic subdomains:
 
 		- blog-static *
+		- get *
 
 	* NetDNA
 
@@ -66,6 +67,8 @@
 					-->
 	<!--securecookie host="^rpm\.newrelic\.com$" name="^omniauth\.states$" /-->
 	<!--securecookie host="^try\.newrelic\.com$" name="^BIGipServerabjweb-ssl4_https$" /-->
+
+	<exclusion pattern="^http://get\.newrelic\.com" />
 
 	<securecookie host="^(?:.*\.)?newrelic\.com$" name=".+" />
 

--- a/src/chrome/content/rules/New-Relic.xml
+++ b/src/chrome/content/rules/New-Relic.xml
@@ -2,6 +2,7 @@
 	Other New Relic rulesets:
 
 		- NR-assets.net.xml
+		- NR-data.net.xml
 
 
 	CDN buckets:


### PR DESCRIPTION
get.newrelic.com is used for interacting with NewRelic's marketing emails (unsubscribing, etc). It doesn't respond to HTTPS.