### PR TITLE
php.net updates

### DIFF
--- a/src/chrome/content/rules/PHP.xml
+++ b/src/chrome/content/rules/PHP.xml
@@ -9,10 +9,12 @@
 		- people ²
 		- talks ³
 		- windows ¹
+    - www ⁴
 
 	¹ Refused
 	² Dropped
 	³ Shows viewvc interface, valid cert
+  ⁴ Depends on the mirror, but the "best case" is an invalid certificate
 
 
 	Problematic subdomains:
@@ -24,7 +26,7 @@
 
 	Fully covered subdomains:
 
-		- (www.)?
+		- (null)
 		- bugs
 		- downloads
 		- edot
@@ -72,7 +74,22 @@
 	<securecookie host="^(?:\w*\.)?php\.net$" name=".+" />
 
 
-	<rule from="^http://((?:bugs|downloads|edit|git|master|museum|pear|qa|shared|snaps|static|svn|wiki|www)\.)?php\.net/"
+	<rule from="^http://((?:bugs|downloads|edit|git|master|museum|pear|qa|shared|snaps|static|svn|wiki)\.)?php\.net/"
 		to="https://$1php.net/" />
+
+  <test url="http://php.net/" />
+  <test url="http://bugs.php.net/" />
+  <test url="http://downloads.php.net/" />
+  <test url="http://edit.php.net/" />
+  <test url="http://git.php.net/" />
+  <test url="http://master.php.net/" />
+  <test url="http://museum.php.net/" />
+  <test url="http://pear.php.net/" />
+  <test url="http://qa.php.net/" />
+  <test url="http://shared.php.net/" />
+  <test url="http://snaps.php.net/" />
+  <test url="http://static.php.net/" />
+  <test url="http://svn.php.net/" />
+  <test url="http://wiki.php.net/" />
 
 </ruleset>

--- a/src/chrome/content/rules/PHP.xml
+++ b/src/chrome/content/rules/PHP.xml
@@ -67,10 +67,7 @@
 	<target host="*.php.net" />
 
 
-	<!--	Not secured by server:
-					-->
-	<!--securecookie host="^bugs\.php\.net$" name="^PHPSESSID$" /-->
-
+	<securecookie host="^bugs\.php\.net$" name="^PHPSESSID$" />
 	<securecookie host="^(?:\w*\.)?php\.net$" name=".+" />
 
 

--- a/src/chrome/content/rules/PHP.xml
+++ b/src/chrome/content/rules/PHP.xml
@@ -9,19 +9,12 @@
 		- people ²
 		- talks ³
 		- windows ¹
-    - www ⁴
+		- www ⁴
 
 	¹ Refused
 	² Dropped
 	³ Shows viewvc interface, valid cert
-  ⁴ Depends on the mirror, but the "best case" is an invalid certificate
-
-
-	Problematic subdomains:
-
-		- pecl *
-
-	* Expired 2013-01-08
+	⁴ Depends on the mirror, but the "best case" is an invalid certificate
 
 
 	Fully covered subdomains:
@@ -34,7 +27,9 @@
 		- master
 		- museum
 		- pear
+		- pecl
 		- qa
+		- secure
 		- shared
 		- snaps
 		- static
@@ -64,29 +59,25 @@
 <ruleset name="PHP.net (partial)">
 
 	<target host="php.net" />
-	<target host="*.php.net" />
+	<target host="bugs.php.net" />
+	<target host="downloads.php.net" />
+	<target host="edit.php.net" />
+	<target host="git.php.net" />
+	<target host="master.php.net" />
+	<target host="museum.php.net" />
+	<target host="pear.php.net" />
+	<target host="pecl.php.net" />
+	<target host="qa.php.net" />
+	<target host="secure.php.net" />
+	<target host="shared.php.net" />
+	<target host="snaps.php.net" />
+	<target host="static.php.net" />
+	<target host="svn.php.net" />
+	<target host="wiki.php.net" />
+
+	<rule from="^http:" to="https:" />
 
 
-	<securecookie host="^bugs\.php\.net$" name="^PHPSESSID$" />
 	<securecookie host="^(?:\w*\.)?php\.net$" name=".+" />
-
-
-	<rule from="^http://((?:bugs|downloads|edit|git|master|museum|pear|qa|shared|snaps|static|svn|wiki)\.)?php\.net/"
-		to="https://$1php.net/" />
-
-  <test url="http://php.net/" />
-  <test url="http://bugs.php.net/" />
-  <test url="http://downloads.php.net/" />
-  <test url="http://edit.php.net/" />
-  <test url="http://git.php.net/" />
-  <test url="http://master.php.net/" />
-  <test url="http://museum.php.net/" />
-  <test url="http://pear.php.net/" />
-  <test url="http://qa.php.net/" />
-  <test url="http://shared.php.net/" />
-  <test url="http://snaps.php.net/" />
-  <test url="http://static.php.net/" />
-  <test url="http://svn.php.net/" />
-  <test url="http://wiki.php.net/" />
 
 </ruleset>

--- a/src/chrome/content/rules/PHP.xml
+++ b/src/chrome/content/rules/PHP.xml
@@ -6,13 +6,11 @@
 		- gtk ³
 		- lxr ¹
 		- news ¹
-		- people ²
 		- talks ³
 		- windows ¹
 		- www ⁴
 
 	¹ Refused
-	² Dropped
 	³ Shows viewvc interface, valid cert
 	⁴ Depends on the mirror, but the "best case" is an invalid certificate
 
@@ -28,6 +26,7 @@
 		- museum
 		- pear
 		- pecl
+		- people
 		- qa
 		- secure
 		- shared
@@ -67,6 +66,7 @@
 	<target host="museum.php.net" />
 	<target host="pear.php.net" />
 	<target host="pecl.php.net" />
+	<target host="people.php.net" />
 	<target host="qa.php.net" />
 	<target host="secure.php.net" />
 	<target host="shared.php.net" />


### PR DESCRIPTION
This fixes two problems:

* www.php.net cannot be used with HTTPS any more, as the domain name will redirect to a mirror that (almost certainly) doesn't have a valid HTTPS configuration.
* bugs.php.net now sends a secure PHPSESSID cookie, so that rule can be enabled.