### PR TITLE
[Alternativet.dk] Reactivated: video streaming fixed

### DIFF
--- a/src/chrome/content/rules/Alternativet.dk.xml
+++ b/src/chrome/content/rules/Alternativet.dk.xml
@@ -3,10 +3,6 @@
 	considered mixed content in Firefox and friends.
 	This does not break the design though.
 
-	Some videos are served on tv.alternativet.dk, which
-	serves a bad cert. This breaks any pages on www
-	which serve video content.
-
 	Problematic domains:
 
 		- tv ¹
@@ -15,7 +11,7 @@
 
 -->
 
-<ruleset name="Alternativet (partial)" default_off="Breaks video">
+<ruleset name="Alternativet (partial)">
 
 	<target host="alternativet.dk" />
 	<target host="www.alternativet.dk" />


### PR DESCRIPTION
After being made aware of the cert problem that caused the ruleset being deactivated (#1673), it looks like the devs made the site https-e friendly once again.