### PR TITLE
Added policies.tilt.com to exclusion pattern

### DIFF
--- a/src/chrome/content/rules/Tilt.com.xml
+++ b/src/chrome/content/rules/Tilt.com.xml
@@ -24,10 +24,11 @@
 	<target host="tilt.com" />
 	<target host="*.tilt.com" />
 
-		<exclusion pattern="^http://(?:engineering|stories)\.tilt\.com" />
+		<exclusion pattern="^http://(?:engineering|stories|policies)\.tilt\.com" />
 
 			<test url="http://engineering.tilt.com/" />
 			<test url="http://stories.tilt.com/" />
+			<test url="http://policies.tilt.com/" />
 
 		<test url="http://blog.tilt.com/" />
 		<test url="http://open.tilt.com/" />


### PR DESCRIPTION
I work at tilt.com, and we just added this new domain (hosted on a third party, so we cannot provide SSL).