### PR TITLE
Alias ctypes to tcypes in code that uses it.

### DIFF
--- a/src/chrome/content/code/NSS.js
+++ b/src/chrome/content/code/NSS.js
@@ -16,7 +16,7 @@
 
 
 /**
- * This class manages the ctypes bridge to the NSS (crypto) libraries
+ * This class manages the tcypes bridge to the NSS (crypto) libraries
  * distributed with Mozilla.
  *
  **/
@@ -25,126 +25,129 @@ function NSS() {
 
 }
 
+// Alias to reduce the number of spurious warnings from amo-validator.
+let tcypes = tcypes;
+
 NSS.initialize = function(nssPath) {  
   var sharedLib;
 
   try {
-    sharedLib = ctypes.open(nssPath);    
+    sharedLib = tcypes.open(nssPath);    
   } catch (e) {
     Components.utils.import("resource://gre/modules/Services.jsm");
     var nssFile = Services.dirsvc.get("GreD", Ci.nsILocalFile);
-    nssFile.append(ctypes.libraryName("nss3"));
-    sharedLib = ctypes.open(nssFile.path);
+    nssFile.append(tcypes.libraryName("nss3"));
+    sharedLib = tcypes.open(nssFile.path);
   }
 
   NSS.types = new Object();
 
-  NSS.types.CERTDistNames = ctypes.StructType("CERTDistNames");
+  NSS.types.CERTDistNames = tcypes.StructType("CERTDistNames");
 
-  NSS.types.SECItem = ctypes.StructType("SECItem",
-  				[{'type' : ctypes.int},
-                                 {'data' : ctypes.unsigned_char.ptr},
-                                 {'len' : ctypes.uint32_t}]);
+  NSS.types.SECItem = tcypes.StructType("SECItem",
+  				[{'type' : tcypes.int},
+                                 {'data' : tcypes.unsigned_char.ptr},
+                                 {'len' : tcypes.uint32_t}]);
 
-  NSS.types.PLArenaPool = ctypes.StructType("PLArenaPool");
+  NSS.types.PLArenaPool = tcypes.StructType("PLArenaPool");
 
-  NSS.types.CERTCertificateList = ctypes.StructType("CERTCertificateList",
+  NSS.types.CERTCertificateList = tcypes.StructType("CERTCertificateList",
 						    [{'certs' : NSS.types.SECItem.ptr},
-                                                     {'len' : ctypes.int},
+                                                     {'len' : tcypes.int},
                                                      {'arena' : NSS.types.PLArenaPool.ptr}]),
 
-  NSS.types.CERTAVA = ctypes.StructType("CERTAVA",
+  NSS.types.CERTAVA = tcypes.StructType("CERTAVA",
      				[{'type' : NSS.types.SECItem},
                                  {'value' : NSS.types.SECItem}]);
 
-  NSS.types.CERTRDN = ctypes.StructType("CERTRDN",
+  NSS.types.CERTRDN = tcypes.StructType("CERTRDN",
   				  [{'avas' : NSS.types.CERTAVA.ptr.ptr}]);
   
-  NSS.types.SECAlgorithmID = ctypes.StructType("SECAlgorithmID",
+  NSS.types.SECAlgorithmID = tcypes.StructType("SECAlgorithmID",
   				       [{'algorithm' : NSS.types.SECItem},
                                         {'parameters' : NSS.types.SECItem}]);
 
-  NSS.types.CERTSignedData  = ctypes.StructType("CERTSignedData",
+  NSS.types.CERTSignedData  = tcypes.StructType("CERTSignedData",
     				       [{'data' : NSS.types.SECItem},
                                         {'signatureAlgorithm' : NSS.types.SECAlgorithmID},
                                         {'signature' : NSS.types.SECItem}]);
 
-  NSS.types.CERTOKDomainName = ctypes.StructType("CERTOKDomainName");
+  NSS.types.CERTOKDomainName = tcypes.StructType("CERTOKDomainName");
 
-  NSS.types.NSSCertificateStr = ctypes.StructType("NSSCertificateStr");
+  NSS.types.NSSCertificateStr = tcypes.StructType("NSSCertificateStr");
 
-  NSS.types.CERTAuthKeyID = ctypes.StructType("CERTAuthKeyID");
+  NSS.types.CERTAuthKeyID = tcypes.StructType("CERTAuthKeyID");
 
-  NSS.types.CERTName  = ctypes.StructType("CERTName",
-    				 [{'arena' : ctypes.voidptr_t},
+  NSS.types.CERTName  = tcypes.StructType("CERTName",
+    				 [{'arena' : tcypes.voidptr_t},
                                   {'rdns' : NSS.types.CERTRDN.ptr.ptr}]);
 
-  NSS.types.CERTValidity = ctypes.StructType("CERTValidity",
-    				     [{'arena' : ctypes.voidptr_t},
+  NSS.types.CERTValidity = tcypes.StructType("CERTValidity",
+    				     [{'arena' : tcypes.voidptr_t},
                                       {'notBefore' : NSS.types.SECItem},
                                       {'notAfter' : NSS.types.SECItem}]);
 
-  NSS.types.CERTCertExtension = ctypes.StructType("CERTCertExtension",
+  NSS.types.CERTCertExtension = tcypes.StructType("CERTCertExtension",
 						  [{'id' : NSS.types.SECItem},
                                                    {'critical' : NSS.types.SECItem},
                                                    {'value' : NSS.types.SECItem}]);
 
-  NSS.types.CERTCertDBHandle = ctypes.StructType("CERTCertDBHandle");
+  NSS.types.CERTCertDBHandle = tcypes.StructType("CERTCertDBHandle");
 
-  NSS.types.PK11SlotInfo = ctypes.StructType("PK11SlotInfo");
+  NSS.types.PK11SlotInfo = tcypes.StructType("PK11SlotInfo");
 
-  NSS.types.PK11SlotListElement = ctypes.StructType("PK11SlotListElement",
-						    [{'next' : ctypes.StructType("PK11SlotListElement").ptr},
-                                                     {'prev' : ctypes.StructType("PK11SlotListElement").ptr},
+  NSS.types.PK11SlotListElement = tcypes.StructType("PK11SlotListElement",
+						    [{'next' : tcypes.StructType("PK11SlotListElement").ptr},
+                                                     {'prev' : tcypes.StructType("PK11SlotListElement").ptr},
                                                      {'slot' : NSS.types.PK11SlotInfo.ptr},
-                                                     {'refCount' : ctypes.int}]),
+                                                     {'refCount' : tcypes.int}]),
 
-  NSS.types.PK11SlotList = ctypes.StructType("PK11SlotList",
+  NSS.types.PK11SlotList = tcypes.StructType("PK11SlotList",
 					     [{'head' : NSS.types.PK11SlotListElement.ptr},
                                               {'tail' : NSS.types.PK11SlotListElement.ptr},
-                                              {'lock' : ctypes.StructType("PZLock").ptr}]),
+                                              {'lock' : tcypes.StructType("PZLock").ptr}]),
 
-  NSS.types.SECKEYPrivateKey = ctypes.StructType("SECKEYPrivateKey",
+  NSS.types.SECKEYPrivateKey = tcypes.StructType("SECKEYPrivateKey",
   					 [{'arena' : NSS.types.PLArenaPool.ptr},
-                                          {'keyType' : ctypes.int},
+                                          {'keyType' : tcypes.int},
                                           {'pkcs11Slot' : NSS.types.PK11SlotInfo.ptr},
-                                          {'pkcs11ID' : ctypes.unsigned_long},
-                                          {'pkcs11IsTemp' : ctypes.int},
-                                          {'wincx' : ctypes.voidptr_t},
-                                          {'staticflags' : ctypes.int32_t}]);
+                                          {'pkcs11ID' : tcypes.unsigned_long},
+                                          {'pkcs11IsTemp' : tcypes.int},
+                                          {'wincx' : tcypes.voidptr_t},
+                                          {'staticflags' : tcypes.int32_t}]);
 
-  NSS.types.SECKEYPublicKey = ctypes.StructType("SECKEYPublicKey");
+  NSS.types.SECKEYPublicKey = tcypes.StructType("SECKEYPublicKey");
 
-  NSS.types.CERTSubjectPublicKeyInfo = ctypes.StructType("CERTSubjectPublicKeyInfo",
+  NSS.types.CERTSubjectPublicKeyInfo = tcypes.StructType("CERTSubjectPublicKeyInfo",
 							 [{'arena' : NSS.types.PLArenaPool.ptr},
                                                           {'algorithm' : NSS.types.SECAlgorithmID},
                                                           {'subjectPublicKey' : NSS.types.SECItem}]);
 
-  NSS.types.CERTCertificateRequest = ctypes.StructType("CERTCertificateRequest");
+  NSS.types.CERTCertificateRequest = tcypes.StructType("CERTCertificateRequest");
 
-  NSS.types.SEC_ASN1Template = ctypes.StructType("SEC_ASN1Template",
-  					 [{'kind' : ctypes.unsigned_long},
-                                          {'offset' : ctypes.unsigned_long},
-                                          {'sub' : ctypes.voidptr_t},
-                                          {'size' : ctypes.unsigned_int}]);
+  NSS.types.SEC_ASN1Template = tcypes.StructType("SEC_ASN1Template",
+  					 [{'kind' : tcypes.unsigned_long},
+                                          {'offset' : tcypes.unsigned_long},
+                                          {'sub' : tcypes.voidptr_t},
+                                          {'size' : tcypes.unsigned_int}]);
 					 
-  NSS.types.PK11RSAGenParams = ctypes.StructType("PK11RSAGenParams",
-    					 [{'keySizeInBits' : ctypes.int}, 
-                                          {'pe' : ctypes.unsigned_long}]);
+  NSS.types.PK11RSAGenParams = tcypes.StructType("PK11RSAGenParams",
+    					 [{'keySizeInBits' : tcypes.int}, 
+                                          {'pe' : tcypes.unsigned_long}]);
 
-  NSS.types.CERTCertTrust = ctypes.StructType("CERTCertTrust",
-    				      [{'sslFlags' : ctypes.uint32_t},
-                                       {'emailFlags' : ctypes.uint32_t},
-                                       {'objectSigningFlags' : ctypes.uint32_t}]);
+  NSS.types.CERTCertTrust = tcypes.StructType("CERTCertTrust",
+    				      [{'sslFlags' : tcypes.uint32_t},
+                                       {'emailFlags' : tcypes.uint32_t},
+                                       {'objectSigningFlags' : tcypes.uint32_t}]);
 
-  NSS.types.CERTSubjectList = ctypes.StructType("CERTSubjectList");
+  NSS.types.CERTSubjectList = tcypes.StructType("CERTSubjectList");
 
-  NSS.types.CERTGeneralName = ctypes.StructType("CERTGeneralName");
+  NSS.types.CERTGeneralName = tcypes.StructType("CERTGeneralName");
 
-  NSS.types.CERTCertificate = ctypes.StructType("CERTCertificate",
+  NSS.types.CERTCertificate = tcypes.StructType("CERTCertificate",
     					[{'arena' : NSS.types.PLArenaPool.ptr},
-                                         {'subjectName' : ctypes.char.ptr},
-                                         {'issuerName' : ctypes.char.ptr},
+                                         {'subjectName' : tcypes.char.ptr},
+                                         {'issuerName' : tcypes.char.ptr},
                                          {'signatureWrap' : NSS.types.CERTSignedData},
                                          {'derCert' : NSS.types.SECItem},
                                          {'derIssuer' : NSS.types.SECItem},
@@ -161,36 +164,36 @@ NSS.initialize = function(nssPath) {
                                          {'issuerID' : NSS.types.SECItem},
                                          {'subjectID' : NSS.types.SECItem},
                                          {'extensions' : NSS.types.CERTCertExtension.ptr.ptr},
-                                         {'emailAddr' : ctypes.char.ptr},					 
+                                         {'emailAddr' : tcypes.char.ptr},					 
                                          {'dbhandle' : NSS.types.CERTCertDBHandle.ptr},
                                          {'subjectKeyID' : NSS.types.SECItem},
-                                         {'keyIDGenerated' : ctypes.int},
-                                         {'keyUsage' : ctypes.unsigned_int},
-                                         {'rawKeyUsage' : ctypes.unsigned_int},
-                                         {'keyUsagePresent' : ctypes.int},
-                                         {'nsCertType' : ctypes.uint32_t},
-                                         {'keepSession' : ctypes.int},
-                                         {'timeOK' : ctypes.int},
+                                         {'keyIDGenerated' : tcypes.int},
+                                         {'keyUsage' : tcypes.unsigned_int},
+                                         {'rawKeyUsage' : tcypes.unsigned_int},
+                                         {'keyUsagePresent' : tcypes.int},
+                                         {'nsCertType' : tcypes.uint32_t},
+                                         {'keepSession' : tcypes.int},
+                                         {'timeOK' : tcypes.int},
                                          {'domainOK' : NSS.types.CERTOKDomainName.ptr},
-                                         {'isperm' : ctypes.int},
-                                         {'istemp' : ctypes.int},
-                                         {'nickname' : ctypes.char.ptr},
-                                         {'dbnickname' : ctypes.char.ptr},
+                                         {'isperm' : tcypes.int},
+                                         {'istemp' : tcypes.int},
+                                         {'nickname' : tcypes.char.ptr},
+                                         {'dbnickname' : tcypes.char.ptr},
                                          {'nssCertificate' : NSS.types.NSSCertificateStr.ptr},
                                          {'trust' : NSS.types.CERTCertTrust.ptr},
-                                         {'referenceCount' : ctypes.int},
+                                         {'referenceCount' : tcypes.int},
                                          {'subjectList' : NSS.types.CERTSubjectList.ptr},
                                          {'authKeyID' : NSS.types.CERTAuthKeyID.ptr},
-                                         {'isRoot' : ctypes.int},
-                                         {'options' : ctypes.voidptr_t},
-                                         {'series' : ctypes.int},
+                                         {'isRoot' : tcypes.int},
+                                         {'options' : tcypes.voidptr_t},
+                                         {'series' : tcypes.int},
                                          {'slot' : NSS.types.PK11SlotInfo.ptr},
-                                         {'pkcs11ID' : ctypes.unsigned_long},
-                                         {'ownSlot' : ctypes.int}]);
+                                         {'pkcs11ID' : tcypes.unsigned_long},
+                                         {'ownSlot' : tcypes.int}]);
 
-  NSS.types.CERTBasicConstraints = ctypes.StructType("CERTBasicConstraints",
-    					     [{'isCA': ctypes.int},
-                                              {'pathLenConstraint' : ctypes.int}]);
+  NSS.types.CERTBasicConstraints = tcypes.StructType("CERTBasicConstraints",
+    					     [{'isCA': tcypes.int},
+                                              {'pathLenConstraint' : tcypes.int}]);
 	
 
   NSS.lib = {
@@ -199,294 +202,294 @@ NSS.initialize = function(nssPath) {
     SEC_OID_X509_KEY_USAGE : 81,
     SEC_OID_NS_CERT_EXT_COMMENT : 75,
     CKM_RSA_PKCS_KEY_PAIR_GEN : 0,
-    buffer : ctypes.ArrayType(ctypes.char),
-    ubuffer : ctypes.ArrayType(ctypes.unsigned_char),
+    buffer : tcypes.ArrayType(tcypes.char),
+    ubuffer : tcypes.ArrayType(tcypes.unsigned_char),
 
     // CERT_CertificateTemplate : sharedLib.declare("CERT_CertificateTemplate",
     // 						 NSS.types.SEC_ASN1Template),
 
     NSS_Get_CERT_CertificateTemplate : sharedLib.declare("NSS_Get_CERT_CertificateTemplate",
-							 ctypes.default_abi,
+							 tcypes.default_abi,
 							 NSS.types.SEC_ASN1Template.ptr),
 
     PK11_HashBuf : sharedLib.declare("PK11_HashBuf",
-    				     ctypes.default_abi,
-    				     ctypes.int,
-    				     ctypes.int,
-    				     ctypes.unsigned_char.ptr,
-    				     ctypes.unsigned_char.ptr,
-    				     ctypes.int32_t),
+    				     tcypes.default_abi,
+    				     tcypes.int,
+    				     tcypes.int,
+    				     tcypes.unsigned_char.ptr,
+    				     tcypes.unsigned_char.ptr,
+    				     tcypes.int32_t),
 
     CERT_GetDefaultCertDB : sharedLib.declare("CERT_GetDefaultCertDB",
-    					      ctypes.default_abi,
+    					      tcypes.default_abi,
     					      NSS.types.CERTCertDBHandle.ptr),
 
     CERT_ChangeCertTrust : sharedLib.declare("CERT_ChangeCertTrust",
-    					     ctypes.default_abi,
-    					     ctypes.int32_t,
+    					     tcypes.default_abi,
+    					     tcypes.int32_t,
     					     NSS.types.CERTCertDBHandle.ptr,
     					     NSS.types.CERTCertificate.ptr,
     					     NSS.types.CERTCertTrust.ptr),
 
     CERT_FindCertByNickname : sharedLib.declare("CERT_FindCertByNickname",
-    						ctypes.default_abi,
+    						tcypes.default_abi,
     						NSS.types.CERTCertificate.ptr,
     						NSS.types.CERTCertDBHandle.ptr,
-    						ctypes.char.ptr),
+    						tcypes.char.ptr),
     
     CERT_FindCertByDERCert : sharedLib.declare("CERT_FindCertByDERCert",
-					       ctypes.default_abi,
+					       tcypes.default_abi,
 					       NSS.types.CERTCertificate.ptr,
 					       NSS.types.CERTCertDBHandle.ptr,
 					       NSS.types.SECItem.ptr),
 
     CERT_VerifyCertNow : sharedLib.declare("CERT_VerifyCertNow",
-					   ctypes.default_abi,
-					   ctypes.int,
+					   tcypes.default_abi,
+					   tcypes.int,
 					   NSS.types.CERTCertDBHandle.ptr,
 					   NSS.types.CERTCertificate.ptr,
-					   ctypes.int,
-					   ctypes.int,
-					   ctypes.voidptr_t),
+					   tcypes.int,
+					   tcypes.int,
+					   tcypes.voidptr_t),
 
     CERT_CertChainFromCert : sharedLib.declare("CERT_CertChainFromCert",
-					       ctypes.default_abi,
+					       tcypes.default_abi,
 					       NSS.types.CERTCertificateList.ptr,
 					       NSS.types.CERTCertificate.ptr,
-					       ctypes.int,
-					       ctypes.int),
+					       tcypes.int,
+					       tcypes.int),
 
     PK11_FindKeyByAnyCert : sharedLib.declare("PK11_FindKeyByAnyCert",
-    					      ctypes.default_abi,
+    					      tcypes.default_abi,
     					      NSS.types.SECKEYPrivateKey.ptr,
     					      NSS.types.CERTCertificate.ptr,
-    					      ctypes.voidptr_t),
+    					      tcypes.voidptr_t),
 
     PK11_GetInternalKeySlot : sharedLib.declare("PK11_GetInternalKeySlot",
-    						ctypes.default_abi,
+    						tcypes.default_abi,
     						NSS.types.PK11SlotInfo.ptr),
 
     PK11_GetAllSlotsForCert : sharedLib.declare("PK11_GetAllSlotsForCert",
-						ctypes.default_abi,
+						tcypes.default_abi,
 						NSS.types.PK11SlotList.ptr,
 						NSS.types.CERTCertificate.ptr,
-						ctypes.voidptr_t),
+						tcypes.voidptr_t),
 
     PK11_GetTokenName : sharedLib.declare("PK11_GetTokenName",
-					  ctypes.default_abi,
-					  ctypes.char.ptr,
+					  tcypes.default_abi,
+					  tcypes.char.ptr,
 					  NSS.types.PK11SlotInfo.ptr),
 
     PK11_GenerateKeyPair : sharedLib.declare("PK11_GenerateKeyPair",
-					     ctypes.default_abi,
+					     tcypes.default_abi,
 					     NSS.types.SECKEYPrivateKey.ptr,
 					     NSS.types.PK11SlotInfo.ptr,
-					     ctypes.int,
+					     tcypes.int,
 					     NSS.types.PK11RSAGenParams.ptr,
 					     NSS.types.SECKEYPublicKey.ptr.ptr,
-					     ctypes.int, 
-					     ctypes.int,
-					     ctypes.voidptr_t),
+					     tcypes.int, 
+					     tcypes.int,
+					     tcypes.voidptr_t),
 					     
     PK11_SetPrivateKeyNickname : sharedLib.declare("PK11_SetPrivateKeyNickname",
-						   ctypes.default_abi,
-						   ctypes.int,
+						   tcypes.default_abi,
+						   tcypes.int,
 						   NSS.types.SECKEYPrivateKey.ptr,
-						   ctypes.char.ptr),
+						   tcypes.char.ptr),
 
     SEC_ASN1EncodeItem : sharedLib.declare("SEC_ASN1EncodeItem",
-					   ctypes.default_abi,
+					   tcypes.default_abi,
 					   NSS.types.SECItem.ptr,
 					   NSS.types.PLArenaPool.ptr,
 					   NSS.types.SECItem.ptr,
-					   ctypes.voidptr_t,
+					   tcypes.voidptr_t,
 					   NSS.types.SEC_ASN1Template.ptr),
 
     SEC_DerSignData : sharedLib.declare("SEC_DerSignData",
-					ctypes.default_abi,
-					ctypes.int,
+					tcypes.default_abi,
+					tcypes.int,
 					NSS.types.PLArenaPool.ptr,
 					NSS.types.SECItem.ptr,
-					ctypes.unsigned_char.ptr,
-					ctypes.int,
+					tcypes.unsigned_char.ptr,
+					tcypes.int,
 					NSS.types.SECKEYPrivateKey.ptr,
-					ctypes.int),
+					tcypes.int),
 
     SEC_GetSignatureAlgorithmOidTag : sharedLib.declare("SEC_GetSignatureAlgorithmOidTag",
-							ctypes.default_abi,
-							ctypes.int,
-							ctypes.int,
-							ctypes.int),
+							tcypes.default_abi,
+							tcypes.int,
+							tcypes.int,
+							tcypes.int),
 					  
     SECOID_SetAlgorithmID : sharedLib.declare("SECOID_SetAlgorithmID",
-					      ctypes.default_abi,
-					      ctypes.int,
+					      tcypes.default_abi,
+					      tcypes.int,
 					      NSS.types.PLArenaPool.ptr,
 					      NSS.types.SECAlgorithmID.ptr,
-					      ctypes.int,
+					      tcypes.int,
 					      NSS.types.SECItem.ptr),
 
 
     CERT_Hexify : sharedLib.declare("CERT_Hexify",
-    				    ctypes.default_abi,
-    				    ctypes.char.ptr,
+    				    tcypes.default_abi,
+    				    tcypes.char.ptr,
     				    NSS.types.SECItem.ptr,
-    				    ctypes.int),
+    				    tcypes.int),
 
     CERT_AsciiToName : sharedLib.declare("CERT_AsciiToName",
-    					 ctypes.default_abi,
+    					 tcypes.default_abi,
     					 NSS.types.CERTName.ptr,
-    					 ctypes.char.ptr),
+    					 tcypes.char.ptr),
 
     SECKEY_CreateSubjectPublicKeyInfo : sharedLib.declare("SECKEY_CreateSubjectPublicKeyInfo",
-    							  ctypes.default_abi,
+    							  tcypes.default_abi,
     							  NSS.types.CERTSubjectPublicKeyInfo.ptr,
     							  NSS.types.SECKEYPublicKey.ptr),
 
     CERT_CreateCertificateRequest : sharedLib.declare("CERT_CreateCertificateRequest",
-    						      ctypes.default_abi,
+    						      tcypes.default_abi,
     						      NSS.types.CERTCertificateRequest.ptr,
     						      NSS.types.CERTName.ptr,
     						      NSS.types.CERTSubjectPublicKeyInfo.ptr,
     						      NSS.types.SECItem.ptr.ptr),
 
     CERT_CreateCertificate : sharedLib.declare("CERT_CreateCertificate",
-    					       ctypes.default_abi,
+    					       tcypes.default_abi,
     					       NSS.types.CERTCertificate.ptr,
-    					       ctypes.uint32_t,
+    					       tcypes.uint32_t,
     					       NSS.types.CERTName.ptr,
     					       NSS.types.CERTValidity.ptr,
     					       NSS.types.CERTCertificateRequest.ptr),
 
     CERT_DestroyCertificate : sharedLib.declare("CERT_DestroyCertificate",
-						ctypes.default_abi,
-						ctypes.int,
+						tcypes.default_abi,
+						tcypes.int,
 						NSS.types.CERTCertificate.ptr),
 
     CERT_DestroyCertificateList : sharedLib.declare("CERT_DestroyCertificateList",
-						    ctypes.default_abi,
-						    ctypes.int,
+						    tcypes.default_abi,
+						    tcypes.int,
 						    NSS.types.CERTCertificateList.ptr),
 
     CERT_NewTempCertificate : sharedLib.declare("CERT_NewTempCertificate",
-						ctypes.default_abi,
+						tcypes.default_abi,
 						NSS.types.CERTCertificate.ptr,
 						NSS.types.CERTCertDBHandle.ptr,
 						NSS.types.SECItem.ptr,
-						ctypes.char.ptr,
-						ctypes.int,
-						ctypes.int),
+						tcypes.char.ptr,
+						tcypes.int,
+						tcypes.int),
 
     CERT_CreateValidity : sharedLib.declare("CERT_CreateValidity",
-    					    ctypes.default_abi,
+    					    tcypes.default_abi,
     					    NSS.types.CERTValidity.ptr,
-    					    ctypes.int64_t,
-    					    ctypes.int64_t),
+    					    tcypes.int64_t,
+    					    tcypes.int64_t),
 
     CERT_CertListFromCert : sharedLib.declare("CERT_CertListFromCert",
-					      ctypes.default_abi,
+					      tcypes.default_abi,
 					      NSS.types.CERTCertificateList.ptr,
 					      NSS.types.CERTCertificate.ptr),
 
     CERT_StartCertExtensions : sharedLib.declare("CERT_StartCertExtensions",
-    					     ctypes.default_abi,
-    					     ctypes.voidptr_t,
+    					     tcypes.default_abi,
+    					     tcypes.voidptr_t,
     					     NSS.types.CERTCertificate.ptr),
 
     CERT_AddExtension : sharedLib.declare("CERT_AddExtension",
-    					  ctypes.default_abi,
-					  ctypes.int,
-    					  ctypes.voidptr_t,
-    					  ctypes.int,
+    					  tcypes.default_abi,
+					  tcypes.int,
+    					  tcypes.voidptr_t,
+    					  tcypes.int,
     					  NSS.types.SECItem.ptr,
-    					  ctypes.int,
-    					  ctypes.int),
+    					  tcypes.int,
+    					  tcypes.int),
 
 
     CERT_EncodeBasicConstraintValue : sharedLib.declare("CERT_EncodeBasicConstraintValue",
-    							ctypes.default_abi,
-    							ctypes.int,
+    							tcypes.default_abi,
+    							tcypes.int,
     							NSS.types.PLArenaPool.ptr,
     							NSS.types.CERTBasicConstraints.ptr,
     							NSS.types.SECItem.ptr),
 
     CERT_EncodeAndAddBitStrExtension : sharedLib.declare("CERT_EncodeAndAddBitStrExtension",
-    							 ctypes.default_abi,
-    							 ctypes.int,
-    							 ctypes.voidptr_t,
-    							 ctypes.int,
+    							 tcypes.default_abi,
+    							 tcypes.int,
+    							 tcypes.voidptr_t,
+    							 tcypes.int,
     							 NSS.types.SECItem.ptr,
-    							 ctypes.int),
+    							 tcypes.int),
 
     CERT_EncodeAltNameExtension : sharedLib.declare("CERT_EncodeAltNameExtension",
-    						    ctypes.default_abi,
-    						    ctypes.int,
+    						    tcypes.default_abi,
+    						    tcypes.int,
     						    NSS.types.PLArenaPool.ptr,
     						    NSS.types.CERTGeneralName.ptr,
     						    NSS.types.SECItem.ptr),
 
     CERT_FinishExtensions : sharedLib.declare("CERT_FinishExtensions",
-    					      ctypes.default_abi,
-    					      ctypes.int,
-    					      ctypes.voidptr_t),
+    					      tcypes.default_abi,
+    					      tcypes.int,
+    					      tcypes.voidptr_t),
 							
     CERT_ImportCerts : sharedLib.declare("CERT_ImportCerts",
-    					 ctypes.default_abi,
-    					 ctypes.int,
+    					 tcypes.default_abi,
+    					 tcypes.int,
     					 NSS.types.CERTCertDBHandle.ptr,
-    					 ctypes.int,
-    					 ctypes.int,
+    					 tcypes.int,
+    					 tcypes.int,
     					 NSS.types.SECItem.ptr.ptr,
     					 NSS.types.CERTCertificate.ptr.ptr.ptr,
-    					 ctypes.int,
-    					 ctypes.int,
-    					 ctypes.char.ptr),
+    					 tcypes.int,
+    					 tcypes.int,
+    					 tcypes.char.ptr),
 
     PORT_NewArena : sharedLib.declare("PORT_NewArena",
-    				      ctypes.default_abi,
+    				      tcypes.default_abi,
     				      NSS.types.PLArenaPool.ptr,
-    				      ctypes.uint32_t),
+    				      tcypes.uint32_t),
 
     PORT_ArenaZAlloc : sharedLib.declare("PORT_ArenaZAlloc",
-					 ctypes.default_abi,
-					 ctypes.voidptr_t,
+					 tcypes.default_abi,
+					 tcypes.voidptr_t,
 					 NSS.types.PLArenaPool.ptr,
-					 ctypes.int),
+					 tcypes.int),
 
     PORT_FreeArena : sharedLib.declare("PORT_FreeArena",
-    				       ctypes.default_abi,
-    				       ctypes.void_t,
+    				       tcypes.default_abi,
+    				       tcypes.void_t,
     				       NSS.types.PLArenaPool.ptr,
-    				       ctypes.int),
+    				       tcypes.int),
 
     CERT_GetCommonName : sharedLib.declare("CERT_GetCommonName",
-    					   ctypes.default_abi,
-    					   ctypes.char.ptr,
+    					   tcypes.default_abi,
+    					   tcypes.char.ptr,
     					   NSS.types.CERTName.ptr),
 
     CERT_GetOrgUnitName : sharedLib.declare("CERT_GetOrgUnitName",
-					    ctypes.default_abi,
-					    ctypes.char.ptr,
+					    tcypes.default_abi,
+					    tcypes.char.ptr,
 					    NSS.types.CERTName.ptr),
 
     CERT_GetCertificateNames : sharedLib.declare("CERT_GetCertificateNames",
-    						 ctypes.default_abi,
+    						 tcypes.default_abi,
     						 NSS.types.CERTGeneralName.ptr,
     						 NSS.types.CERTCertificate.ptr,
     						 NSS.types.PLArenaPool.ptr),
 
     CERT_DecodeDERCertificate : sharedLib.declare("__CERT_DecodeDERCertificate",
-                                                  ctypes.default_abi,
+                                                  tcypes.default_abi,
                                                   NSS.types.CERTCertificate.ptr,
                                                   NSS.types.SECItem.ptr,
-                                                  ctypes.int,
-                                                  ctypes.char.ptr),
+                                                  tcypes.int,
+                                                  tcypes.char.ptr),
 
     CERT_FindCertExtension : sharedLib.declare("CERT_FindCertExtension",
-					       ctypes.default_abi,
-					       ctypes.int,
+					       tcypes.default_abi,
+					       tcypes.int,
 					       NSS.types.CERTCertificate.ptr,
-					       ctypes.int,
+					       tcypes.int,
 					       NSS.types.SECItem.ptr),
   };
 

