### PR TITLE
Add rule for pao-pao.net

### DIFF
--- a/src/chrome/content/rules/Pao-pao.net.xml
+++ b/src/chrome/content/rules/Pao-pao.net.xml
@@ -1,0 +1,6 @@
+<ruleset name="Pao-pao.net">
+  <target host="pao-pao.net" />
+  <target host="www.pao-pao.net" />
+
+  <rule from="^http:" to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/Pao-pao.net.xml
+++ b/src/chrome/content/rules/Pao-pao.net.xml
@@ -1,4 +1,4 @@
-<ruleset name="Pao-pao.net">
+<ruleset name="Pao-pao.net" platform="mixedcontent">
   <target host="pao-pao.net" />
   <target host="www.pao-pao.net" />
 


### PR DESCRIPTION
Note, that even though this page has mixed content, it 301-s to https,
so this rule shouldn't do any harm.

```
$ curl -I http://pao-pao.net/
HTTP/1.1 301 Moved Permanently
[...]
Location: https://pao-pao.net/
```