### PR TITLE
Update AllTube Download rule

### DIFF
--- a/src/chrome/content/rules/AlltubeDownload.xml
+++ b/src/chrome/content/rules/AlltubeDownload.xml
@@ -2,5 +2,5 @@
   <target host="alltubedownload.net" />
   <target host="www.alltubedownload.net" />
 
-  <rule from="^http://(www\.)?alltubedownload\.net/" to="https://www.alltubedownload.net/" />
+  <rule from="^http://(www\.)?alltubedownload\.net/" to="https://alltube.herokuapp.com/" />
 </ruleset>


### PR DESCRIPTION
Hello,

The app is now hosted on a Heroku free plan so HTTPS is not available on alltubedownload.net anymore, so I updated the rule.

Regards,