### PR TITLE
[Employeeexpress.gov][WTF is my IP.com] Reenable IPv6-only rulesets

### DIFF
--- a/src/chrome/content/rules/Employeeexpress.gov.xml
+++ b/src/chrome/content/rules/Employeeexpress.gov.xml
@@ -1,8 +1,4 @@
-<!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://employeeexpress.gov/ => https://www.employeeexpress.gov/: (7, '')
--->
-<ruleset name="Employeeexpress.gov" default_off='failed ruleset test'>
+<ruleset name="Employeeexpress.gov">
 	<target host="employeeexpress.gov" />
 	<target host="www.employeeexpress.gov" />
 

--- a/src/chrome/content/rules/WTFismyIP.xml
+++ b/src/chrome/content/rules/WTFismyIP.xml
@@ -1,8 +1,4 @@
-
 <!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://ipv6.wtfismyip.com/ => https://ipv6.wtfismyip.com/: (7, '')
-
 	Fully covered hosts:
 
 		- (www.)?
@@ -10,7 +6,7 @@ Fetch error: http://ipv6.wtfismyip.com/ => https://ipv6.wtfismyip.com/: (7, '')
 		- ipv6
 
 -->
-<ruleset name="WTF is my IP.com" default_off='failed ruleset test'>
+<ruleset name="WTF is my IP.com">
 	<target host="wtfismyip.com" />
 	<target host="ipv4.wtfismyip.com" />
 	<target host="ipv6.wtfismyip.com" />


### PR DESCRIPTION
The checker only failed because the subdomain is IPv6-only. It passes when run from a dual-stack system.