### PR TITLE
makexpi.sh: Don't copy and delete rules a second time

### DIFF
--- a/makexpi.sh
+++ b/makexpi.sh
@@ -139,8 +139,7 @@ fi
 cp -a src/ pkg/xpi-eff/
 rm -r pkg/xpi-eff/chrome/content/rules
 [ -e pkg/xpi-amo ] && rm -rf pkg/xpi-amo
-cp -a src/ pkg/xpi-amo/
-rm -r pkg/xpi-amo/chrome/content/rules
+cp -a pkg/xpi-eff/ pkg/xpi-amo/
 # The AMO version of the package cannot contain the updateKey or updateURL tags
 sed -i.bak -e '/updateKey/d' -e '/updateURL/d' pkg/xpi-amo/install.rdf
 rm pkg/xpi-amo/install.rdf.bak

--- a/src/Changelog
+++ b/src/Changelog
@@ -1,3 +1,7 @@
+Firefox 5.0.7 / Chrome-2015.7.17
+  * Ruleset fixes, in particular disable broken Netflix rule
+  * Fix "Add a rule" functionality in Chrome.
+
 Chrome-2015.7.15
   * Fix a broken ruleset that caused Chrome version to fail to rewrite all URLs.
 


### PR DESCRIPTION
This reduces `make` runtime ~40% on one of my (slow) systems.

(The compare page is showing four other commits from master as part of this branch, though it's not showing them in the diff. I... don't know why.)