### PR TITLE
Update rule for Scriptfodder.com

### DIFF
--- a/src/chrome/content/rules/Scriptfodder.com.xml
+++ b/src/chrome/content/rules/Scriptfodder.com.xml
@@ -1,14 +1,11 @@
-
-<!--
-Disabled by https-everywhere-checker because:
-Non-2xx HTTP code: http://cdn.scriptfodder.com/ (200) => https://cdn.scriptfodder.com/ (403)
-
--->
-<ruleset name="ScriptFodder" default_off='failed ruleset test'>
+<ruleset name="ScriptFodder">
   <target host="scriptfodder.com" />
   <target host="www.scriptfodder.com" />
   <target host="cdn.scriptfodder.com" />
   <target host="media.scriptfodder.com" />
 
-  <rule from="^http://(www\.|cdn\.|media\.)?scriptfodder\.com/" to="https://$1scriptfodder.com/" />
+  <test url="http://cdn.scriptfodder.com/assets/favicon.ico" />
+
+  <rule from="^http://cdn\.scriptfodder\.com/" to="https://scriptfodder.com/" />
+  <rule from="^http:" to="https:" />
 </ruleset>


### PR DESCRIPTION
Re-enable the ruleset and handle `cdn.scriptfodder.com/` with special care, to prevent the 403 error, that caused https-everywhere-checker to disable the ruleset.
Provided an alternative test url, too.