### PR TITLE
Make 'make clean' clean up pkg/xpi-amo and pkg/xpi-eff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ prerelease: pkg
 pkg:
 	mkdir pkg
 clean:
+	rm -rf pkg/xpi-amo/ pkg/xpi-eff/
 	rm -f pkg/*.xpi
 	rm -f src/chrome/content/rules/default.rulesets
 	rm -f src/defaults/rulesets.sqlite


### PR DESCRIPTION
For normal functioning, this change is 100% unnecessary. (makexpi.sh itself cleans them up before it starts building.) Nonetheless, as relatively large build artifacts (15 MB total), my sense of order in the universe wants `make clean` to handle them. :-P