### PR TITLE
[GMX.xml] Update ruleset

### DIFF
--- a/src/chrome/content/rules/GMX.xml
+++ b/src/chrome/content/rules/GMX.xml
@@ -1,66 +1,59 @@
 <!--
+
 	For other United Internet coverage, see United-Internet.xml.
 
 
-		CDN buckets:
-
-			- gmx.con-tech.de
-
-				- kino.gmx.de
-
-			- gmx.ivwbox.de
-
+	CDN buckets:
+		- gmx.con-tech.de
+		- kino.gmx.de
+		- gmx.ivwbox.de
 
 	Nonfunctional domains:
+		- kino.gmx.de			(redirects to www.govento.de; mismatched, CN: ct-cds.con-tech.de)
 
-		- kino.gmx.de		(redirects to www.govento.de; mismatched, CN: ct-cds.con-tech.de)
-		- newsroom.gmx.net	(refused)
-		- finanzvergleich (refused)
-		- gutscheine (diffrent host)
-		- media (refused)
-		- postmaster (timeout)
-		- video (redirect)
+		- gmx.net subdomains:
+			- newsroom		(refused)
+			- finanzvergleich	(refused)
+			- gutscheine		(timeout)
+			- media			(unknown protocol)
+			- postmaster		(timeout)
 
+		- gmx.com subdomains:
+			- (www.)		(MCB)
+			- i[0-9]		(diffrent host, causes MCB at (www.)gmx.com)
+			- postmaster		(timeout)
+			- search		(refused)
 
 	Fully covered domains:
 
-		- (www.)gmx.at		(^ → www)
+		- (www.)gmx.at		(→ www.gmx.ch)
 		- (www.)gmx.ca		(→ www.gmx.com)
 		- (www.)gmx.ch		(^ → www)
 		- (www.)gmx.co.uk	(^ → www)
 
 		- gmx.com subdomains:
-
 			- (www.)	(^ → www)
 			- help
-			- images
 			- organizer
 			- service
 			- storage-file-eu
 
-		- (www.)gmx.de		(→ www.gmx.net)
+		- (www.)gmx.de		(→ www.gmx.ch)
 		- mobile.gmx.de
 		- (www.)gmx.fr		(^ → www)
 		- (www.)gmx.it		(→ www.gmx.com)
 
 		- gmx.net subdomains:
 
-			- (www.)	(^ → www)
-			- dl
+			- (www.)	(→ www.gmx.ch)
 			- hilfe
-			- images
-			- img
-			- js
 			- kontakt
 			- lotto
 			- mailings
-			- mailxchange
-			- registrierung
 			- millionenklick
 			- passwort
 			- registrierung
-			- sec-i0
-			- service
+			- service	(→ www.gmx.ch)
 			- suche
 			- vorteile
 
@@ -68,12 +61,10 @@
 		- (www.)gmx.se		(→ www.gmx.com)
 
 	Observed cookie domains:
-
-		- .gmx.de
+		- (www.)gmx.de
 		- mobile.gmx.de
 
 		- gmx.net subdomains:
-
 			- .
 			- .suche
 			- service
@@ -81,97 +72,72 @@
 			- .www
 
 -->
