### PR TITLE
Enable Dreamwidth

### DIFF
--- a/src/chrome/content/rules/Dreamwidth.xml
+++ b/src/chrome/content/rules/Dreamwidth.xml
@@ -5,7 +5,16 @@
   <securecookie host="^\.dreamwidth\.org$" name=".+" />
 
   <test url="http://www.dreamwidth.org/" />
+  <test url="http://shop.dreamwidth.org" />
+  <test url="http://support.dreamwidth.org" />
+
+  <!--
+    Test journal subdomains.
+
+    "system" is an official journal, guaranteed to stay around.
+  -->
   <test url="http://system.dreamwidth.org/" />
+  <test url="http://users.dreamwidth.org/system" />
 
   <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Dreamwidth.xml
+++ b/src/chrome/content/rules/Dreamwidth.xml
@@ -1,26 +1,11 @@
-<!--
-	NOTE: In its current form and with the current site
-	configuration, this rule protects login passwords
-	but prevents the user from reading other users' journals!
+<ruleset name="Dreamwidth">
+  <target host="dreamwidth.org" />
+  <target host="*.dreamwidth.org" />
 
+  <securecookie host="^\.dreamwidth\.org$" name=".+" />
 
-	Nonfunctional subdomains:
+  <test url="http://www.dreamwidth.org/" />
+  <test url="http://system.dreamwidth.org/" />
 
-		- dw-news *
-
-	* Redirects to http, valid cert
-
--->
-<ruleset name="Dreamwidth" default_off="breaks for non-logged-in users">
-
-	<target host="dreamwidth.org" />
-	<target host="*.dreamwidth.org" />
-
-
-	<securecookie host="^\.dreamwidth\.org$" name=".+" />
-
-
-	<rule from="^http://(?:www\.)?dreamwidth\.org/"
-		to="https://www.dreamwidth.org/" />
-
+  <rule from="^http:" to="https:" />
 </ruleset>


### PR DESCRIPTION
https now works on Dreamwidth for both www and journal pages


Work on Dreamwidth here. We've done a bunch of work on https support recently, and https now works with journal subdomains and for logged out users.