### PR TITLE
[Andover.edu] Fix mail.andover.edu rule

### DIFF
--- a/src/chrome/content/rules/Phillips_Academy_Andover.xml
+++ b/src/chrome/content/rules/Phillips_Academy_Andover.xml
@@ -18,6 +18,11 @@
 	<!-- mail.andover.edu returns an error, but should be included to protect mail.andover.edu/owa -->
 	<target host="mail.andover.edu" />
 	
+	<test url="http://andover.edu" />
+	<test url="http://andover.edu/" />
+	<test url="http://mail.andover.edu" />
+	<test url="http://mail.andover.edu/" />
+	 
 	<securecookie host=".+" name=".+" />
 	
 	<!-- redirects andover.edu to https://www.andover.edu -->

--- a/src/chrome/content/rules/Phillips_Academy_Andover.xml
+++ b/src/chrome/content/rules/Phillips_Academy_Andover.xml
@@ -20,7 +20,6 @@
 	<target host="mail.andover.edu" />
 		-->
 	
-	<test url="http://andover.edu" />
 	<test url="http://andover.edu/" />
 	 
 	<securecookie host=".+" name=".+" />

--- a/src/chrome/content/rules/Phillips_Academy_Andover.xml
+++ b/src/chrome/content/rules/Phillips_Academy_Andover.xml
@@ -26,12 +26,15 @@
 	<securecookie host=".+" name=".+" />
 	
 	<!-- redirects andover.edu to https://www.andover.edu -->
-	<rule from="^http://andover\.edu/*"
+	<rule from="^http://andover\.edu/"
 		to="https://www.andover.edu/" />
 	
+	
 	<!-- redirects http://mail.andover.edu/ (with or without "/") to https://mail.andover.edu/owa -->
+	<!-- commented out until 'no-test' attribute is available
 	<rule from="^http://mail\.andover\.edu/*$"
 		to="https://mail.andover.edu/owa" />
+		-->
 
 	<rule from="^http:"
 		to="https:" />

--- a/src/chrome/content/rules/Phillips_Academy_Andover.xml
+++ b/src/chrome/content/rules/Phillips_Academy_Andover.xml
@@ -1,14 +1,3 @@
-<!--
-	Phillips Academy Andover
-
-
-	Problematic hosts in *andover.edu:
-
-		- mail *
-
-	* Expired
-
--->
 <ruleset name="Phillips Academy">
 
 	<target host="www.andover.edu" />
@@ -17,13 +6,27 @@
 	<target host="colwizlive.andover.edu" />
 	<target host="sso.andover.edu" />
 	<target host="studentreports.andover.edu" />
-	<!--target host="mail.andover.edu" /-->
 	<target host="mypassword.andover.edu" />
 	<target host="student.andover.edu" />
 	<target host="patechmasters.com" />
 	<target host="*.patechmasters.com" />
 	
+	
+	<!-- andover.edu does not respond, but should be redirected to https://www.andover.edu to prevent MitM. -->
+	<target host="andover.edu" />
+	
+	<!-- mail.andover.edu returns an error, but should be included to protect mail.andover.edu/owa -->
+	<target host="mail.andover.edu" />
+	
 	<securecookie host=".+" name=".+" />
+	
+	<!-- redirects andover.edu to https://www.andover.edu -->
+	<rule from="^http://andover\.edu"
+		to="https://www.andover.edu/" />
+	
+	<!-- redirects http://mail.andover.edu/ (with or without "/") to https://mail.andover.edu/owa -->
+	<rule from="^http://mail\.andover\.edu/*$"
+		to="https://mail.andover.edu/owa" />
 
 	<rule from="^http:"
 		to="https:" />

--- a/src/chrome/content/rules/Phillips_Academy_Andover.xml
+++ b/src/chrome/content/rules/Phillips_Academy_Andover.xml
@@ -22,8 +22,6 @@
 	
 	<test url="http://andover.edu" />
 	<test url="http://andover.edu/" />
-	<test url="http://mail.andover.edu" />
-	<test url="http://mail.andover.edu/" />
 	 
 	<securecookie host=".+" name=".+" />
 	
@@ -36,6 +34,9 @@
 	<!-- commented out until 'no-test' attribute is available
 	<rule from="^http://mail\.andover\.edu/*$"
 		to="https://mail.andover.edu/owa" />
+		
+	<test url="http://mail.andover.edu" />
+	<test url="http://mail.andover.edu/" />
 		-->
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/Phillips_Academy_Andover.xml
+++ b/src/chrome/content/rules/Phillips_Academy_Andover.xml
@@ -11,6 +11,7 @@
 	<target host="patechmasters.com" />
 	<target host="*.patechmasters.com" />
 	
+	<target host="sslvpn.andover.edu:10443" />
 	
 	<!-- andover.edu does not respond, but should be redirected to https://www.andover.edu to prevent MitM. -->
 	<target host="andover.edu" />
@@ -21,7 +22,7 @@
 	<securecookie host=".+" name=".+" />
 	
 	<!-- redirects andover.edu to https://www.andover.edu -->
-	<rule from="^http://andover\.edu"
+	<rule from="^http://andover\.edu/*"
 		to="https://www.andover.edu/" />
 	
 	<!-- redirects http://mail.andover.edu/ (with or without "/") to https://mail.andover.edu/owa -->

--- a/src/chrome/content/rules/Phillips_Academy_Andover.xml
+++ b/src/chrome/content/rules/Phillips_Academy_Andover.xml
@@ -11,7 +11,6 @@
 	<target host="patechmasters.com" />
 	<target host="*.patechmasters.com" />
 	
-	<target host="sslvpn.andover.edu:10443" />
 	
 	<!-- andover.edu does not respond, but should be redirected to https://www.andover.edu to prevent MitM. -->
 	<target host="andover.edu" />

--- a/src/chrome/content/rules/Phillips_Academy_Andover.xml
+++ b/src/chrome/content/rules/Phillips_Academy_Andover.xml
@@ -16,7 +16,9 @@
 	<target host="andover.edu" />
 	
 	<!-- mail.andover.edu returns an error, but should be included to protect mail.andover.edu/owa -->
+	<!-- commented out until 'no-test' attribute is available
 	<target host="mail.andover.edu" />
+		-->
 	
 	<test url="http://andover.edu" />
 	<test url="http://andover.edu/" />


### PR DESCRIPTION
Continuation of pull request #2023. Attempts to fix the mail.andover.edu rule and adds a new rule for the root domain.

Please note that https://mail.andover.edu/owa requires login credentials, and thus may cause the rule to fail checks by the automatic checker. This is similar to #2022, where the website requires authentication with a client certificate.