### PR TITLE
[Leafletjs.com] Disabled ruleset; fixes #1837 and #1938

### DIFF
--- a/src/chrome/content/rules/Leaflet_JS.com.xml
+++ b/src/chrome/content/rules/Leaflet_JS.com.xml
@@ -1,21 +1,13 @@
 <!--
-	CDN buckets:
-
-		- d591zijq8zntj.cloudfront.net
-
-			- cdn
-
-
 	^: refused
 	www: dropped
-
+	cdn: wrong CN
 -->
-<ruleset name="Leaflet JS.com (partial)">
+<ruleset name="Leaflet JS.com (bad cert)" default_off="Bad CN in cert">
 
 	<target host="cdn.leafletjs.com" />
 
-
-	<rule from="^http://cdn\.leafletjs\.com/"
-		to="https://d591zijq8zntj.cloudfront.net/" />
+	<rule from="^http:"
+		to="https:" />
 
 </ruleset>


### PR DESCRIPTION
The rule in this ruleset pointed at a non-responding cloudfront subdomain. The subdomain cdn.leafletjs.com itself does serve https but on a bad certificate.

This fixes #1837 and #1938.