### PR TITLE
Rulesets for use on herlev.dk

### DIFF
--- a/src/chrome/content/rules/Emply.net.xml
+++ b/src/chrome/content/rules/Emply.net.xml
@@ -1,0 +1,10 @@
+<ruleset name="Emply.net">
+	<target host="herlev.emply.net" />
+
+	<test url="http://herlev.emply.net/overview/herlev.aspx?mediaId=f1fb8e12-1928-4328-88fd-9918a34a2bf2" />
+
+	<securecookie host="herlev\.emply\.net" name=".*" />
+
+	<rule from="^http:"
+		to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/Synchronicer.dk.xml
+++ b/src/chrome/content/rules/Synchronicer.dk.xml
@@ -1,0 +1,13 @@
+<!--
+	Mixed content problems on
+		https://www.synchronicer.dk/app?WSLOAD=TipHerlev4229fdF
+-->
+<ruleset name="Synchronicer.dk (mixed content)" platform="mixedcontent">
+	<target host="synchronicer.dk" />
+	<target host="www.synchronicer.dk" />
+
+	<securecookie host="(www\.)?synchronicer\.dk" name=".*" />
+
+	<rule from="^http://(www\.)?synchronicer\.dk/"
+		to="https://www.synchronicer.dk/" />
+</ruleset>


### PR DESCRIPTION
These two rules are useful on herlev.dk, which itself has a decent SSL implementation but probably too many bugs for use in HTTPS-E.