### PR TITLE
New rule for Webjet

### DIFF
--- a/src/chrome/content/rules/Webjet.xml
+++ b/src/chrome/content/rules/Webjet.xml
@@ -1,0 +1,40 @@
+<!--
+	Nonfunctional TLD:
+		- .com
+		- .co.uk
+		- .ca
+		- .co.za (mixed content)
+		- .com.mx
+
+	Nonfunctional subdomains:
+		- hotels
+		- exclusives
+		- packages
+		- investor
+		- cms
+-->
+
+<ruleset name="Webjet">
+	<target host=        "webjet.com.au" />
+	<target host=    "www.webjet.com.au" />
+	<target host=   "cars.webjet.com.au" />
+	<target host="cruises.webjet.com.au" />
+	<target host="flights.webjet.com.au" />
+
+	<target host=        "webjet.co.nz" />
+	<target host=    "www.webjet.co.nz" />
+	<target host=   "cars.webjet.co.nz" />
+	<target host="cruises.webjet.co.nz" />
+	<target host="flights.webjet.co.nz" />
+
+  	<securecookie host="^.*\.webjet\.(com\.au|co\.nz)$" name=".+" />
+
+	<rule from="^http://webjet\.(com\.au|co\.nz)/"
+		to="https://www.webjet.$1/" />
+
+		<test url="http://www.webjet.com.au/" />
+		<test url="http://www.webjet.co.nz/" />
+
+	<rule from="^http:" 
+		to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/Webjet.xml
+++ b/src/chrome/content/rules/Webjet.xml
@@ -29,11 +29,9 @@
 
   	<securecookie host="^.*\.webjet\.(com\.au|co\.nz)$" name=".+" />
 
+	<!-- cert only match www -->
 	<rule from="^http://webjet\.(com\.au|co\.nz)/"
 		to="https://www.webjet.$1/" />
-
-		<test url="http://www.webjet.com.au/" />
-		<test url="http://www.webjet.co.nz/" />
 
 	<rule from="^http:" 
 		to="https:" />


### PR DESCRIPTION
Rule test might fail due to missing CA cert in `/etc/ssl/certs/ca-certificates.crt` (#1862)
Edit:
Travis CI build log,
```
+bash test-ruleset-coverage.sh
ERROR src/chrome/content/rules/LinkedIn.xml
```
Hmm....