### PR TITLE
Add northeast.* and scotland.* subdomains

### DIFF
--- a/src/chrome/content/rules/Open_Rights_Group.xml
+++ b/src/chrome/content/rules/Open_Rights_Group.xml
@@ -24,6 +24,8 @@
 	<target host="wiki.openrightsgroup.org" />
 	<target host="www.openrightsgroup.org" />
 	<target host="zine.openrightsgroup.org" />
+	<target host="northeast.openrightsgroup.org" />
+	<target host="scotland.openrightsgroup.org" />
 
 
 	<!--	Not secured by server:


### PR DESCRIPTION
Proposed edit to add northeast.openrightsgroup.org and scotland.openrightsgroup.org subdomains to preexisting ruleset.