### PR TITLE
Improve Unhosted.xml

### DIFF
--- a/src/chrome/content/rules/Unhosted.xml
+++ b/src/chrome/content/rules/Unhosted.xml
@@ -1,16 +1,21 @@
 <!--
 	Problematic subdomains:
 
-		- www		(prints "See https://unhosted.org/")
+		- www		(self-signed)
 
 -->
-<ruleset name="Unhosted ">
+<ruleset name="Unhosted">
 
 	<target host="unhosted.org" />
-	<target host="*.unhosted.org" />
+	<target host="www.unhosted.org" />
+	<target host="apps.unhosted.org" />
 
+	<rule from="^http://www\.unhosted\.org/"
+		to="https://unhosted.org/" />
 
-	<rule from="^http://(?:(apps\.)|www\.)?unhosted\.org/"
-		to="https://$1unhosted.org/" />
+		<test url="http://unhosted.org/" />
+
+	<rule from="^http:" 
+		to="https:" />
 
 </ruleset>


### PR DESCRIPTION
The site's SSL cert is only valid for unhosted.org and apps.unhosted.org, so *.unhosted.org is dropped. There is also redirect rule for www.unhosted.org because it presents self-signed cert.