### PR TITLE
New rule computerguard.de

### DIFF
--- a/src/chrome/content/rules/Threema.xml
+++ b/src/chrome/content/rules/Threema.xml
@@ -1,5 +1,18 @@
 <ruleset name="Threema">
-<target host="*.threema.ch" />
-<target host="threema.ch" />
-<rule from="^http://(shop\.|www\.)?threema\.ch/" to="https://$1threema.ch/"/>
+    <target host="threema.ch" />
+    <target host="www.threema.ch" />
+    <target host="gateway.threema.ch" />
+    <target host="shop.threema.ch" />
+    <target host="myid.threema.ch" />
+
+    <test url="http://threema.ch/en/whats-new" />
+    <test url="http://www.threema.ch/" />
+    <test url="http://gateway.threema.ch/en/developer/api" />
+    <test url="http://shop.threema.ch/download" />
+    <test url="http://myid.threema.ch/revoke" />
+
+    <securecookie host="^(www.|gateway.|shop\.|myid.)?threema\.ch/$" name=".+" />
+
+    <rule from="^http:"
+            to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Threema.xml
+++ b/src/chrome/content/rules/Threema.xml
@@ -1,18 +1,5 @@
 <ruleset name="Threema">
-    <target host="threema.ch" />
-    <target host="www.threema.ch" />
-    <target host="gateway.threema.ch" />
-    <target host="shop.threema.ch" />
-    <target host="myid.threema.ch" />
-
-    <test url="http://threema.ch/en/whats-new" />
-    <test url="http://www.threema.ch/" />
-    <test url="http://gateway.threema.ch/en/developer/api" />
-    <test url="http://shop.threema.ch/download" />
-    <test url="http://myid.threema.ch/revoke" />
-
-    <securecookie host="^(www.|gateway.|shop\.|myid.)?threema\.ch/$" name=".+" />
-
-    <rule from="^http:"
-            to="https:" />
+<target host="*.threema.ch" />
+<target host="threema.ch" />
+<rule from="^http://(shop\.|www\.)?threema\.ch/" to="https://$1threema.ch/"/>
 </ruleset>

--- a/src/chrome/content/rules/computerguard.xml
+++ b/src/chrome/content/rules/computerguard.xml
@@ -18,7 +18,7 @@
 	<test url="http://www.computerguard.de/threads/willkommen-bei-computerguard-deinem-computer-und-security-forum.9550/" />
 	<test url="http://computerguard.de/threads/unser-security-forum-ist-jetzt-noch-sicherer-https-rocks.9590/" />
 	<test url="http://www.computerguard.de/forums/eset-allgemein.851/" />
-	<test url="https://www.computerguard.de/members/" />
+	<test url="http://www.computerguard.de/members/" />
 
 	<rule from="^http:"
 		to="https:" />

--- a/src/chrome/content/rules/computerguard.xml
+++ b/src/chrome/content/rules/computerguard.xml
@@ -1,0 +1,25 @@
+<!--
+	author notes:
+		Mixed content:
+			As we are a forum some images may be loaded from other websites with unsecured connections. This is intended and cannot be solved.
+			We are encouraging all users to host their files on our own web space with just uploading it on our forum or use HTTPS-enabled image hosters.
+		
+		Contact:
+			In case of any issue you can contact us at webmaster <at> computerguard.de.
+		
+		~~ rugk, administrator of Computerguard.de
+-->
+<ruleset name="Computerguard.de Security Forum">
+	<target host="computerguard.de" />
+	<target host="www.computerguard.de" />
+
+  	<securecookie host="^(www\.)?computerguard\.de$" name=".+" />
+	
+	<test url="http://www.computerguard.de/threads/willkommen-bei-computerguard-deinem-computer-und-security-forum.9550/" />
+	<test url="http://computerguard.de/threads/unser-security-forum-ist-jetzt-noch-sicherer-https-rocks.9590/" />
+	<test url="http://www.computerguard.de/forums/eset-allgemein.851/" />
+	<test url="https://www.computerguard.de/members/" />
+
+	<rule from="^http:"
+		to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/computerguard.xml
+++ b/src/chrome/content/rules/computerguard.xml
@@ -2,7 +2,7 @@
 	author notes:
 		Mixed content:
 			As we are a forum some images may be loaded from other websites with unsecured connections. This is intended and cannot be solved.
-			We are encouraging all users to host their files on our own web space with just uploading it on our forum or use HTTPS-enabled image hosters.
+			We are encouraging all users to host their files on our own web space by just uploading it on our forum or use HTTPS-enabled image hosters.
 		
 		Contact:
 			In case of any issue you can contact us at webmaster <at> computerguard.de.


### PR DESCRIPTION
As a security forum we recently enabled HTTPS on [our website] (https://www.computerguard.de/).
Now we think it would be a good idea to include us in HTTPS-Everywhere.

Just a small note: As we allow including images from outer sources some users choose http:// image host and so mixed content errors can occur. However this is quite rarely and we always encourage our users to host the images on https sites or on our own forum to prevent this.
I've also described this in the comments of this rule.
But this is not really a problem as most of today's browsers does not block mixed content images anyway.