### PR TITLE
Enable rules for whirlpool.net.au and add tests

### DIFF
--- a/src/chrome/content/rules/Whirlpool.xml
+++ b/src/chrome/content/rules/Whirlpool.xml
@@ -1,7 +1,3 @@
-<!--
-Automatically by https-everywhere-checker because:
-Fetch error: http://whirlpool.net.au/ => https://whirlpool.net.au/: (52, 'Empty reply from server')
--->
 <ruleset name="Whirlpool">
 
 	<target host="whirlpool.net.au" />

--- a/src/chrome/content/rules/Whirlpool.xml
+++ b/src/chrome/content/rules/Whirlpool.xml
@@ -2,11 +2,14 @@
 Automatically by https-everywhere-checker because:
 Fetch error: http://whirlpool.net.au/ => https://whirlpool.net.au/: (52, 'Empty reply from server')
 -->
-<ruleset name="Whirlpool" default_off='failed ruleset test'>
+<ruleset name="Whirlpool">
 
 	<target host="whirlpool.net.au" />
 	<target host="*.whirlpool.net.au" />
 
+    <test url="http://whirlpool.net.au/" />
+    <test url="http://forums.whirlpool.net.au/" />
+    <test url="http://bc.whirlpool.net.au/" />
 
 	<securecookie host="^\.whirlpool\.net\.au$" name=".+" />
 


### PR DESCRIPTION
Whirlpool's now fully functional on HTTPS, so enable the ruleset and add tests.