### PR TITLE
[UU.se] Removed www.physics.uu.se due to new (bad) cert

### DIFF
--- a/src/chrome/content/rules/UU.se.xml
+++ b/src/chrome/content/rules/UU.se.xml
@@ -5,8 +5,11 @@
 	Nonfunctional subdomains:
 
 		- www.astro ⁴
+		- www.botan ³⁵
+		- www.hammerby ³⁵
 		- user.it ¹
 		- www.kalendarium ³
+		- www.linnaeus ³⁵
 		- www.listserv ³
 		- www.math ³
 		- www.physics ³
@@ -18,7 +21,7 @@
 	² Handshake fails
 	³ Mismatched
 	⁴ No local issuer cert provided
-
+	⁵ Redirects to other domain
 
 	Other domains not covered:
 

--- a/src/chrome/content/rules/UU.se.xml
+++ b/src/chrome/content/rules/UU.se.xml
@@ -8,6 +8,7 @@
 		- user.it ¹
 		- www.listserv ³
 		- www.math ³
+		- www.physics ³
 		- static ³
 		- www.uaf ²
 		- www.uuinnovation ³
@@ -36,7 +37,6 @@
 		- katalog
 		- lists
 		- mail
-		- www.physics
 		- uadm
 		- www.uppmax
 		- webmail
@@ -57,7 +57,6 @@
 	<target host="katalog.uu.se" />
 	<target host="lists.uu.se" />
 	<target host="mail.uu.se" />
-	<target host="www.physics.uu.se" />
 	<target host="uadm.uu.se" />
 	<target host="www.uppmax.uu.se" />
 	<target host="webmail.uu.se" />
@@ -69,4 +68,3 @@
 		to="https:" />
 
 </ruleset>
-

--- a/src/chrome/content/rules/UU.se.xml
+++ b/src/chrome/content/rules/UU.se.xml
@@ -6,6 +6,7 @@
 
 		- www.astro ⁴
 		- user.it ¹
+		- www.kalendarium ³
 		- www.listserv ³
 		- www.math ³
 		- www.physics ³


### PR DESCRIPTION
After a site change, this rule no longer works; the webadmins have been notified and it will be added again if it gets fixed.