### PR TITLE
[Politiken.dk] Re-enabled; video streaming now fixed

### DIFF
--- a/src/chrome/content/rules/Politiken.dk.xml
+++ b/src/chrome/content/rules/Politiken.dk.xml
@@ -48,7 +48,7 @@
 	* Secured by us
 
 -->
-<ruleset name="Politiken.dk (partial)" default_off="Breaks streaming video">
+<ruleset name="Politiken.dk (mixed content)">
 
 	<!--	Direct rewrites:
 				-->


### PR DESCRIPTION
This ruleset was initially disabled as a result of it breaking the various kinds of video streaming on the page. After being made aware of this, the site devs fixed the underlying mixed content issue, so this ruleset is "safe" once again.

The entire page still serves a large amount of passive mixed content, whose redirection relies on the currently disabled ruleset in Pol.dk.xml. To the best of my knowledge, devs are currently working on fixing that as well.