### PR TITLE
Adding ruleset for T411

### DIFF
--- a/src/chrome/content/rules/T411.xml
+++ b/src/chrome/content/rules/T411.xml
@@ -1,0 +1,16 @@
+<ruleset name="T411">
+  <target host="t411.io" />
+  <target host="*.t411.io" />
+  <target host="t411.me" />
+  <target host="*.t411.me" />
+  
+  <test url="http://wiki.t411.io/" />
+  <test url="http://www.t411.io/" />
+  <test url="http://forum.t411.io/" />
+  <test url="http://wiki.t411.me/" />
+  <test url="http://www.t411.me/" />
+  <test url="http://forum.t411.me/" />
+  
+  <rule from="^http:" to="https:" />
+  <securecookie host="^.*t411\.(io|me)$" name=".*" />
+</ruleset>


### PR DESCRIPTION
T411 is present on both t411.me and t411.io.
Known subdomains: www., wiki., forum., there may be more.
Cookies are from forum.t411.io and .t411.io (and respectively .me).
t411.me is getting deprecated but still in use. t411.io is the new address.