### PR TITLE
install-dev-dependencies: make packages installable on Debian

### DIFF
--- a/install-dev-dependencies.sh
+++ b/install-dev-dependencies.sh
@@ -3,8 +3,15 @@
 # HTTPS Everywhere
 set -o errexit -o xtrace
 if type apt-get >/dev/null ; then
+  BROWSERS="firefox chromium-browser"
+  if [[ "$(lsb_release -is)" == "Debian" ]]; then
+    # Iceweasel is the rebranded Firefox that Debian ships, and Chromium
+    # takes the name of 'chromium' instead of 'chromium-browser' in
+    # Debian 7 (wheezy) and later.
+    BROWSERS="iceweasel chromium"
+  fi
   sudo apt-get install libxml2-dev libxml2-utils libxslt1-dev python-dev \
-    firefox chromium-browser zip sqlite3 python-pip libcurl4-openssl-dev
+    $BROWSERS zip sqlite3 python-pip libcurl4-openssl-dev
 elif type brew >/dev/null ; then
   brew list python &>/dev/null || brew install python
   brew install libxml2 gnu-sed


### PR DESCRIPTION
On Debian, Chromium uses the package name `chromium` instead of `chromium-browser`, and a rebranded version of Firefox, Iceweasel, is shipped instead. (`/usr/bin/firefox` is a wrapper to `iceweasel`, so command line names don't need any changing afaik; only this.)