### PR TITLE
Adding two excludes for *.tilt.com

### DIFF
--- a/src/chrome/content/rules/Tilt.com.xml
+++ b/src/chrome/content/rules/Tilt.com.xml
@@ -1,18 +1,4 @@
 <!--
-	NB: Tor users cannot view* this website due to CloudFlare settings.
-
-	See:
-
-		- https://blog.torproject.org/blog/call-arms-helping-internet-services-accept-anonymous-users
-		- https://support.cloudflare.com/hc/en-us/articles/203306930-Does-CloudFlare-block-Tor-
-		- https://support.cloudflare.com/hc/en-us/articles/200170206-How-do-I-turn-I-m-Under-Attack-mode-on-
-
-	* without enabling javascript, for security and privacy implications see e.g.:
-
-		- https://www.mozilla.org/security/known-vulnerabilities/firefox.html
-		- https://trac.torproject.org/projects/tor/query?status=!closed&keywords=~tbb-fingerprinting
-		- https://panopticlick.eff.org
-
 
 	Fully covered domains:
 
@@ -28,7 +14,6 @@
 
 	* Per-account domains
 
-
 	Insecure cookies are set for these domains:
 
 		- .tilt.com
@@ -39,18 +24,13 @@
 	<target host="tilt.com" />
 	<target host="*.tilt.com" />
 
-		<test url="http://blog.tilt.com/" />
-		<test url="http://open.tilt.com/" />
-		<test url="http://questions.tilt.com/" />
-		<test url="http://www.tilt.com/" />
+	<exclusion pattern="^http://stories\.tilt\.com" />
+	<exclusion pattern="^http://engineering\.tilt\.com" />
 
-
-	<!--	CloudFlare cookies:
-					-->
-	<!--securecookie host="^\.tilt\.com$" name="^(__cfduid|cf_clearance)$" /-->
-
-	<securecookie host="^\.tilt\.com$" name="^(?:__cfduid|cf_clearance)$" />
-
+	<test url="http://blog.tilt.com/" />
+	<test url="http://open.tilt.com/" />
+	<test url="http://questions.tilt.com/" />
+	<test url="http://www.tilt.com/" />
 
 	<rule from="^http://([\w-]+\.)?tilt\.com/"
 		to="https://$1tilt.com/" />


### PR DESCRIPTION
Tilt no longer uses CloudFlare so we can remove that part of the ruleset.  Also, two domains hosted on other services do not pass the correct cert over HTTPS, so I added excludes for those.