### PR TITLE
Repair disabled ruleset iapc.utwente.nl

### DIFF
--- a/src/chrome/content/rules/iapc.utwente.nl.xml
+++ b/src/chrome/content/rules/iapc.utwente.nl.xml
@@ -1,12 +1,11 @@
-<!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://iapc.utwente.nl/ => https://www.iapc.utwente.nl/: (6, 'Could not resolve host: iapc.utwente.nl')
-Fetch error: http://iapc.nl/ => https://www.iapc.utwente.nl/: (6, 'Could not resolve host: iapc.nl')
--->
-<ruleset name="Stichting IAPC" default_off='failed ruleset test'>
+<ruleset name="Stichting IAPC">
+	<!--
+	# Not possible due to DNS policy Twente University (www.utwente.nl)
 	<target host="iapc.utwente.nl"/>
-	<target host="*.iapc.utwente.nl"/>
 	<target host="iapc.nl"/>
+	<rule from="^http://iapc\.(?:utwente\.)?nl/" to="https://www.iapc.utwente.nl/"/>
+	-->
+	<target host="*.iapc.utwente.nl"/>
 	<target host="*.iapc.nl"/>
 	<target host="isdewinkelopen.nl"/>
 	<target host="*.isdewinkelopen.nl"/>
@@ -14,7 +13,6 @@ Fetch error: http://iapc.nl/ => https://www.iapc.utwente.nl/: (6, 'Could not res
 	<target host="*.startjesucces.nl"/>
 	<rule from="^http://([^/:@]*)\.iapc\.utwente\.nl/" to="https://$1.iapc.utwente.nl/"/>
 	<rule from="^http://([^/:@]*)\.iapc\.nl/" to="https://$1.iapc.utwente.nl/"/>
-	<rule from="^http://iapc\.(?:utwente\.)?nl/" to="https://www.iapc.utwente.nl/"/>
 	<rule from="^http://(?:[^/:@]*\.)?isdewinkelopen\.nl/" to="https://isdewinkelopen.iapc.utwente.nl/"/>
 	<rule from="^http://(?:[^/:@]*\.)?startjesucces\.nl/" to="https://startjesucces.iapc.utwente.nl/"/>
 	<securecookie host="(?:^|\.)iapc.utwente.nl$" name=".*" />

--- a/src/chrome/content/rules/iapc.utwente.nl.xml
+++ b/src/chrome/content/rules/iapc.utwente.nl.xml
@@ -16,4 +16,10 @@
 	<rule from="^http://(?:[^/:@]*\.)?isdewinkelopen\.nl/" to="https://isdewinkelopen.iapc.utwente.nl/"/>
 	<rule from="^http://(?:[^/:@]*\.)?startjesucces\.nl/" to="https://startjesucces.iapc.utwente.nl/"/>
 	<securecookie host="(?:^|\.)iapc.utwente.nl$" name=".*" />
+	<test url="http://www.iapc.utwente.nl/" />
+	<test url="http://webapps.iapc.utwente.nl/" />
+	<test url="http://www.iapc.nl/" />
+	<test url="http://intra.iapc.nl/" />
+	<test url="http://www.startjesucces.nl/" />
+	<test url="http://www.isdewinkelopen.nl/" />
 </ruleset>


### PR DESCRIPTION
The DNS policy at Twente University only allows us to use subdomains under iapc.nl and iapc.utwente.nl. The ruleset has been updated to reflect this policy and is enabled again.

A comment is added that shows the illegal rulesets and an explanation on why they are disabled, so that someone may enable them again when policy changes.