### PR TITLE
add rule for UbuntuUsers.de

### DIFF
--- a/src/chrome/content/rules/UbuntuUsers.de.xml
+++ b/src/chrome/content/rules/UbuntuUsers.de.xml
@@ -1,0 +1,18 @@
+<ruleset name="UbuntuUsers.de" >
+
+<target host="ubuntuusers.de"/>
+<target host="*.ubuntuusers.de"/>
+<!-- passive mixedcontent warnings caused by http://media.cdn.ubuntu-de.org which can't be secured yet -->
+
+<securecookie host="^(?:.*\.)?ubuntuusers\.de$" name=".+" />
+
+	<rule from="^http:"
+		to="https:" />
+
+<test url="http://ubuntuusers.de/" />
+<test url="http://forum.ubuntuusers.de/" />
+<test url="http://wiki.ubuntuusers.de/" />
+<test url="http://ikhaya.ubuntuusers.de/" />
+<test url="http://planet.ubuntuusers.de/" />
+
+</ruleset>


### PR DESCRIPTION
German Ubuntu community began to secure its websites today.
Here is a rule for it.