### PR TITLE
aircrack-ng.org

### DIFF
--- a/src/chrome/content/rules/aircrack-ng.org.xml
+++ b/src/chrome/content/rules/aircrack-ng.org.xml
@@ -2,16 +2,17 @@
 	CN: ssl2.ovh.net
 
 -->
-<ruleset name="Aircrack-ng" default_off="mismatched">
+<ruleset name="aircrack-ng.org (mismatched)" default_off="mismatched">
 
 	<target host="aircrack-ng.org" />
 	<target host="www.aircrack-ng.org" />
 
 
 	<securecookie host="^aircrack-ng\.org$" name=".+" />
+	<securecookie host="^.+\.aircrack-ng\.org$" name=".+" />
 
 
-	<rule from="^http://(?:www\.)?aircrack-ng\.org/"
-		to="https://aircrack-ng.org/" />
+	<rule from="^http:"
+		to="https:" />
 
 </ruleset>


### PR DESCRIPTION
Two minor changes: ruleset name to indicate mismatched and secure
cookies.