### PR TITLE
Re-enable Wickr.com.xml

### DIFF
--- a/src/chrome/content/rules/Wickr.com.xml
+++ b/src/chrome/content/rules/Wickr.com.xml
@@ -1,16 +1,12 @@
-<!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://mywickr.com/ => https://mywickr.com/: (52, 'Empty reply from server')
--->
-<ruleset name="Wickr.com" default_off='failed ruleset test'>
+<ruleset name="Wickr.com">
 
 	<target host="mywickr.com" />
 	<target host="www.mywickr.com" />
 	<target host="wickr.com" />
 	<target host="www.wickr.com" />
 
-
+	<!-- redirect mywickr.com to wickr.com, in addition to https -->
 	<rule from="^http://(www\.)?(my)?wickr\.com/"
-		to="https://$1$2wickr.com/" />
+		to="https://$1wickr.com/" />
 
 </ruleset>


### PR DESCRIPTION
Redirect mywickr.com to wickr.com (server's default behaviour).