### PR TITLE
Lanyrd: fix bad redirect to from signin/ to ignin/

### DIFF
--- a/src/chrome/content/rules/Lanyrd.xml
+++ b/src/chrome/content/rules/Lanyrd.xml
@@ -14,8 +14,8 @@
 	<target host="static.lanyrd.net" />
 
 
-	<rule from="^http://(www\.)?lanyrd\.com/s(ignin|tatic/)"
-		to="https://$1lanyrd.com/$2" />
+	<rule from="^http://(www\.)?lanyrd\.com/s(ignin/|tatic/)"
+		to="https://$1lanyrd.com/s$2" />
 
 	<rule from="^http://static\.lanyrd\.net/"
 		to="https://s3.amazonaws.com/static.lanyrd.net/" />


### PR DESCRIPTION
One of our users reported a bug signing in to https://lanyrd.com/ with HTTPS Everywhere installed. He tracked it down to a bad regular expression - here's his bug report: https://gist.github.com/tomviner/16c9fd5950ce1d9bc8d7