### PR TITLE
[Spiegel.de] fixing ruleset

### DIFF
--- a/src/chrome/content/rules/Spiegel.xml
+++ b/src/chrome/content/rules/Spiegel.xml
@@ -38,6 +38,10 @@
 	<rule from="^http://www\.spiegel\.de/(images/|img/|layout/|static/|staticgen/)"
 		to="https://www.spiegel.de/$1" />
 
+	<!-- exlude static/flash from rule above to make videos work properly -->
+	
+	<exclusion pattern="^http://www\.spiegel\.de/static/flash/" />
+
 	<rule from="^http://(abo|count|magazin|shop|wissen)\.spiegel\.de/"
 		to="https://$1.spiegel.de/" />
 

--- a/src/chrome/content/rules/Spiegel.xml
+++ b/src/chrome/content/rules/Spiegel.xml
@@ -17,6 +17,8 @@
 		- forum
 		- tvprogramm
 		- wetter	(cert: plesk; shows default Parallels Plesk page)
+		- shop
+		- wissen
 
 -->
 <ruleset name="Spiegel (partial)">
@@ -35,14 +37,26 @@
 	<rule from="^http://(?:cdn\d?\.)?spiegel\.de/"
 		to="https://www.spiegel.de/" />
 
-	<rule from="^http://www\.spiegel\.de/(images/|img/|layout/|static/|staticgen/)"
+	<rule from="^http://www\.spiegel\.de/(images/|pics/|layout/|static/|staticgen/)"
 		to="https://www.spiegel.de/$1" />
 
-	<!-- exlude static/flash from rule above to make videos work properly -->
+	<!-- exclude static/flash from rule above to make videos work properly -->
 	
 	<exclusion pattern="^http://www\.spiegel\.de/static/flash/" />
 
-	<rule from="^http://(abo|count|magazin|shop|wissen)\.spiegel\.de/"
+	<rule from="^http://(abo|count|magazin)\.spiegel\.de/"
 		to="https://$1.spiegel.de/" />
+	
+	<test url="http://www.spiegel.de/images/image-429070-thumbsmall-mmtp.png" />
+	<test url="http://www.spiegel.de/pics/43/0,1020,308043,00.jpg" />
+	<test url="http://www.spiegel.de/layout/jscfg/http/global-V6-7.js" />
+	<test url="http://www.spiegel.de/static/sys/dimensionspixel.gif" />
+<test url="http://www.spiegel.de/staticgen/fussballticker/heatmaps/BUNDESLIGA/201213/18/spiegel_heatmap_138361_35099_440_330.jpg" />
+	<test url="http://abo.spiegel.de/" />
+	<test url="http://abo.spiegel.de/" />
+	<test url="http://count.spiegel.de/" />
+	<test url="http://magazin.spiegel.de/" />
+	<test url="http://www.spiegel.de/static/flash/flashvideo/homadconfig.json" />
+	
 
 </ruleset>

--- a/src/chrome/content/rules/Spiegel.xml
+++ b/src/chrome/content/rules/Spiegel.xml
@@ -51,7 +51,7 @@
 	<test url="http://www.spiegel.de/pics/43/0,1020,308043,00.jpg" />
 	<test url="http://www.spiegel.de/layout/jscfg/http/global-V6-7.js" />
 	<test url="http://www.spiegel.de/static/sys/dimensionspixel.gif" />
-<test url="http://www.spiegel.de/staticgen/fussballticker/heatmaps/BUNDESLIGA/201213/18/spiegel_heatmap_138361_35099_440_330.jpg" />
+	<test url="http://www.spiegel.de/staticgen/fussballticker/heatmaps/BUNDESLIGA/201213/18/spiegel_heatmap_138361_35099_440_330.jpg" />
 	<test url="http://abo.spiegel.de/" />
 	<test url="http://abo.spiegel.de/" />
 	<test url="http://count.spiegel.de/" />


### PR DESCRIPTION
Based on issue #1960 I fixed the broken flash videos per exclusion, added test urls and did some general fixes

img/ gets rewritten to pics/ by the site itself, so i corrected the rule
shop.spiegel.de and wissen.spiegel.de are not longer functional due to bad ssl domain