### PR TITLE
[Pdfreaders.org] Add ruleset

### DIFF
--- a/src/chrome/content/rules/Pdfreaders.org.xml
+++ b/src/chrome/content/rules/Pdfreaders.org.xml
@@ -1,0 +1,5 @@
+<ruleset name="Pdfreaders.org">
+  <target host="pdfreaders.org" />
+
+  <rule from="^http:" to="https:" />
+</ruleset>


### PR DESCRIPTION
Add ruleset for Pdfreaders.org, a site from FSFE recommending free
software PDF readers.