### PR TITLE
Remove podbean mixcontent & subdomains

### DIFF
--- a/src/chrome/content/rules/Podbean.com.xml
+++ b/src/chrome/content/rules/Podbean.com.xml
@@ -1,17 +1,7 @@
-<ruleset name="Podbean.com (partial)">
+<ruleset name="Podbean.com (partial)" platform="mixedcontent">
 
 	<target host="podbean.com" />
-	<target host="*.podbean.com" />
-		<!--
-			At least media57 504s
-
-			Only hosts images & audio files
-							-->
-		<exclusion pattern="^http://media\d+\." />
-
-
-	<securecookie host="^(?:.*\.)?podbean\.com$" name=".+" />
-
+	<target host="www.podbean.com" />
 
 	<rule from="^http://(\w+\.)?podbean\.com/"
 		to="https://$1podbean.com/" />


### PR DESCRIPTION
The site isn't displayed correctly due to content being blocked on browsers that block mixed-content content and on many other podcast sites (such as pagebreakpodcast.com) the podcast doesn't load with no indication that the cause is https everywhere.

![screen shot 2015-07-07 at 8 10 21 pm](https://cloud.githubusercontent.com/assets/2470152/8562205/3d9518d4-24e4-11e5-89e9-22bc2094bddd.png)
![screen shot 2015-07-07 at 7 21 39 pm](https://cloud.githubusercontent.com/assets/2470152/8562206/3e686810-24e4-11e5-85fc-8df11f584043.png)