### PR TITLE
Fix mp3 uploads on deezer.com

### DIFF
--- a/src/chrome/content/rules/Deezer.xml
+++ b/src/chrome/content/rules/Deezer.xml
@@ -4,7 +4,7 @@
 	<target host="*.deezer.com" />
 
 
-	<rule from="^http://(cdns-files\.|www\.)?deezer\.com/"
+	<rule from="^http://(cdns-files\.|upload\.|www\.)?deezer\.com/"
 		to="https://$1deezer.com/" />
 
 </ruleset>


### PR DESCRIPTION
Deezer uploads mp3s via upload.deezer.com, which isn't whitelisted here.
This results in mixed-content errors in chrome and a broken feature!