### PR TITLE
[Pol.dk] Disabled ruleset: connections are refused

### DIFF
--- a/src/chrome/content/rules/Pol.dk.xml
+++ b/src/chrome/content/rules/Pol.dk.xml
@@ -1,11 +1,13 @@
 <!--
 	For other Politiken coverage, see Politiken.dk.xml.
 
+	Note: A valid certificate exists and used to be used
+	on multimedia.pol.dk, which currently refuses connections.
+
 -->
-<ruleset name="Pol.dk (partial)">
+<ruleset name="Pol.dk (broken)" default_off="Connection refused">
 
 	<target host="multimedia.pol.dk" />
-
 
 	<rule from="^http:"
 		to="https:" />


### PR DESCRIPTION
As of today or yesterday, the existing rule would cause all images on https://politiken.dk not to be loaded. Devs are contacted, and hopefully it will be fixed soon enough.

As an aside: For PRs like these, fixing broken websites, do you want an companion issue submitted as well?