### PR TITLE
Updated ed.ac.uk rules due to user problems.

### DIFF
--- a/src/chrome/content/rules/Ed.ac.uk.xml
+++ b/src/chrome/content/rules/Ed.ac.uk.xml
@@ -11,22 +11,22 @@
 	Problematic subdomains:
 
 		- www.ug.ucs *
+		- www.inf ²
 
 	* Self-signed
+	² Some branches via HTTPS require authentication, but are public via HTTP
 
 
 	Fully covered subdomains:
 
 		- www.ease
 		- wiki.inf
-		- www.inf
 
 -->
 <ruleset name="Ed.ac.uk (partial)">
 
 	<target host="www.ease.ed.ac.uk" />
 	<target host="wiki.inf.ed.ac.uk" />
-	<target host="www.inf.ed.ac.uk" />
 
 
 	<rule from="^http:"


### PR DESCRIPTION
Our users were having problems because some branches of www.inf.ed.ac.uk require authentication when using HTTPS (eg to edit content), but the content is still publicly readable via HTTP.  So
I've removed www.inf.ed.ac.uk from the list of sites to automatically
redirect to HTTPS. neilb @ inf. ed. ac .uk

Excuse any newbie github faux pas, it's my first time!

Neil