### PR TITLE
New rule for dejure.org

### DIFF
--- a/src/chrome/content/rules/Dejure.org.xml
+++ b/src/chrome/content/rules/Dejure.org.xml
@@ -1,0 +1,6 @@
+<ruleset name="Dejure.org">
+  <target host="dejure.org" />
+  <target host="www.dejure.org" />
+
+  <rule from="^http:" to="https:" />
+</ruleset>


### PR DESCRIPTION
The site's owner confirmed that all pages are also available through https.