### PR TITLE
fix and rewrite RTL.de (#1994)

### DIFF
--- a/src/chrome/content/rules/RTL.de.xml
+++ b/src/chrome/content/rules/RTL.de.xml
@@ -19,7 +19,7 @@
 		- gzsz.rtl.de ¹
 
 	* Works, akamai
-	¹ mixed content blocking (required active content from bilder.akamai)
+	¹ mixed content blocking (requires active content from bilder.akamai)
 	² bad cert domain
 	³ refused
 

--- a/src/chrome/content/rules/RTL.de.xml
+++ b/src/chrome/content/rules/RTL.de.xml
@@ -7,15 +7,21 @@
 			- bilder.akamai
 
 
-	(www.): refused
-
-
 	Problematic subdomains:
 
 		- bilder.akamai *
+		- (www.) ¹
+		- intentium ²
+		- kommunikation ²
+		- rtl-living ³
+		- rtl-crime ³
+		- spiele.rtl.de ¹
+		- gzsz.rtl.de ¹
 
 	* Works, akamai
-
+	¹ mixed content blocking (required active content from bilder.akamai)
+	² bad cert domain
+	³ refused
 
 	Fully covered subdomains:
 
@@ -25,16 +31,19 @@
 		- rtl-videoclip-player
 
 -->
-<ruleset name="RTL.de (partial)">
+<ruleset name="RTL.de (partial)" >
 
-	<target host="*.rtl.de" />
-		<!--exclusion pattern="^http://www\.rtl\.de/" /-->
-
+	<target host="autoimg.rtl.de" />
+	<target host="bilder.rtl.de" />
+	<target host="bilder.akamai.rtl.de" />
+	<target host="rtl-videoclip-player.rtl.de" />
 
 	<rule from="^http://bilder\.akamai\.rtl\.de/"
-		to="https://a248.e.akamai.net/f/610/6737/8/bilder.akamai.net/" />
+		to="https://a248.e.akamai.net/f/610/6737/8/bilder.akamai.rtl.de/" />
 
-	<rule from="^http://(autoimg|bilder|rtl-videoclip-player)\.rtl\.de/"
-		to="https://$1.rtl.de/" />
-
+	<rule from="^http:"
+		to="https:" />
+	
+	<test url="http://a248.e.akamai.net/f/610/6737/8/bilder.akamai.rtl.de/" />
+	
 </ruleset>


### PR DESCRIPTION
This pull request aims to fix issue #1994 by providing a working replacement for https://a248.e.akamai.net/f/610/6737/8/bilder.akamai.net/ which fails with a 503 error (DNS failure).
Furthermore the ruleset is rewritten according to the style guidelines.