### PR TITLE
[The Verge] Re-enable for all platforms

### DIFF
--- a/src/chrome/content/rules/The-Verge.xml
+++ b/src/chrome/content/rules/The-Verge.xml
@@ -42,7 +42,7 @@
 	² Unsecurable <= refused
 
 -->
-<ruleset name="The Verge.com (partial)" platform="firefox">
+<ruleset name="The Verge.com (partial)">
 
 	<target host="theverge.com" />
 	<target host="mobile.theverge.com" />


### PR DESCRIPTION
Images and comments (over HTTPS) are working again on both Chrome and Firefox, so issue #1299 may no longer be a problem.

Images working:
![images](https://cloud.githubusercontent.com/assets/2025495/8316305/eae5309a-19aa-11e5-9be8-e8da721fc051.JPG)

Comments working:
![comments](https://cloud.githubusercontent.com/assets/2025495/8316306/ebed6dc2-19aa-11e5-85cb-4a7080f152a3.JPG)
