### PR TITLE
[StartCom] Should not be disabled

### DIFF
--- a/src/chrome/content/rules/StartCom.xml
+++ b/src/chrome/content/rules/StartCom.xml
@@ -1,10 +1,4 @@
-
-<!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://auth.startssl.com/ => https://auth.startssl.com/: (35, 'error:14094410:SSL routines:SSL3_READ_BYTES:sslv3 alert handshake failure')
-
--->
-<ruleset name="StartCom" default_off='failed ruleset test'>
+<ruleset name="StartCom">
   <target host="startssl.com" />
   <target host="*.startssl.com" />
   <target host="startssl.net" />

--- a/src/chrome/content/rules/StartCom.xml
+++ b/src/chrome/content/rules/StartCom.xml
@@ -56,6 +56,6 @@
 
   <!-- host startcom.org responds neither on 80 nor on 443,
     but should be protected from MitM and redirected to https://www.startcom.org -->
-  <rule from="^http://startcom\.org/" to="https://www.startcom.org/" />
+  <rule from="^http://startcom\.org/*" to="https://www.startcom.org/" />
   <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/StartCom.xml
+++ b/src/chrome/content/rules/StartCom.xml
@@ -56,6 +56,6 @@
 
   <!-- host startcom.org responds neither on 80 nor on 443,
     but should be protected from MitM and redirected to https://www.startcom.org -->
-  <rule from="^http://startcom\.org" to="https://www.startcom.org" />
+  <rule from="^http://startcom\.org/*" to="https://www.startcom.org/" />
   <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/StartCom.xml
+++ b/src/chrome/content/rules/StartCom.xml
@@ -56,6 +56,6 @@
 
   <!-- host startcom.org responds neither on 80 nor on 443,
     but should be protected from MitM and redirected to https://www.startcom.org -->
-  <rule from="^http://startcom\.org/*" to="https://www.startcom.org/" />
+  <rule from="^http://startcom\.org" to="https://www.startcom.org" />
   <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/StartCom.xml
+++ b/src/chrome/content/rules/StartCom.xml
@@ -46,7 +46,6 @@
   <test url="http://forum.startcom.org/" />
   
   <test url="http://www.startssl.com/" />
-  <!-- url="http://auth.startssl.com/" host doesn't respond -->
   <test url="http://www.startssl.net/" />
   <test url="http://www.startssl.org/" />
   <test url="http://www.startssl.eu/" />
@@ -56,6 +55,6 @@
 
   <!-- host startcom.org responds neither on 80 nor on 443,
     but should be protected from MitM and redirected to https://www.startcom.org -->
-  <rule from="^http://startcom\.org/*" to="https://www.startcom.org/" />
+  <rule from="^http://startcom\.org/" to="https://www.startcom.org/" />
   <rule from="^http:" to="https:" />
 </ruleset>


### PR DESCRIPTION
This rule should not be disabled. The checker encounters an error at https://auth.startssl.com/ because it requires a client certificate for the handshake to complete, but this does not mean that https-everywhere should not include this rule. Is there a way to override this error?

Thanks!