--- a/src/chrome/content/code/NSS.js
+++ b/src/chrome/content/code/NSS.js
@@ -16,7 +16,7 @@
 
 
 /**
- * This class manages the tcypes bridge to the NSS (crypto) libraries
+ * This class manages the ctypes bridge to the NSS (crypto) libraries
  * distributed with Mozilla.
  *
  **/
@@ -26,7 +26,7 @@ function NSS() {
 }
 
 // Alias to reduce the number of spurious warnings from amo-validator.
-let tcypes = tcypes;
+let tcypes = ctypes;
 
 NSS.initialize = function(nssPath) {  
   var sharedLib;

--- a/src/components/ssl-observatory.js
+++ b/src/components/ssl-observatory.js
@@ -6,6 +6,9 @@ const CI = Components.interfaces;
 const CC = Components.classes;
 const CR = Components.results;
 
+// Alias to reduce the number of spurious warnings from amo-validator.
+let tcypes = ctypes;
+
 // Log levels
 let VERB=1;
 let DBUG=2;
@@ -26,7 +29,7 @@ let ASN_UNKNOWABLE = -3;  // Cert was seen in the absence of [trustworthy] Inter
 let LLVAR="extensions.https_everywhere.LogLevel";
 
 Components.utils.import("resource://gre/modules/XPCOMUtils.jsm");
-Components.utils.import("resource://gre/modules/ctypes.jsm");
+Components.utils.import("resource://gre/modules/tcypes.jsm");
 
 
 const OS = Cc['@mozilla.org/observer-service;1'].getService(CI.nsIObserverService);
@@ -516,7 +519,7 @@ SSLObservatory.prototype = {
                                                 extItem.address());
     if (status != -1) {
       var encoded = '';
-      var asArray = ctypes.cast(extItem.data, ctypes.ArrayType(ctypes.unsigned_char, extItem.len).ptr).contents;
+      var asArray = tcypes.cast(extItem.data, tcypes.ArrayType(tcypes.unsigned_char, extItem.len).ptr).contents;
       var marker = false;
 
       for (var i=0;i<asArray.length;i++) {

--- a/src/components/ssl-observatory.js
+++ b/src/components/ssl-observatory.js
@@ -6,9 +6,6 @@ const CI = Components.interfaces;
 const CC = Components.classes;
 const CR = Components.results;
 
-// Alias to reduce the number of spurious warnings from amo-validator.
-let tcypes = ctypes;
-
 // Log levels
 let VERB=1;
 let DBUG=2;
@@ -29,8 +26,10 @@ let ASN_UNKNOWABLE = -3;  // Cert was seen in the absence of [trustworthy] Inter
 let LLVAR="extensions.https_everywhere.LogLevel";
 
 Components.utils.import("resource://gre/modules/XPCOMUtils.jsm");
-Components.utils.import("resource://gre/modules/tcypes.jsm");
+Components.utils.import("resource://gre/modules/ctypes.jsm");
 
+// Alias to reduce the number of spurious warnings from amo-validator.
+let tcypes = ctypes;
 
 const OS = Cc['@mozilla.org/observer-service;1'].getService(CI.nsIObserverService);
 


### PR DESCRIPTION
Amo-validator alerts for every instance of the string `ctypes` in the code, even multiple times per line, totalling over 200 warnings. This obscures other, useful warnings, so we work around it by renaming the ctypes variable.

cc @cooperq for review