### PR TITLE
[Cyon.ch] Resolved insecure cookie and include all subdomains

### DIFF
--- a/src/chrome/content/rules/Cyon.ch.xml
+++ b/src/chrome/content/rules/Cyon.ch.xml
@@ -6,31 +6,11 @@
 		- order
 		- webmail
 
-
-	Insecure cookies are set for these domains and hosts:
-
-		- .cyon.ch
-		- my.cyon.ch
-
 -->
 <ruleset name="cyon.ch">
 
-	<!--	Direct rewrites:
-				-->
 	<target host="cyon.ch" />
-	<target host="my.cyon.ch" />
-	<target host="order.cyon.ch" />
-	<target host="webmail.cyon.ch" />
-	<target host="www.cyon.ch" />
-
-
-	<!--	Not secured by server:
-					-->
-	<!--securecookie host="^\.cyon\.ch$" name="^cyon-l10n-settings$" /-->
-	<!--securecookie host="^my\.cyon\.ch$" name="^myproxyroute$" /-->
-
-	<securecookie host="^(?:my)?\.cyon\.ch$" name=".+" />
-
+	<target host="*.cyon.ch" />
 
 	<rule from="^http:"
 		to="https:" />


### PR DESCRIPTION
The reported issue with secure cookie are resolved on the server side. The securecookie tag is obsolete.
All subdomain content is served over https. HSTS header is constructed to includeSubDomains.