### PR TITLE
www.moverall.com

### DIFF
--- a/src/chrome/content/rules/Moverall.com.xml
+++ b/src/chrome/content/rules/Moverall.com.xml
@@ -2,6 +2,7 @@
 
 	<target host="moverall.com" />
 	<target host="*.moverall.com" />
+	<target host="az698912.vo.msecnd.net" />
 
 	<test url="http://moverall.com/" />
 	<test url="http://www.moverall.com/" />

--- a/src/chrome/content/rules/Moverall.com.xml
+++ b/src/chrome/content/rules/Moverall.com.xml
@@ -4,7 +4,7 @@
 	<target host="*.moverall.com" />
 
 	<rule from="^http://(www\.)?moverall\.com/" to="https://www.moverall.com/" />
-	<rule from="^http://az698912\.vo\.msecnd\.net/" to="https://az698912.vo.msecnd.net" />
-	<rule from="^http://cdn\.moverall\.com/" to="https://az698912.vo.msecnd.net" />
+	<rule from="^http://az698912\.vo\.msecnd\.net/" to="https://az698912.vo.msecnd.net/" />
+	<rule from="^http://cdn\.moverall\.com/" to="https://az698912.vo.msecnd.net/" />
 
 </ruleset>

--- a/src/chrome/content/rules/Moverall.com.xml
+++ b/src/chrome/content/rules/Moverall.com.xml
@@ -1,0 +1,10 @@
+<ruleset name="Moverall">
+
+	<target host="moverall.com" />
+	<target host="*.moverall.com" />
+
+	<rule from="^http://(www\.)?moverall\.com/" to="https://www.moverall.com/" />
+	<rule from="^http://az698912\.vo\.msecnd\.net/" to="https://az698912.vo.msecnd.net" />
+	<rule from="^http://cdn\.moverall\.com/" to="https://az698912.vo.msecnd.net" />
+
+</ruleset>

--- a/src/chrome/content/rules/Moverall.com.xml
+++ b/src/chrome/content/rules/Moverall.com.xml
@@ -3,6 +3,11 @@
 	<target host="moverall.com" />
 	<target host="*.moverall.com" />
 
+	<test url="http://moverall.com/" />
+	<test url="http://www.moverall.com/" />
+	<test url="http://cdn.moverall.com/" />
+	<test url="http://az698912.vo.msecnd.net/" />
+
 	<rule from="^http://(www\.)?moverall\.com/" to="https://www.moverall.com/" />
 	<rule from="^http://az698912\.vo\.msecnd\.net/" to="https://az698912.vo.msecnd.net/" />
 	<rule from="^http://cdn\.moverall\.com/" to="https://az698912.vo.msecnd.net/" />


### PR DESCRIPTION
This adds support for moverall.com which is a removal comparison website. It supports SSL but has no autoredirect. It also loads al its resources from SSL when accessed via SSL.