-<ruleset name="GMX">
-	<target host="gmx.*" />
-	<target host="www.gmx.*" />
-	<target host="gmx.co.uk"/>
-	<target host="www.gmx.co.uk" />
-	<target host="*.gmx.com" />
-	<target host="mobile.gmx.de" />
-	<target host="*.gmx.net" />
-
-	<test url="http://gmx.com/" />
-	<test url="http://help.gmx.com/" />
-	<test url="http://images.gmx.com/" />
-	<test url="http://organizer.gmx.com/" />
-	<test url="http://postmaster.gmx.com/" />
-	<test url="http://storage-file-eu.gmx.com/" />
-	<test url="http://search.gmx.com/" />
-	<test url="http://service.gmx.com/" />
-	<test url="http://www.gmx.com/" />
-	<test url="http://gmx.net/" />
-	<test url="http://dl.gmx.net/" />
-	<test url="http://finanzvergleich.gmx.net/" />
-	<test url="http://gutscheine.gmx.net/" />
-	<test url="http://hilfe.gmx.net/" />
-	<test url="http://images.gmx.net/" />
-	<test url="http://img.gmx.net/" />
-	<test url="http://js.gmx.net/" />
-	<test url="http://kontakt.gmx.net/" />
-	<test url="http://lotto.gmx.net/" />
-	<test url="http://mailings.gmx.net/" />
-	<test url="http://mailxchange.gmx.net/" />
-	<test url="http://millionenklick.gmx.net/" />
-	<test url="http://media.gmx.net/" />
-	<test url="http://newsroom.gmx.net/" />
-	<test url="http://passwort.gmx.net" />
-	<test url="http://postmaster.gmx.net/" />
-	<test url="http://registrierung.gmx.net/" />
-	<test url="http://sec-i0.gmx.net/" />
-	<test url="http://service.gmx.net/" />
-	<test url="http://suche.gmx.net/" />
-	<test url="http://video.gmx.net/" />
-	<test url="http://vorteile.gmx.net/" />
-	<test url="http://www.gmx.net/" />
-	<test url="http://gmx.ca/" />
-	<test url="http://www.gmx.ca/" />
-	<test url="http://gmx.se/" />
-	<test url="http://www.gmx.se/" />
-	<test url="http://gmx.ru/" />
-	<test url="http://www.gmx.ru/" />
-	<test url="http://gmx.at/" />
-	<test url="http://www.gmx.at/" />
-	<test url="http://gmx.ch/" />
-	<test url="http://www.gmx.ch/" />
-	<test url="http://gmx.co.uk/" />
-	<test url="http://www.gmx.co.uk/" />
-	<test url="http://gmx.fr/" />
-	<test url="http://www.gmx.fr/" />
-	<test url="http://gmx.de/" />
-	<test url="http://www.gmx.de/" />
-
-	<exclusion pattern="http://postmaster\.gmx\.com/" />
-	<exclusion pattern="http://finanzvergleich\.gmx\.net/" />
-	<exclusion pattern="http://gutscheine\.gmx\.net/" />
-	<exclusion pattern="http://media\.gmx\.net/" />
-	<exclusion pattern="http://newsroom\.gmx\.net/" />
-	<exclusion pattern="http://postmaster\.gmx\.net/" />
-	<exclusion pattern="http://video\.gmx\.net/" />
+<ruleset name="GMX (partial)">
+	<!-- MCB issue
+	<target host=                "gmx.com" />
+	<target host=            "www.gmx.com" />-->
+	<target host=           "help.gmx.com" />
+	<target host=      "organizer.gmx.com" />
+	<target host="storage-file-eu.gmx.com" />
+	<target host=        "service.gmx.com" />
+	<target host=                "gmx.net" />
+	<target host=            "www.gmx.net" />
+	<target host=          "hilfe.gmx.net" />
+	<target host=        "kontakt.gmx.net" />
+	<target host=          "lotto.gmx.net" />
+	<target host=       "mailings.gmx.net" />
+	<target host= "millionenklick.gmx.net" />
+	<target host=       "passwort.gmx.net" />
+	<target host=  "registrierung.gmx.net" />
+	<target host=        "service.gmx.net" />
+	<target host=          "suche.gmx.net" />
+	<target host=       "vorteile.gmx.net" />
+	<target host=                "gmx.co.uk"/>
+	<target host=            "www.gmx.co.uk" />
+	<target host=                "gmx.ca"/>
+	<target host=            "www.gmx.ca" />
+	<target host=                "gmx.se"/>
+	<target host=            "www.gmx.se" />
+	<target host=                "gmx.ru"/>
+	<target host=            "www.gmx.ru" />
+	<target host=                "gmx.it"/>
+	<target host=            "www.gmx.it" />
+	<target host=                "gmx.at"/>
+	<target host=            "www.gmx.at" />
+	<target host=                "gmx.ch"/>
+	<target host=            "www.gmx.ch" />
+	<target host=                "gmx.fr"/>
+	<target host=            "www.gmx.fr" />
+	<target host=                "gmx.de" />
+	<target host=            "www.gmx.de" />
+	<target host=         "mobile.gmx.de" />
 
 	<!--securecookie host="^\.gmx\.de$" name="^(NG_USERID|ns_sample)$" /-->
 	<securecookie host="^mobile\.gmx\.de$" name=".+" />
 	<!--securecookie host="^\.gmx\.net$" name="^(emos_webde_sid|emos_webde_vid|ns_sample|ps-cid|psid|SSID|SSLB_P|SSRT|SSSC)$" /-->
 	<securecookie host="^(?:service|\.suche|\.?www)?\.gmx\.net$" name=".+" />
 
-	<!--	In countries like se, it, ca, and ru, www.gmx.cctld redirects
-		to www.gmx.com; we may as well secure that a bit but it should
-		work regardless of whether we got all of these countries.
-	-->
-	<rule from="^http://(www\.)?gmx\.(ca|it|se|ru)/"
+	<!-- MCB issue
+	<rule from="^http://(www\.)?gmx\.(ca|it|ru|se)/"
 		to="https://www.gmx.com/"/>
 
-	<!--	In these domains GMX supports SSL right at the homepage
+		<test url="http://www.gmx.com/" />-->
 
+	<!--	In these domains GMX supports SSL right at the homepage
 		https://gmx.com appears to work but hopefully
 		redirecting away won't break anything.
 	-->
-	<rule from="^http://gmx\.(at|ch|co\.uk|fr)/"
+	<rule from="^http://gmx\.(ch|co\.uk|fr)/"
 		to="https://www.gmx.$1/" />
 
-	<!--	gmx.de lives at gmx.net
+		<test url="http://www.gmx.ch/" />
+		<test url="http://www.gmx.co.uk/" />
+		<test url="http://www.gmx.fr/" />
+
+	<!--	follow server's behaviour
 					-->
