### PR TITLE
[Wikimedia.xml] Include subdomains

### DIFF
--- a/src/chrome/content/rules/Wikimedia.xml
+++ b/src/chrome/content/rules/Wikimedia.xml
@@ -39,7 +39,7 @@ Disabled by https-everywhere-checker because:
 	<target host="frwp.org" />
 
 	<target host="mediawiki.org" />
-	<target host="www.mediawiki.org" />
+	<target host="*.mediawiki.org" />
 	<target host="wikimedia.org" />
 	<target host="*.wikimedia.org" />
 		<exclusion pattern="^http://(?:apt|cs|cz|parsoid-lb\.eqiad|smokeping|status|torrus|ubuntu)\.wikimedia\.org" />
@@ -54,7 +54,7 @@ Disabled by https-everywhere-checker because:
 			<test url="http://ubuntu.wikimedia.org" />
 
 	<target host="wikimediafoundation.org" />
-	<target host="www.wikimediafoundation.org" />
+	<target host="*.wikimediafoundation.org" />
 
 	<!-- Wikimedia projects (also some wikimedia.org subdomains) -->
 	<target host="wikibooks.org" />
@@ -104,6 +104,8 @@ Disabled by https-everywhere-checker because:
 	<test url="http://www.wikidata.org" />
 	<test url="http://www.wikimedia.org" />
 	<test url="http://www.wikimediafoundation.org" />
+	<test url="http://m.wikimediafoundation.org" />
+	<test url="http://m.mediawiki.org" />
 
 	<!-- Wikimedia Tool Labs -->
 	<target host="tools.wmflabs.org" />


### PR DESCRIPTION
mediawiki.org and wikimediafoundation.org have subdomains other than www, and they all support HTTPS.

https://raw.githubusercontent.com/wikimedia/operations-dns/master/templates/wikimediafoundation.org
https://raw.githubusercontent.com/wikimedia/operations-dns/master/templates/mediawiki.org