### PR TITLE
[Paste2.org] Fix bad regexp.

### DIFF
--- a/src/chrome/content/rules/Paste2.org-falsemixed.xml
+++ b/src/chrome/content/rules/Paste2.org-falsemixed.xml
@@ -12,7 +12,7 @@
 
 	<!--	(avoiding cf_clearance <= mixed content)
 								-->
-	<securecookie host="^\.paste2\.org$" name="^(?:__cfduid|__qca$" />
+	<securecookie host="^\.paste2\.org$" name="^(?:__cfduid|__qca)$" />
 
 
 	<rule from="^http:"

--- a/utils/trivial-validate.py
+++ b/utils/trivial-validate.py
@@ -32,7 +32,8 @@ def fail(s):
 
 # Precompile xpath expressions that get run repeatedly.
 xpath_exclusion_pattern = etree.XPath("/ruleset/exclusion/@pattern")
-xpath_cookie_pattern = etree.XPath("/ruleset/securecookie/@host")
+xpath_cookie_host_pattern = etree.XPath("/ruleset/securecookie/@host")
+xpath_cookie_name_pattern = etree.XPath("/ruleset/securecookie/@name")
 
 # Load lists of ruleset names whitelisted for downgrade & duplicate rules
 thispath = os.path.dirname(os.path.realpath(__file__))
@@ -44,8 +45,9 @@ with open(thispath + '/duplicate-whitelist.txt') as duplicate_fh:
 
 def test_bad_regexp(tree, rulename, from_attrib, to):
     # Rules with invalid regular expressions.
-    """The 'from' rule contains an invalid extended regular expression."""
-    patterns = from_attrib + xpath_exclusion_pattern(tree) + xpath_cookie_pattern(tree)
+    """The rule contains an invalid extended regular expression."""
+    patterns = (from_attrib + xpath_exclusion_pattern(tree) +
+        xpath_cookie_host_pattern(tree) + xpath_cookie_name_pattern(tree))
     for pat in patterns:
         try:
             re.compile(pat)


### PR DESCRIPTION
Also, expand trivial-validate to catch this case.
Fixes https://github.com/EFForg/https-everywhere/issues/2220