### PR TITLE
[PDF.yt] Add www again

### DIFF
--- a/src/chrome/content/rules/PDF.yt.xml
+++ b/src/chrome/content/rules/PDF.yt.xml
@@ -1,12 +1,7 @@
-<!--
-	Nonfunctional subdomains:
-
-		- www	(times out)
-
--->
 <ruleset name="PDF.yt">
 
 	<target host="pdf.yt" />
+	<target host="www.pdf.yt" />
 
 
 	<!--	Not secured by server:


### PR DESCRIPTION
We removed `www` last month because it didn't work; now it works again.