### PR TITLE
[US Selective Service System] Removed the training.sss.gov domain and…

### DIFF
--- a/src/chrome/content/rules/US-Selective-Service-System.xml
+++ b/src/chrome/content/rules/US-Selective-Service-System.xml
@@ -1,14 +1,12 @@
-<!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://sss.gov/ => https://www.sss.gov/: (6, 'Could not resolve host: sss.gov')
--->
-<ruleset name="US Selective Service System" platform="mixedcontent" default_off='failed ruleset test'>
+<ruleset name="US Selective Service System">
 	<target host="sss.gov" />
-	<target host="training.sss.gov" />
 	<target host="www.sss.gov" />
 
-	<securecookie host="^(?:.*\.)?sss\.gov$" name=".+" />
+	<securecookie host="^(?:.*\.)?sss\.gov$"
+			name=".+" />
 
-	<rule from="^http://sss\.gov/" to="https://www.sss.gov/" />
-	<rule from="^http://(training|www)\.sss\.gov/" to="https://$1.sss.gov/" />
+	<rule from="^http://sss\.gov/"
+		to="https://www.sss.gov/" />
+	<rule from="^http:"
+		to="https:" />
 </ruleset>


### PR DESCRIPTION
… changed the redirect rules to a more preferable format