### PR TITLE
Updates to Politiken.dk and its ad service nugg.ad

### DIFF
--- a/src/chrome/content/rules/Nugg.ad.xml
+++ b/src/chrome/content/rules/Nugg.ad.xml
@@ -1,26 +1,32 @@
 <!--
-	Nonfunctional subdomains:
+	Problematic subdomains:
 
-		- (www.) *
-		- goldbach *
+		- (www.) ¹
+		- axdget-sync ²
+		- goldbach ²
+		- mtm ³
 
-	* Refused
-
+	¹ Mismatched, CN: nugg.ad
+	² Appears to work; unsure what content ought to be
+	³ Redirects to http
 
 	Fully covered subdomains:
 
 		- [\w-]+-s	(per-client web bugs)
+		- ci
+		- poldk
 
 -->
 <ruleset name="nugg.ad (partial)">
 
 	<target host="*.nuggad.net" />
 
-
 	<securecookie host="^\.nuggad\.net$" name="^d$" />
 
+	<test url="http://ci.nuggad.net/ci" />
+	<test url="http://poldk.nuggad.net/rc" />
 
-	<rule from="^http://([\w-]+-s|mtm)\.nuggad\.net/"
+	<rule from="^http://([\w-]+-s|ci|poldk)\.nuggad\.net/"
 		to="https://$1.nuggad.net/" />
 
 </ruleset>

--- a/src/chrome/content/rules/Nugg.ad.xml
+++ b/src/chrome/content/rules/Nugg.ad.xml
@@ -25,6 +25,8 @@
 
 	<test url="http://ci.nuggad.net/ci" />
 	<test url="http://poldk.nuggad.net/rc" />
+	<test url="http://yahoo-s.nuggad.net/" />
+	<test url="http://ip-s.nuggad.net/" />
 
 	<rule from="^http://([\w-]+-s|ci|poldk)\.nuggad\.net/"
 		to="https://$1.nuggad.net/" />

--- a/src/chrome/content/rules/Politiken.dk.xml
+++ b/src/chrome/content/rules/Politiken.dk.xml
@@ -9,6 +9,7 @@
 		- eavis *
 		- kundecenter *
 		- kundecentertest *
+		- soejle3cache *
 		- subtest *
 		- tildoeren *
 		- web *
@@ -19,9 +20,11 @@
 
 	Problematic subdomains:
 
-		- nyhedsbreve ¹
+		- boligmarked ¹
+		- nyhedsbreve 2
 
-	¹ Works; mismatched, CN: *.peytz.dk
+	¹ No content; mismatched, CN: *.boligsiden.dk
+	² Works; mismatched, CN: *.peytz.dk
 
 
 	Partially covered subdomains:

--- a/src/chrome/content/rules/Politiken.dk.xml
+++ b/src/chrome/content/rules/Politiken.dk.xml
@@ -6,7 +6,7 @@
 
 	Nonfunctional subdomains:
 
-		- eavis *
+		- eavis ¹
 		- kundecenter *
 		- kundecentertest *
 		- soejle3cache *
@@ -15,13 +15,12 @@
 		- web *
 		- weekly *
 
-	* Refused
-
+	* Connection timed out
 
 	Problematic subdomains:
 
 		- boligmarked ¹
-		- nyhedsbreve 2
+		- nyhedsbreve ²
 
 	¹ No content; mismatched, CN: *.boligsiden.dk
 	² Works; mismatched, CN: *.peytz.dk


### PR DESCRIPTION
The nugg.ad ruleset test currently fails due to a lack of tests. I would add those but I am not sure what the intent of the original ruleset is (i.e. what <code>[\w-]+-s\.nuggad\.net/</code> is supposed to match).