-	<rule from="^http://(www\.)?gmx\.de/"
-		to="https://www.gmx.net/" />
+	<rule from="^http://(www\.|service\.)?gmx\.(at|de|net)/"
+		to="https://www.gmx.ch/" />
 	
 	<rule from="^http:"
 		to="https:" />

--- a/src/chrome/content/rules/GMX.xml
+++ b/src/chrome/content/rules/GMX.xml
@@ -9,7 +9,15 @@
 		- gmx.ivwbox.de
 
 	Nonfunctional domains:
-		- kino.gmx.de			(redirects to www.govento.de; mismatched, CN: ct-cds.con-tech.de)
+		- (www.)gmx.ca		(→ www.gmx.com)
+
+		- gmx.com subdomains:
+			- (www.)		(MCB)
+			- i[0-9]		(diffrent host, causes MCB at (www.)gmx.com)
+			- postmaster		(timeout)
+			- search		(refused)
+
+		- (www.)gmx.it		(→ www.gmx.com)
 
 		- gmx.net subdomains:
 			- newsroom		(refused)
@@ -18,21 +26,18 @@
 			- media			(unknown protocol)
 			- postmaster		(timeout)
 
-		- gmx.com subdomains:
-			- (www.)		(MCB)
-			- i[0-9]		(diffrent host, causes MCB at (www.)gmx.com)
-			- postmaster		(timeout)
-			- search		(refused)
+		- (www.)gmx.ru		(→ www.gmx.com)
+		- (www.)gmx.se		(→ www.gmx.com)
+		- kino.gmx.de		(redirects to www.govento.de; mismatched, CN: ct-cds.con-tech.de)
 
 	Fully covered domains:
-
 		- (www.)gmx.at		(→ www.gmx.ch)
-		- (www.)gmx.ca		(→ www.gmx.com)
+
 		- (www.)gmx.ch		(^ → www)
 		- (www.)gmx.co.uk	(^ → www)
 
 		- gmx.com subdomains:
-			- (www.)	(^ → www)
+			- (www.)		(^ → www)
 			- help
 			- organizer
 			- service
@@ -41,11 +46,9 @@
 		- (www.)gmx.de		(→ www.gmx.ch)
 		- mobile.gmx.de
 		- (www.)gmx.fr		(^ → www)
-		- (www.)gmx.it		(→ www.gmx.com)
 
 		- gmx.net subdomains:
-
-			- (www.)	(→ www.gmx.ch)
+			- (www.)		(→ www.gmx.ch)
 			- hilfe
 			- kontakt
 			- lotto
@@ -53,12 +56,9 @@
 			- millionenklick
 			- passwort
 			- registrierung
-			- service	(→ www.gmx.ch)
+			- service		(→ www.gmx.ch)
 			- suche
 			- vorteile
-
-		- (www.)gmx.ru		(→ www.gmx.com)
-		- (www.)gmx.se		(→ www.gmx.com)
 
 	Observed cookie domains:
 		- (www.)gmx.de
@@ -94,14 +94,6 @@
 	<target host=       "vorteile.gmx.net" />
 	<target host=                "gmx.co.uk"/>
 	<target host=            "www.gmx.co.uk" />
-	<target host=                "gmx.ca"/>
-	<target host=            "www.gmx.ca" />
-	<target host=                "gmx.se"/>
-	<target host=            "www.gmx.se" />
-	<target host=                "gmx.ru"/>
-	<target host=            "www.gmx.ru" />
-	<target host=                "gmx.it"/>
-	<target host=            "www.gmx.it" />
 	<target host=                "gmx.at"/>
 	<target host=            "www.gmx.at" />
 	<target host=                "gmx.ch"/>
@@ -111,13 +103,22 @@
 	<target host=                "gmx.de" />
 	<target host=            "www.gmx.de" />
 	<target host=         "mobile.gmx.de" />
+	<!-- gmx.com MCB issue
+	<target host=                "gmx.ca"/>
+	<target host=            "www.gmx.ca" />
+	<target host=                "gmx.it"/>
+	<target host=            "www.gmx.it" />
+	<target host=                "gmx.ru"/>
+	<target host=            "www.gmx.ru" />
+	<target host=                "gmx.se"/>
+	<target host=            "www.gmx.se" />-->
 
 	<!--securecookie host="^\.gmx\.de$" name="^(NG_USERID|ns_sample)$" /-->
 	<securecookie host="^mobile\.gmx\.de$" name=".+" />
 	<!--securecookie host="^\.gmx\.net$" name="^(emos_webde_sid|emos_webde_vid|ns_sample|ps-cid|psid|SSID|SSLB_P|SSRT|SSSC)$" /-->
 	<securecookie host="^(?:service|\.suche|\.?www)?\.gmx\.net$" name=".+" />
 
-	<!-- MCB issue
+	<!-- gmx.com MCB issue
 	<rule from="^http://(www\.)?gmx\.(ca|it|ru|se)/"
 		to="https://www.gmx.com/"/>
 


### PR DESCRIPTION
Excludes gmx.com due to MCB #1895
Removes `*` and unnecessary `test url`. Update subdomain and TLD.
Excludes .ca .it .ru .se as they redirect to gmx.com