### PR TITLE
BR

### DIFF
--- a/src/chrome/content/rules/BR.xml
+++ b/src/chrome/content/rules/BR.xml
@@ -1,7 +1,8 @@
 <ruleset name="Bayrischer Rundfunk">
 
 	<target host="br.de"/>
-	<target host="*.br.de"/>
+	<!-- cdn-storage.br.de is serving an akamai-only cert-->
+	<target host="www.br.de"/>
 	<target host="www.brreisen.de"/>
 
 	<rule from="^http:"


### PR DESCRIPTION
I moved the rule from wildcard to specific target hosts to fix cdn-storage subdomain , since that one only serves an akamai certificate for now.