### PR TITLE
[Egedalkommune.dk] New ruleset

### DIFF
--- a/src/chrome/content/rules/Egedalkommune.dk.xml
+++ b/src/chrome/content/rules/Egedalkommune.dk.xml
@@ -1,0 +1,19 @@
+<!--
+	Not covered:
+
+		- infokort ¹
+
+	¹: Refused
+-->
+
+<ruleset name="Egedalkommune.dk">
+
+	<target host="egedalkommune.dk" />
+	<target host="www.egedalkommune.dk" />
+
+	<securecookie host="^\.?www\.egedalkommune\.dk$" name=".+" />
+
+	<rule from="^http:"
+		to="https:" />
+
+</ruleset>


### PR DESCRIPTION
The entire page is covered; the only problem I could find was [this page](https://www.egedalkommune.dk/service-sider/nyhedsbreve) which loads JS over a connection which can not be secured. Is it worth it to force an insecure connection on that one page?