### PR TITLE
Surpress make failure if the old build script didn't support AMO

### DIFF
--- a/makexpi.sh
+++ b/makexpi.sh
@@ -44,7 +44,9 @@ if [ -n "$1" ] && [ "$2" != "--no-recurse" ] && [ "$1" != "--fast" ] ; then
   cd ..
   XPI_NAME="$APP_NAME-$1"
   cp $SUBDIR/pkg/$XPI_NAME.xpi pkg/
-  cp $SUBDIR/pkg/$XPI_NAME-amo.xpi pkg/
+  if ! cp $SUBDIR/pkg/$XPI_NAME-amo.xpi pkg/ 2> /dev/null ; then
+    echo Old version does not support AMO
+  fi
   rm -rf $SUBDIR
   exit 0
 fi


### PR DESCRIPTION
Somehow make was obtaining the return value from this cp command and erroring
on it.

This preserves makexpi's ability to build releases from 3.x stable onwards.  2.x is broken, though I'm not sure that matters.