### PR TITLE
Deleting invalid subdomain for sigal-spam.fr

### DIFF
--- a/src/chrome/content/rules/Signal_Spam.xml
+++ b/src/chrome/content/rules/Signal_Spam.xml
@@ -1,16 +1,5 @@
-<!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://signal-spam.fr/ => https://www.signal-spam.fr/: (6, 'Could not resolve host: signal-spam.fr')
-	!www: cert only matches www
-
--->
-<ruleset name="Signal Spam" default_off='failed ruleset test'>
-
-	<target host="signal-spam.fr" />
+<ruleset name="Signal Spam">
 	<target host="www.signal-spam.fr" />
-
-
-	<rule from="^http://(?:www\.)?signal-spam\.fr/"
-		to="https://www.signal-spam.fr/" />
-
+	<rule from="^http:"
+		to="https:" />
 </ruleset>


### PR DESCRIPTION
I deleted the invalid domain "signal-spam.fr" to resolve problems.