### PR TITLE
Remove exclusions for careers.stackoverflow.com

### DIFF
--- a/src/chrome/content/rules/Stack-Exchange.xml
+++ b/src/chrome/content/rules/Stack-Exchange.xml
@@ -135,9 +135,6 @@
 <!-- Rules -->
 	
 	<!-- https links from other pages to these will cause MCB for important elements, hence the downgrades -->
-	<rule from="^https://careers\.stackoverflow\.com/(cities|employer)" 
-		to="http://careers.stackoverflow.com/$1" downgrade="1" />
-		
 	<rule from="^https://([\w.-]+)\.([\w-]+)\.stackexchange\.com/" 
 		to="http://$1.$2.stackexchange.com/" downgrade="1" />
 	

--- a/src/chrome/content/rules/Stack-Exchange.xml
+++ b/src/chrome/content/rules/Stack-Exchange.xml
@@ -70,12 +70,6 @@
 	<!-- Stackoverflow -->
 	<target host="chat.stackoverflow.com" />
 	<target host="careers.stackoverflow.com" />
-		<!-- These two have mixed active content over https - there is also a downgrade rule below -->
-		<exclusion pattern="^http://careers\.stackoverflow\.com/(cities|employer)"/>
-		<test url="http://careers.stackoverflow.com/cities/san-francisco/" />
-		<test url="http://careers.stackoverflow.com/employer/" />
-		<test url="https://careers.stackoverflow.com/cities/san-francisco/" />
-		<test url="https://careers.stackoverflow.com/employer/" />
 	<target host="ja.stackoverflow.com" />
 	<target host="meta.stackoverflow.com" />
 	<target host="pt.stackoverflow.com" />


### PR DESCRIPTION
I fixed the mixed content on the site (I'm a dev on the Careers.SO team). The downgrade rule breaks parts of the /employer section of the site, such as [employer login](https://careers.stackoverflow.com/employer/login), by causing redirect loops.