### PR TITLE
[Alphabet] Remove duplicate rule

### DIFF
--- a/src/chrome/content/rules/Alphabet.xml
+++ b/src/chrome/content/rules/Alphabet.xml
@@ -1,9 +1,0 @@
-<ruleset name="Alphabet">
-
-	<target host="abc.xyz" />
-	<target host="www.abc.xyz" />
-
-	<rule from="^http:"
-		to="https:" />
-
-</ruleset>


### PR DESCRIPTION
There are duplicate rules for abc.xyz and www.abc.xyz in the current master, causing ruleset validation to fail. This removes one of those rulesets containing these.