### PR TITLE
Exclude ftp.kernel.org

### DIFF
--- a/src/chrome/content/rules/KernelOrg.xml
+++ b/src/chrome/content/rules/KernelOrg.xml
@@ -5,11 +5,13 @@
 		- vger ²
 		- wireless ³
 		- oops ⁴
+		- ftp ⁵
 
 	¹ Plaintext reply
 	² Refused
 	³ 404, CN: sipsolutions.net
 	⁴ CN: *.rhcloud.com, too many redirects
+	⁵ Uses www.kernel.org cert
 
 
 	Problematic subdomains:
@@ -36,7 +38,6 @@
 			- boot
 			- bugzilla
 			- eu
-			- ftp
 			- git
 			- [\w-]+.git
 			- mirrors
@@ -53,12 +54,13 @@
 
 	<target host="kernel.org" />
 	<target host="*.kernel.org" />
-		<exclusion pattern="^http://(?:oops|planet|vger|wireless)\." />
+		<exclusion pattern="^http://(?:ftp|oops|planet|vger|wireless)\." />
 
 	<test url="http://patchwork.kernel.org/" />
 	<test url="http://mirrors.eu.kernel.org/" />
-	<test url="http://planet.kernel.org" />
+	<test url="http://ftp.kernel.org" />
 	<test url="http://oops.kernel.org" />
+	<test url="http://planet.kernel.org" />
 	<test url="http://vger.kernel.org" />
 	<test url="http://wireless.kernel.org" />
 


### PR DESCRIPTION
Uses www.kernel.org ssl cert

Fixes #1605