### PR TITLE
Improvements to Deviantart.xml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,20 @@
 # Config copied from
 #  http://www.theautomatedtester.co.uk/blog/2012/using-travis-ci-for-building-and-testing-firefox-addons.html
-# Use node_js because there are maybe more workers?
 language: python
 python:
   - "2.7"
+cache: pip
 addons:
+  apt:
+    packages:
+      - libxml2-dev
+      - python-dev
+      - libcurl4-openssl-dev
+      - python-lxml
   firefox: "37.0"
 virtualenv:
   system_site_packages: true
 install:
-  - sudo apt-get -qq install libxml2-dev libxslt-dev python-dev libcurl4-openssl-dev python-lxml
   - pip install -r https-everywhere-checker/requirements.txt
 before_script:
   - sh -e /etc/init.d/xvfb start
@@ -17,6 +22,7 @@ env:
   - DISPLAY=':99.0'
 script:
   - ./test.sh
+sudo: false
 notifications:
   email:
     recipients:

--- a/src/chrome/content/rules/Deviantart.xml
+++ b/src/chrome/content/rules/Deviantart.xml
@@ -47,7 +47,7 @@
 			Mustn't rewrite from https here, as doing so
 		would conflict with the first rule.
 								-->
-	<rule from="^http://([^/:@\.]+\.)?deviantart\.(?:com|net)/"
-		to="https://$1deviantart.com/" />
+	<rule from="^http://([^/:@\.]+\.)?deviantart\.(com|net)/"
+		to="https://$1deviantart.$2/" />
 
 </ruleset>


### PR DESCRIPTION
2nd rule would previously fail for deviantart.net because it changed the TLD to into deviantart.com. Added 2nd capture group like the first rule.