### PR TITLE
Disable Razer due to broken redirect

### DIFF
--- a/src/chrome/content/rules/Razer.xml
+++ b/src/chrome/content/rules/Razer.xml
@@ -12,7 +12,7 @@
 		- ^
 
 -->
-<ruleset name="Razer">
+<ruleset name="Razer" default_off="redirects to http">
 
 	<target host="razerzone.com" />
 	<target host="*.razerzone.com" />


### PR DESCRIPTION
razerzone.com redirects https -> http, creating a redirect loop with the existing rule.