### PR TITLE
Fix the rule that breaks fotki.com

### DIFF
--- a/src/chrome/content/rules/Fotki.xml
+++ b/src/chrome/content/rules/Fotki.xml
@@ -1,43 +1,15 @@
 <!--
-	CDN buckets:
 
-		- fotki.cachefly.net
-			- images.fotki.com
+    Fotki does not use cachefly anymore
 
-
-	Nonfunctional subdomains:
-
-		- about *
-		- client *
-		- contests *
-		- downloads *
-		- help *
-		- host *
-		- myaccount *
-		- search *
-		- signup *
-
-	* 503, mismatched, CN: secure.fotki.com
-
-
-	Problematic subdomains:
-
-		- images	(mismatched, CN: *.cachefly.net)
-		- login		(503, mismatched, CN: secure.fotki.com)
+    Most of subdomains should just work now with https
 
 -->
 <ruleset name="Fotki (partial)">
 
 	<target host="*.fotki.com" />
 
-
-	<rule from="^http://images\.fotki\.com/"
-		to="https://fotki.cachefly.net/" />
-
-	<rule from="^http://login\.fotki\.com/($|\?.*)"
-		to="https://secure.fotki.com/login$1" />
-
-	<rule from="^http://secure\.fotki\.com/"
-		to="https://secure.fotki.com/" />
+	<rule from="^http:"
+		to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Fotki.xml
+++ b/src/chrome/content/rules/Fotki.xml
@@ -11,5 +11,8 @@
 
 	<rule from="^http:"
 		to="https:" />
+		
+	<test url="http://www.fotki.com/" />
+	<test url="http://images.fotki.com/pixel.gif" />
 
 </ruleset>


### PR DESCRIPTION
fotki.com looks completely broken currently with HTTPS Everywhere. 
That's because the current rule redirects all static files to cachefly and Fotki does not use cachefly anymore. 
Since the rule was created, Fotki added support for https for most of subdomains and it's being constantly improved. So it's better to have a full redirect. (Tested, it seems to work).