### PR TITLE
[Alternativet.dk] Deactivated: breaks video content

### DIFF
--- a/src/chrome/content/rules/Alternativet.dk.xml
+++ b/src/chrome/content/rules/Alternativet.dk.xml
@@ -2,12 +2,25 @@
 	A few style sheets are hardcoded as http:// and
 	considered mixed content in Firefox and friends.
 	This does not break the design though.
+
+	Some videos are served on tv.alternativet.dk, which
+	serves a bad cert. This breaks any pages on www
+	which serve video content.
+
+	Problematic domains:
+
+		- tv ¹
+
+	¹ Bad CN in cert
+
 -->
 
-<ruleset name="Alternativet (partial)">
+<ruleset name="Alternativet (partial)" default_off="Breaks video">
+
 	<target host="alternativet.dk" />
 	<target host="www.alternativet.dk" />
 
 	<rule from="^http:"
 		to="https:"/>
+
 </ruleset>


### PR DESCRIPTION
Alternativet.dk (just now, I believe) started pulling in content from tv.alternativet.dk, which is not covered by the ruleset as it serves https on a bad cert.