### PR TITLE
[YouTube.com] fix embedded videos

### DIFF
--- a/src/chrome/content/rules/YouTube.xml
+++ b/src/chrome/content/rules/YouTube.xml
@@ -219,7 +219,7 @@
 	<target host="youtu.be" />
 	<target host="www.youtube-nocookie.com"/>
 
-	<!-- Many third-party flash applications which make use of the chromeless YouTube player 			via the deprecated Flash API (AS3) break if we rewrite their requests to HTTPS. -->
+	<!-- Many third-party flash applications which make use of the chromeless YouTube player via the deprecated Flash API (AS3) break if we rewrite their requests to HTTPS. -->
 
 	<exclusion pattern="^http://www\.youtube\.com/apiplayer" />
 	<test url="http://www.youtube.com/apiplayer" />

--- a/src/chrome/content/rules/YouTube.xml
+++ b/src/chrome/content/rules/YouTube.xml
@@ -219,6 +219,10 @@
 	<target host="youtu.be" />
 	<target host="www.youtube-nocookie.com"/>
 
+	<!-- Many third-party flash applications which make use of the chromeless YouTube player 			via the deprecated Flash API (AS3) break if we rewrite their requests to HTTPS. -->
+
+	<exclusion pattern="^http://www\.youtube\.com/apiplayer" />
+	<test url="http://www.youtube.com/apiplayer" />
 
 	<!--	Not secured by server:
 					-->


### PR DESCRIPTION
This pull request proposes a fix for third-party flash applications which make use of the embedded chromeless YouTube player via the deprecated AS3 API.
Most of those applications fail to load the player if we rewrite the URL to HTTPS because it is an unexpected behaviour. They expect a HTTP connection in the first place. (see this example implementation which is also broken: http://www.republicofcode.com/tutorials/flash/as3youtube/)
The connection then gets upgraded to HTTPS by YouTube itself via a HTTP 301 redirect, however if we do that by ourselves things break. This is a flaw (or security feature?) in those third-party applications or Flash itself but we can work around it by excluding the URL used for loading the player from rewrite.

Fixes #1598, #2228 and probably some other websites.