### PR TITLE
[Git] www.git-scm.com now has a certificate, drop git-scm.herokuapp.com

### DIFF
--- a/src/chrome/content/rules/Git.xml
+++ b/src/chrome/content/rules/Git.xml
@@ -3,7 +3,7 @@
 	<target host="git-scm.com"/>
 	<target host="www.git-scm.com"/>
 
-	<rule from="^http://(?:www\.)?git-scm\.com/"
-		to="https://git-scm.herokuapp.com/" />
+	<rule from="^http:"
+		to="https:" />
 
 </ruleset>


### PR DESCRIPTION
https://github.com/git/git-scm.com/issues/489