### PR TITLE
Add a try/catch around ruleset processing.

### DIFF
--- a/chromium/rules.js
+++ b/chromium/rules.js
@@ -132,7 +132,11 @@ RuleSets.prototype = {
   addFromXml: function(ruleXml) {
     var sets = ruleXml.getElementsByTagName("ruleset");
     for (var i = 0; i < sets.length; ++i) {
-      this.parseOneRuleset(sets[i]);
+      try {
+        this.parseOneRuleset(sets[i]);
+      } catch (e) {
+        log(WARN, 'Error processing ruleset:' + e);
+      }
     }
   },
 


### PR DESCRIPTION
This will help mitigate future bugs like
https://github.com/EFForg/https-everywhere/issues/2220, so an error processing a
single ruleset doesn't break the whole extension. cc @semenko for review.