### PR TITLE
Update thePlatform to fix #1431

### DIFF
--- a/src/chrome/content/rules/ThePlatform.xml
+++ b/src/chrome/content/rules/ThePlatform.xml
@@ -23,7 +23,7 @@
 	** https://github.com/EFForg/https-everywhere/issues/1431
 
 
-	Partially covered subdomains:
+	Partially securable subdomains:
 
 		- help		(some paths 403)
 
@@ -39,10 +39,14 @@
 	<target host="mps.theplatform.com" />
 	<target host="player.theplatform.com" />
 	<target host="release.theplatform.com" />
-	<target host="help.theplatform.com" />
-		<exclusion pattern="^http://help\.theplatform\.com/(?!login(?:$|\?|/))" />
-
 		
+	<!-- 
+	Commented out for the moment since I can't find some appropriate rule tests. 
+	<target host="help.theplatform.com" />
+		<exclusion pattern="^http://help\.theplatform\.com/(?!login(?:$|\?|/))" /> 
+	-->
+
+
 	<securecookie host="^(?:mps|release)\.theplatform\.com$" name=".+" />
 
 

--- a/src/chrome/content/rules/ThePlatform.xml
+++ b/src/chrome/content/rules/ThePlatform.xml
@@ -17,18 +17,15 @@
 
 		- mpx *
 		- web *
+		- pdk **
 
 	* Works, akamai
+	** https://github.com/EFForg/https-everywhere/issues/1431
 
 
 	Partially covered subdomains:
 
 		- help		(some paths 403)
-
-
-	Fully covered subdomains:
-
-		- pdk
 
 
 	NB: crossdomain.xml on player forbids https (FUU!)
@@ -38,15 +35,16 @@
 
 -->
 <ruleset name="thePlatform (partial)">
-
-	<target host="*.theplatform.com" />
+	<target host="feed.theplatform.com" />
+	<target host="mps.theplatform.com" />
+	<target host="player.theplatform.com" />
+	<target host="release.theplatform.com" />
+	<target host="help.theplatform.com" />
 		<exclusion pattern="^http://help\.theplatform\.com/(?!login(?:$|\?|/))" />
 
-
+		
 	<securecookie host="^(?:mps|release)\.theplatform\.com$" name=".+" />
 
 
-	<rule from="^http://(feed|help|mps|pdk|player|release)\.theplatform\.com/"
-		to="https://$1.theplatform.com/" />
-
+	<rule from="^http:" to="https:" />
 </ruleset>


### PR DESCRIPTION
I found out the pdk subdomain of thePlatform was the culprit behind #1431. I've removed this subdomain and modernized the ruleset.