### PR TITLE
[YTS.to] Revert "add new domain" (fixing the build!)

### DIFF
--- a/src/chrome/content/rules/YTS.to.xml
+++ b/src/chrome/content/rules/YTS.to.xml
@@ -5,8 +5,7 @@
   <target host="yts.to" />
 	<target host="axs.yts.to" />
   <target host="www.yts.to" />
-  <target host="s.ynet.io" />
-  
+
   <securecookie host="^.*\.yts\.to$" name=".+" />
 
   <rule from="^http:"


### PR DESCRIPTION
The domain, `s.ynet.io`, is a duplicate: someone else concurrently added it in `Ynet.io.xml` in fafaa2838c361a2e7a698ead200a14e3398286f6.

This reverts commit f0722e55a4f27f07fcb4585d6cdee09bf2c0970d.