### PR TITLE
New rules (imirhil.fr, chiffrofete.fr, café-vie-privée.fr)

### DIFF
--- a/src/chrome/content/rules/Cafe-vie-privee.fr.xml
+++ b/src/chrome/content/rules/Cafe-vie-privee.fr.xml
@@ -1,0 +1,8 @@
+<ruleset name="café-vie-privée.fr">
+	<target host="café-vie-privée.fr" />
+	<target host="*.café-vie-privée.fr" />
+	
+	<test url="http://mail.café-vie-privée.fr/" />
+	
+	<rule from="^http:" to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/Chiffrofete.fr.xml
+++ b/src/chrome/content/rules/Chiffrofete.fr.xml
@@ -1,0 +1,8 @@
+<ruleset name="chiffrofete.fr">
+	<target host="chiffrofete.fr" />
+	<target host="*.chiffrofete.fr" />
+
+	<test url="http://mail.chiffrofete.fr/" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/Imirhil.fr.xml
+++ b/src/chrome/content/rules/Imirhil.fr.xml
@@ -1,0 +1,8 @@
+<ruleset name="imirhil.fr">
+	<target host="imirhil.fr" />
+	<target host="*.imirhil.fr" />
+
+	<test url="http://blog.imirhil.fr/" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>

--- a/utils/relaxng.xml
+++ b/utils/relaxng.xml
@@ -32,9 +32,7 @@
     <oneOrMore>
       <element name="target">
         <attribute name="host">
-          <data type="string">
-            <param name="pattern">(([A-Za-z0-9äö-]+|\*)\.)*([A-Za-z0-9äö-]+|\*)</param>
-          </data>
+          <data type="string" />
         </attribute>
       </element>
     </oneOrMore>


### PR DESCRIPTION
Hello,

Here are 3 new rules.

For one (café-vie-privée.fr), the domain use Unicode symbols.
First, I test with punny-code inside rule file, but the rule doesn’t seems match (too simple char to char matching ?)…
Secondly, I test with Unicode directly on the rule file, but the relaxng schema is too restrictive for host check.
I just remove the pattern restriction from host, not sure if it can really be filter with regex since IDN exist (any Unicode symbol is allowed).

Perhaps IDN can/must be manage with the corresponding punny-code ?
Will avoid charset encoding problem on rule files and direct punny-code input by the user…

I will open a standalone ticket for this.

Regards,