### PR TITLE
Re-add IO optimisations

### DIFF
--- a/makexpi.sh
+++ b/makexpi.sh
@@ -52,6 +52,12 @@ if [ -n "$1" ] && [ "$2" != "--no-recurse" ] && [ "$1" != "--fast" ] ; then
 fi
 
 if [ "$1" != "--fast" -o ! -f "$RULESETS_SQLITE" ] ; then
+  # This is an optimization to get the OS reading the rulesets into RAM ASAP;
+  # it's useful on machines with slow disk seek times; there might be something
+  # better (vmtouch? readahead?) that tells the IO subsystem to read the files
+  # in whatever order it wants...
+  nohup cat src/chrome/content/rules/*.xml >/dev/null 2>/dev/null &
+
   echo "Generating sqlite DB"
   python2.7 ./utils/make-sqlite.py
 fi


### PR DESCRIPTION
- IO optimisations were useless when building tagged releases (since git
  already did this), but we should keep them when building from the
  git index.

- Various changes to the build scripts had meant that these were now in an
  inappropriate place, so put them before all ruleset-processing build work,
  and only run them if we're doing that work.