### PR TITLE
Update Photosynth.xml

### DIFF
--- a/src/chrome/content/rules/Photosynth.xml
+++ b/src/chrome/content/rules/Photosynth.xml
@@ -1,30 +1,13 @@
 <!--
 	For other Microsoft coverage, see Microsoft.xml.
-
-
 -->
-<ruleset name="Photosynth.net" platform="mixedcontent">
+<ruleset name="Photosynth.net">
 
-	<!--	Direct rewrites:
-				-->
 	<target host="photosynth.net" />
 	<target host="www.photosynth.net" />
-
-	<!--	Complications:
-				-->
 	<target host="cdn.photosynth.net" />
 
-
 	<securecookie host="^(?:www\.)?photosynth\.net$" name=".*" />
-
-
-	<!--	cdn:
-			- Cert: *.sharepointonline.com
-			- Shows blank page over https
-				-LimeLight CDN?
-					-->
-	<rule from="^http://cdn\.photosynth\.net/"
-		to="https://photosynth.net/" />
 
 	<rule from="^http:"
 		to="https:" />


### PR DESCRIPTION
No more mixed content. Caught my attention after reading this [news](http://arstechnica.com/gadgets/2015/07/microsoft-killing-off-some-of-its-msn-apps-photosynth-app-this-fall/). Photosynth.net will continue so this ruleset still applies.