### PR TITLE
[Google Services] Fix, reenable. Still lacks a billion tests.

### DIFF
--- a/src/chrome/content/rules/GoogleServices.xml
+++ b/src/chrome/content/rules/GoogleServices.xml
@@ -1,8 +1,4 @@
-
 <!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://googleusercontent.com/ => http://googleusercontent.com/: (6, 'Could not resolve host: googleusercontent.com')
-
 	Other Google rulesets:
 
 		- 2mdn.net.xml
@@ -37,10 +33,11 @@ Fetch error: http://googleusercontent.com/ => http://googleusercontent.com/: (6,
 		- safebrowsing.clients.google.com	(404, mismatched)
 		- (www.)googlesyndicatedsearch.com	(404; mismatched, CN: google.com)
 		- buttons.googlesyndication.com *
+		- googleusercontent.com ³
 
 	* 404, valid cert
 	² 404; mismatched, CN: www.google.com
-
+	³ Does not resolve
 
 	Nonfunctional google.com paths:
 
@@ -184,7 +181,7 @@ Fetch error: http://googleusercontent.com/ => http://googleusercontent.com/: (6,
 	XXX: Needs more testing
 
 -->
-<ruleset name="Google Services" default_off='failed ruleset test'>
+<ruleset name="Google Services">
 
 	<target host="*.ggpht.com" />
 	<target host="gmail.com" />
@@ -236,7 +233,6 @@ Fetch error: http://googleusercontent.com/ => http://googleusercontent.com/: (6,
 	<target host="*.googlesource.com" />
 	<target host="*.googlesyndication.com" />
 	<target host="www.googletagservices.com" />
-	<target host="googleusercontent.com" />
 	<target host="*.googleusercontent.com" />
 		<!--
 			Necessary for the Followers widget:

--- a/src/chrome/content/rules/GoogleServices.xml
+++ b/src/chrome/content/rules/GoogleServices.xml
@@ -39,6 +39,7 @@
 	² 404; mismatched, CN: www.google.com
 	³ Does not resolve
 
+
 	Nonfunctional google.com paths:
 
 		- analytics	(redirects to http)


### PR DESCRIPTION
Last time around, GoogleServices.xml was grandfathered through... This pull request fixes the simple immediate issue that got it disabled this time, but doesn't make the other changes that probably ought to be done.

Shortage of test coverage aside, it does pass the current tests.

I'm not sure if this is useful to merge or not.

(Also, should I have edited `ruleset-coverage-whitelist.txt`? If so, by hand?)