### PR TITLE
Update YourBittorrent.xml: strip "www."

### DIFF
--- a/src/chrome/content/rules/YourBittorrent.xml
+++ b/src/chrome/content/rules/YourBittorrent.xml
@@ -16,7 +16,8 @@
 <ruleset name="YourBittorrent">
 
 	<target host="yourbittorrent.com" />
-	<target host="*.yourbittorrent.com" />
+	<target host="i.yourbittorrent.com" />
+	<target host="www.yourbittorrent.com" />
 
 
 	<securecookie host="^\.yourbittorrent\.com$" name=".+" />

--- a/src/chrome/content/rules/YourBittorrent.xml
+++ b/src/chrome/content/rules/YourBittorrent.xml
@@ -9,6 +9,7 @@
 
 	Problematic subdomains:
 
+		- www (certificate name mismatch)
 		- i	(404)
 
 -->
@@ -22,7 +23,7 @@
 
 
 	<rule from="^http://(www\.)?yourbittorrent\.com/"
-		to="https://$1yourbittorrent.com/" />
+		to="https://yourbittorrent.com/" />
 
 	<rule from="^http://i\.yourbittorrent\.com/"
 		to="https://yourbittorrent.com/images/" />


### PR DESCRIPTION
The "www" subdomain doesn't seem to work on this domain. (See [this](https://www.ssllabs.com/ssltest/analyze.html?d=yourbittorrent.com))