### PR TITLE
Fix user rules in Chromium.

### DIFF
--- a/chromium/popup.html
+++ b/chromium/popup.html
@@ -22,7 +22,7 @@
   <a href="#" id="add-rule-link" i18n="menu_add_rule"></a>
   <div id="add-new-rule-div" style="display:none">
     <h3 i18n="about_add_new_rule"> </h3>
-    <p i18n="menu_always_https_for_host">
+    <p i18n="menu_always_https_for_host"></p>
     <label for="new-rule-host" i18n="menu_host"></label> <br><input size="50" id="new-rule-host" type="text" disabled><br>
 
     <div id="new-rule-regular-text">


### PR DESCRIPTION
An unclosed <p> tag meant that i18n message replacement was eliminating some UI
elements that were expected to be there.

Fixes https://github.com/EFForg/https-everywhere/issues/2227

cc @semenko @smarek for review.