### PR TITLE
[Consumentenbond.nl] Add ruleset

### DIFF
--- a/src/chrome/content/rules/Consumentenbond.nl.xml
+++ b/src/chrome/content/rules/Consumentenbond.nl.xml
@@ -1,0 +1,10 @@
+<ruleset name="Consumentenbond.nl">
+  <target host="consumentenbond.nl" />
+  <target host="www.consumentenbond.nl" />
+
+  <rule from="^http:" to="https:" />
+
+  <test url="http://www.consumentenbond.nl/" />
+  <test url="http://www.consumentenbond.nl/juridisch-advies/" />
+  <test url="http://www.consumentenbond.nl/test/geld-verzekering/" />
+</ruleset>


### PR DESCRIPTION
Added a ruleset for consumentenbond.nl, a Dutch non-profit organization
dedicated to consumer protection and rights.

Some sensitive login forms where already automatically being redirected
to https urls, but the information pages weren't. That's why a dedicated
ruleset was needed.