### PR TITLE
[Wikimedia.xml] No need to exclude lists.wikimedia.org

### DIFF
--- a/src/chrome/content/rules/Wikimedia.xml
+++ b/src/chrome/content/rules/Wikimedia.xml
@@ -53,10 +53,6 @@ Disabled by https-everywhere-checker because:
 			<test url="http://torrus.wikimedia.org" />
 			<test url="http://ubuntu.wikimedia.org" />
 
-		<exclusion pattern="^http://lists\.wikimedia\.org/pipermail(?:$|/)" />
-			<test url="http://lists.wikimedia.org/pipermail" />
-			<test url="http://lists.wikimedia.org/pipermail/" />
-
 	<target host="wikimediafoundation.org" />
 	<target host="www.wikimediafoundation.org" />
 


### PR DESCRIPTION
lists.wikimedia.org now supports HTTPS for the whole site, and it has enabled HSTS. e.g. https://lists.wikimedia.org/pipermail/commons-l/. See also https://www.ssllabs.com/ssltest/analyze.html?d=lists.wikimedia.org&latest.