### PR TITLE
repair Heise.de

### DIFF
--- a/src/chrome/content/rules/Heise.de.xml
+++ b/src/chrome/content/rules/Heise.de.xml
@@ -38,6 +38,8 @@
 	<rule from="^http://(?:www\.)?heise\.de/([ai]vw-bin/|favicon\.ico|icons/|ix/images/|imgs/|js/|software/screenshots/|stil/|security/dienste/portscan/test/go\.shtml|support/lib/)"
 		to="https://www.heise.de/$1"/>
 		<exclusion pattern="^http://www\.heise\.de/js/ho/jwplayer-6.10/skin/" />
+		<exclusion pattern="^http://www\.heise\.de/js/foto/galerie/angularjs/partials/ngDialog.inc" />
+		<exclusion pattern="^http://www\.heise\.de/js/foto/galerie/angularjs/partials/photo/diashow.html" />
 	<!-- userdb-subfolder can be secured, but breaks login if you do so -->
 	<rule from="^http://(abo|prophet)\.heise\.de/" to="https://$1.heise.de/"/>
 
@@ -58,6 +60,8 @@
 	<test url="http://www.heise.de/js/ho/login.min.js" />
 	<test url="http://www.heise.de/js/heise.min.js" />
 	<test url="http://www.heise.de/js/ho/jwplayer-6.10/skin/bekle.xml" />
+	<test url="http://www.heise.de/js/foto/galerie/angularjs/partials/ngDialog.inc"/>
+	<test url="http://www.heise.de/js/foto/galerie/angularjs/partials/photo/diashow.html"/>
 
 	<test url="http://www.heise.de/stil/heise-ui.css" />
 	<test url="http://www.heise.de/security/dienste/portscan/test/go.shtml" />

--- a/src/chrome/content/rules/Heise.de.xml
+++ b/src/chrome/content/rules/Heise.de.xml
@@ -35,7 +35,7 @@
 	<!--<target host="heiseshop.de" /> -->
 	<target host="*.heiseshop.de"/>
 
-	<rule from="^http://(?:www\.)?heise\.de/([ai]vw-bin/|favicon\.ico|icons/|ix/images/|imgs/|js/|newsticker/meldung/|software/screenshots/|stil/|security/dienste/portscan/test/go\.shtml|support/lib/)"
+	<rule from="^http://(?:www\.)?heise\.de/([ai]vw-bin/|favicon\.ico|icons/|ix/images/|imgs/|js/|software/screenshots/|stil/|security/dienste/portscan/test/go\.shtml|support/lib/)"
 		to="https://www.heise.de/$1"/>
 		<exclusion pattern="^http://www\.heise\.de/js/ho/jwplayer-6.10/skin/" />
 	<!-- userdb-subfolder can be secured, but breaks login if you do so -->
@@ -58,8 +58,6 @@
 	<test url="http://www.heise.de/js/ho/login.min.js" />
 	<test url="http://www.heise.de/js/heise.min.js" />
 	<test url="http://www.heise.de/js/ho/jwplayer-6.10/skin/bekle.xml" />
-	
-	<test url="http://www.heise.de/newsticker/meldung/Nach-Hacking-Team-Hack-Zyperns-Geheimdienst-Chef-tritt-zurueck-2749219.html" />
 
 	<test url="http://www.heise.de/stil/heise-ui.css" />
 	<test url="http://www.heise.de/security/dienste/portscan/test/go.shtml" />


### PR DESCRIPTION
unfortunately Heise redirects all news pages to plain now, after i began rewriting them.
To avoid a redirect infinite loop we need to remove them from the ruleset.