### PR TITLE
Updated ruleset for GNUnet.org

### DIFF
--- a/src/chrome/content/rules/GNUnet.xml
+++ b/src/chrome/content/rules/GNUnet.xml
@@ -1,21 +1,12 @@
-<!--
-	Mixed content:
-
-		- Web bug from i.creativecommons.org *
-
-	* Secured by us
-
--->
 <ruleset name="GNUnet">
-
 	<target host="gnunet.org" />
-	<target host="*.gnunet.org" />
-
+	<target host="www.gnunet.org" />
+	
+	<test url="https://www.gnunet.org/" />
 
 	<securecookie host="^(?:.*\.)?gnunet\.org$" name=".+" />
 
-
-	<rule from="^http://(www\.)?gnunet\.org/"
-		to="https://$1gnunet.org/" />
-
+	<rule from="^http:" to="https:" />
+	
+	<rule from="^https://www\.gnunet\.org/" to="https://gnunet.org/" />
 </ruleset>

--- a/src/chrome/content/rules/GNUnet.xml
+++ b/src/chrome/content/rules/GNUnet.xml
@@ -2,11 +2,7 @@
 	<target host="gnunet.org" />
 	<target host="www.gnunet.org" />
 	
-	<test url="https://www.gnunet.org/" />
-
 	<securecookie host="^(?:.*\.)?gnunet\.org$" name=".+" />
 
-	<rule from="^http:" to="https:" />
-	
-	<rule from="^https://www\.gnunet\.org/" to="https://gnunet.org/" />
+	<rule from="^https?://(www\.)?gnunet\.org/" to="https://gnunet.org/" />
 </ruleset>


### PR DESCRIPTION
* The certificate is not valid for `www.gnunet.org`, redirect to `gnunet.org`
* Removed *.gnunet.org wildcard, as I haven't been able to find any relevant subdomains.
`http://de.gnunet.org` exists, but `https://de.gnunet.org` doesn't.  
However, `http://gnunet.org` 301s to `https://gnunet.org/`, which sends `Strict-Transport-Security: max-age=15768000 ; includeSubDomains`, so they break `de.gnunet.org` for everyone.