### PR TITLE
[tv2.dk update] Fixed a typo and removed domains which now force http redirects

### DIFF
--- a/src/chrome/content/rules/TV2.dk-mixedcontent.xml
+++ b/src/chrome/content/rules/TV2.dk-mixedcontent.xml
@@ -1,22 +1,12 @@
 
 <!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://beep.tv2.dk/ => https://beep.tv2.dk/: Too many redirects while fetching 'https://beep.tv2.dk/'
-Fetch error: http://finans.tv2.dk/ => https://finans.tv2.dk/: Too many redirects while fetching 'https://finans.tv2.dk/'
-Fetch error: http://go.tv2.dk/ => https://go.tv2.dk/: Too many redirects while fetching 'https://go.tv2.dk/'
-Fetch error: http://politik.tv2.dk/ => https://politik.tv2.dk/: Too many redirects while fetching 'https://politik.tv2.dk/'
-
 	See TV2.dk.xml for all comments on this rule.
 -->
-<ruleset name="TV2.dk (mixed content)" platform="mixedcontent" default_off='failed ruleset test'>
-	<target host="beep.tv2.dk" />
-	<target host="finans.tv2.dk" />
-	<target host="go.tv2.dk" />
+<ruleset name="TV2.dk (mixed content)" platform="mixedcontent">
 	<target host="google.tv2.dk" />
 	<target host="mad.tv2.dk" />
-	<target host="politik.tv2.dk" />
 	<target host="ttv.tv2.dk" />
 	
 	<rule from="^http:"
-			to="https:"/>
+		to="https:"/>
 </ruleset>

--- a/src/chrome/content/rules/TV2.dk.xml
+++ b/src/chrome/content/rules/TV2.dk.xml
@@ -12,8 +12,8 @@
 		- lb-stat.tv2.dk **
 		- omtv2 **
 		- piratestorm **
-		- politik *
 		- play ****
+		- politik *
 		- presse **
 		- programmer *
 		- risingcities **

--- a/src/chrome/content/rules/TV2.dk.xml
+++ b/src/chrome/content/rules/TV2.dk.xml
@@ -70,7 +70,7 @@
 -->
 <ruleset name="TV2.dk (partial)">
 	<target host="common.tv2.dk" />
-	<target host="dropal-images.tv2.dk" />
+	<target host="drupal-images.tv2.dk" />
 	<target host="eps-images.tv2.dk" />
 	<target host="feeds.tv2.dk" />
 	<target host="files.tv2.dk" />

--- a/src/chrome/content/rules/TV2.dk.xml
+++ b/src/chrome/content/rules/TV2.dk.xml
@@ -2,13 +2,17 @@
 	Domains not covered:
 		- www (and web root) *
 
+		- beep *
 		- forgeofempires ***
+		- finans *
 		- fri *
+		- go *
 		- nyhederne *
 		- nyhedsbreve ***
 		- lb-stat.tv2.dk **
 		- omtv2 **
 		- piratestorm **
+		- politik *
 		- play ****
 		- presse **
 		- programmer *
@@ -33,18 +37,14 @@
 	     http, so the site is largely useless
 
 	Covered domains:
-		- beep *
 		- common
 		- drupal-images
 		- epg-images
 		- feeds
 		- files
-		- finans *
-		- go *
 		- google **
 		- grid
 		- mad *
-		- politik *
 		- r7
 		- spil
 		- spillehallen
@@ -83,5 +83,5 @@
 	<target host="whistleblower.tv2.dk" />
 
 	<rule from="^http:"
-			to="https:"/>
+		to="https:"/>
 </ruleset>


### PR DESCRIPTION
Test found 4 domains which are now broken. These have been fixed. (Is disabling the entire rule, including all functional domains, fortunate?)