### PR TITLE
Suggestion: Change style of heading menuitem

### DIFF
--- a/src/chrome/content/code/ApplicableList.js
+++ b/src/chrome/content/code/ApplicableList.js
@@ -115,7 +115,7 @@ ApplicableList.prototype = {
     label.setAttribute('label', strings.getString('https-everywhere.menu.enableDisable'));
     label.setAttribute('disabled', 'true');
     label.setAttribute('class', 'menuitem-non-iconic');
-    label.setAttribute('style', 'color:#000000;');
+    label.setAttribute('style', 'font-weight: bold; color: -moz-MenuBarText;');
     var label2 = false;
     if (!any_rules) {
       label2 = document.createElement('menuitem');


### PR DESCRIPTION
If I understand it correctly, the first menuitem in the dropdown menu has been coloured black so as to avoid it being gray with its disabled status. This doesn't work very well on dark-themed setups though:

![tilgithub2](https://cloud.githubusercontent.com/assets/6169306/9290565/42cb069c-4398-11e5-801f-42d080d720d2.png)

Now, I don't know of a way to pick out the text colours of the other menuitems, but <code>-moz-MenuBarText</code> seems to almost do the trick. This probably requires a bit of testing on various systems/theme setups.