### PR TITLE
Exclude smokeping.wikimedia.org

### DIFF
--- a/src/chrome/content/rules/Wikimedia.xml
+++ b/src/chrome/content/rules/Wikimedia.xml
@@ -40,12 +40,13 @@
 	<target host="www.mediawiki.org" />
 	<target host="wikimedia.org" />
 	<target host="*.wikimedia.org" />
-		<exclusion pattern="^http://(?:apt|cs|cz|parsoid-lb\.eqiad|status|torrus|ubuntu)\.wikimedia\.org" />
+		<exclusion pattern="^http://(?:apt|cs|cz|parsoid-lb\.eqiad|smokeping|status|torrus|ubuntu)\.wikimedia\.org" />
 		<!-- https://mail1.eff.org/pipermail/https-everywhere-rules/2012-June/001189.html -->
 			<test url="http://apt.wikimedia.org" />
 			<test url="http://cs.wikimedia.org" />
 			<test url="http://cz.wikimedia.org" />
 			<test url="http://parsoid-lb.eqiad.wikimedia.org" />
+			<test url="http://smokeping.wikimedia.org" />
 			<test url="http://status.wikimedia.org" />
 			<test url="http://torrus.wikimedia.org" />
 			<test url="http://ubuntu.wikimedia.org" />


### PR DESCRIPTION
The certificate is only valid for librenms.wikimedia.org