### PR TITLE
Update Online.net.xml

### DIFF
--- a/src/chrome/content/rules/Online.net.xml
+++ b/src/chrome/content/rules/Online.net.xml
@@ -21,6 +21,7 @@
 		- stats.cloud
 		- console
 		- status
+		- phpmyadmin
 
 
 	Insecure cookies are set for these hosts:
@@ -44,6 +45,7 @@
 	<target host="status.online.net" />
 	<!--target host="webmail.online.net" /-->
 	<target host="www.online.net" />
+	<target host="phpmyadmin.online.net" />
 
 
 	<!--	Not secured by server:


### PR DESCRIPTION
Add phpmyadmin.online.net to targeted host

Note:

- After login on https://phpmyadmin.online.net/index.php, you are redirected to http://phpmyadmin.online.net/index.php?token={token_id} which with this update to the rules is prevented and become a redirect to https://phpmyadmin.online.net/index.php?token={token_id}, preventing you to switch from https to http :-)