### PR TITLE
exclusion for wacken.com anfahrt-widget

### DIFF
--- a/src/chrome/content/rules/Wacken.com.xml
+++ b/src/chrome/content/rules/Wacken.com.xml
@@ -12,4 +12,6 @@
 
 	<rule from="^http:"
 		to="https:" />
+	<!-- https breaks the widget -->
+	<exclusion pattern="^http:\/\/www\.wacken\.com\/anfahrt-widget\/index-(de|en)\.php" />
 </ruleset>

--- a/src/chrome/content/rules/Wacken.com.xml
+++ b/src/chrome/content/rules/Wacken.com.xml
@@ -13,7 +13,7 @@
 	<rule from="^http:"
 		to="https:" />
 	<!-- https breaks the widget -->
-	<exclusion pattern="^http:\/\/www\.wacken\.com\/anfahrt-widget\/index-(de|en)\.php" />
- 		<test url="http://www.wacken.com/anfahrt-widget/index-de.php" />
-    	<test url="http://www.wacken.com/anfahrt-widget/index-en.php" />
+	<exclusion pattern="^http://www\.wacken\.com/anfahrt-widget/index-(de|en)\.php" />
+		<test url="http://www.wacken.com/anfahrt-widget/index-de.php" />
+		<test url="http://www.wacken.com/anfahrt-widget/index-en.php" />
 </ruleset>

--- a/src/chrome/content/rules/Wacken.com.xml
+++ b/src/chrome/content/rules/Wacken.com.xml
@@ -14,4 +14,6 @@
 		to="https:" />
 	<!-- https breaks the widget -->
 	<exclusion pattern="^http:\/\/www\.wacken\.com\/anfahrt-widget\/index-(de|en)\.php" />
+ 		<test url="http://www.wacken.com/anfahrt-widget/index-de.php" />
+    	<test url="http://www.wacken.com/anfahrt-widget/index-en.php" />
 </ruleset>


### PR DESCRIPTION
the travel planning widget for the Wacken festival does not work with https, I added an exclusion. The festival will take place from July 30 to August 1, 2015, so please merge this soon.