### PR TITLE
Disabled status.net rules. Fixes #1838.

### DIFF
--- a/src/chrome/content/rules/StatusNet.xml
+++ b/src/chrome/content/rules/StatusNet.xml
@@ -11,7 +11,13 @@
 	²: bad CN
 -->
 
-<ruleset name="StatusNet (partial)" default_off="No valid certificates">
+<ruleset name="StatusNet (broken)" default_off="No valid certificates">
+
+	<target host="avatar3.status.net" />
+	<target host="file.status.net" />
+	<target host="plugins.status.net" />
+	<target host="plugins2.status.net" />
+	<target host="theme2.status.net" />
 
 	<rule from="^http:"
 		to="https:" />

--- a/src/chrome/content/rules/StatusNet.xml
+++ b/src/chrome/content/rules/StatusNet.xml
@@ -1,7 +1,19 @@
-<ruleset name="StatusNet (partial)">
+<!--
+	Problematic subdomains:
 
-	<target host="*.status.net"/>
+		- avatar3 ¹
+		- file ¹
+		- plugins ²
+		- plugins2 ¹
+		- theme2 ¹
 
-	<rule from="^http://(avatar3|file|plugins[12]|theme[12])\.status\.net/" to="https://$1.status.net/"/>
+	¹: cert expired
+	²: bad CN
+-->
+
+<ruleset name="StatusNet (partial)" default_off="No valid certificates">
+
+	<rule from="^http:"
+		to="https:" />
 
 </ruleset>


### PR DESCRIPTION
All active rules in StatusNet.xml are problematic and have been removed, fixing #1838. This leaves a ruleset with no targets; perhaps this should be deleted/left with just the comment instead? Certainly the Travis test does not seem overly impressed.