### PR TITLE
Use a data-id element for rule toggling.

### DIFF
--- a/src/chrome/content/code/ApplicableList.js
+++ b/src/chrome/content/code/ApplicableList.js
@@ -213,10 +213,10 @@ ApplicableList.prototype = {
   },
 
   add_command: function(rule) {
-      var command = this.document.createElement("command");
+      var command = this.document.getElementById("https-everywhere-menuitem-rule-toggle-template").cloneNode();
       command.setAttribute('id', JSON.stringify(rule.id)+'-command');
+      command.setAttribute('data-id', JSON.stringify(rule.id));
       command.setAttribute('label', rule.name);
-      command.setAttribute('oncommand', 'toggle_rule("'+JSON.stringify(rule.id)+'")');
       this.commandset.appendChild(command);
   },
 

--- a/src/chrome/content/toolbar_button.xul
+++ b/src/chrome/content/toolbar_button.xul
@@ -57,21 +57,21 @@
     </toolbarbutton>
   </toolbarpalette>
   <commandset>
+    <command id="https-everywhere-menuitem-rule-toggle-template"
+      oncommand="toggle_rule(event.target.attributes['data-id'].value)" />
     <command id="https-everywhere-menuitem-resetToDefaults"
       oncommand="httpsEverywhere.toolbarButton.resetToDefaults()" />
     <command id="https-everywhere-menuitem-globalEnableToggle"
       oncommand="toggleEnabledState();" />
     <command id="https-everywhere-menuitem-about"
       oncommand="HTTPSEverywhere.chrome_opener('chrome://https-everywhere/content/about.xul');" />
-    <command id="https-everywhere-menuitem-birthday"
-      oncommand="open_in_tab('https://www.eff.org/EFF25');" />
     <command id="https-everywhere-menuitem-observatory"
       oncommand="HTTPSEverywhere.chrome_opener('chrome://https-everywhere/content/observatory-preferences.xul', 'chrome,centerscreen,resizable=yes');" />
-    <command id="https-everywhere-menuitem-donate-eff" 
+    <command id="https-everywhere-menuitem-donate-eff"
       oncommand="open_in_tab('https://www.eff.org/donate');" />
-    <command id="https-everywhere-menuitem-donate-tor" 
+    <command id="https-everywhere-menuitem-donate-tor"
       oncommand="open_in_tab('https://www.torproject.org/donate');" />
-    <command id="https-everywhere-menuitem-ruleset-tests" 
+    <command id="https-everywhere-menuitem-ruleset-tests"
       oncommand="openStatus();" />
   </commandset>
 </overlay>


### PR DESCRIPTION
Per amo-validator advice, we should avoid setting oncommand attributes using
interpolated JS. Instead this puts one constant oncommand attribute in the XUL,
which pull the necessary rule id from a data attribute.

cc @cooperq for review.