### PR TITLE
[Andover.edu] Should not be disabled

### DIFF
--- a/src/chrome/content/rules/Phillips_Academy_Andover.xml
+++ b/src/chrome/content/rules/Phillips_Academy_Andover.xml
@@ -1,6 +1,5 @@
 <ruleset name="Phillips Academy">
 
-	<target host="andover.edu" />
 	<target host="www.andover.edu" />
 	<target host="panet.andover.edu" />
 	<target host="canvas.andover.edu" />
@@ -11,16 +10,24 @@
 	<target host="student.andover.edu" />
 	<target host="patechmasters.com" />
 	<target host="*.patechmasters.com" />
-
-	<!-- These are internal hosts or require special ports, but can still use protection: -->
-	<target host="printon.andover.edu" />
+	
+	
+	<!-- andover.edu does not respond, but should be redirected to https://www.andover.edu to prevent MitM. -->
+	<target host="andover.edu" />
+	
+	<!-- mail.andover.edu returns an error, but should be included to protect mail.andover.edu/owa -->
 	<target host="mail.andover.edu" />
-	<target host="sslvpn.andover.edu" />
 	
 	<securecookie host=".+" name=".+" />
 	
-	<rule from="^http://andover\.edu/"
+	<!-- redirects andover.edu to https://www.andover.edu -->
+	<rule from="^http://andover\.edu"
 		to="https://www.andover.edu/" />
+	
+	<!-- redirects http://mail.andover.edu/ (with or without "/") to https://mail.andover.edu/owa -->
+	<rule from="^http://mail\.andover\.edu/*$"
+		to="https://mail.andover.edu/owa" />
+
 	<rule from="^http:"
 		to="https:" />
 

--- a/src/chrome/content/rules/Phillips_Academy_Andover.xml
+++ b/src/chrome/content/rules/Phillips_Academy_Andover.xml
@@ -1,31 +1,25 @@
-
-<!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://printon.andover.edu/ => https://printon.andover.edu/: (6, 'Could not resolve host: printon.andover.edu')
-Fetch error: http://mail.andover.edu/ => https://mail.andover.edu/: (60, 'SSL certificate problem: certificate has expired')
-Fetch error: http://sslvpn.andover.edu/ => https://sslvpn.andover.edu/: (28, 'Connection timed out after 10001 milliseconds')
-
-	Phillips Academy Andover
-
--->
-<ruleset name="Phillips Academy" default_off='failed ruleset test'>
+<ruleset name="Phillips Academy">
 
 	<target host="www.andover.edu" />
 	<target host="panet.andover.edu" />
 	<target host="canvas.andover.edu" />
 	<target host="colwizlive.andover.edu" />
-	<target host="printon.andover.edu" />
 	<target host="sso.andover.edu" />
 	<target host="studentreports.andover.edu" />
-	<target host="mail.andover.edu" />
-	<target host="sslvpn.andover.edu" />
 	<target host="mypassword.andover.edu" />
 	<target host="student.andover.edu" />
 	<target host="patechmasters.com" />
 	<target host="*.patechmasters.com" />
+
+	<!-- These are internal hosts or require special ports, but can still use protection: -->
+	<target host="printon.andover.edu" />
+	<target host="mail.andover.edu" />
+	<target host="sslvpn.andover.edu" />
 	
 	<securecookie host=".+" name=".+" />
-
+	
+	<rule from="^http://andover\.edu/"
+		to="https://www.andover.edu/" />
 	<rule from="^http:"
 		to="https:" />
 

--- a/src/chrome/content/rules/Phillips_Academy_Andover.xml
+++ b/src/chrome/content/rules/Phillips_Academy_Andover.xml
@@ -1,5 +1,6 @@
 <ruleset name="Phillips Academy">
 
+	<target host="andover.edu" />
 	<target host="www.andover.edu" />
 	<target host="panet.andover.edu" />
 	<target host="canvas.andover.edu" />


### PR DESCRIPTION
This rule should not be disabled. The checker encounters an error at three hosts because they either require special ports to access or are on an internal network, but this does not mean that https-everywhere should not include this rule set. Is there a way to override this error?

Thanks!