### PR TITLE
Change id of extension for AMO signing.

### DIFF
--- a/https-everywhere-tests/test_profile_skeleton/extensions.json
+++ b/https-everywhere-tests/test_profile_skeleton/extensions.json
@@ -16,7 +16,7 @@
       "hasBinaryComponents": false,
       "icon64URL": null,
       "iconURL": "chrome://https-everywhere/skin/https-everywhere.png",
-      "id": "https-everywhere@eff.org",
+      "id": "https-everywhere-eff@eff.org",
       "installDate": 1407525887000,
       "internalName": null,
       "locales": [],

--- a/makexpi.sh
+++ b/makexpi.sh
@@ -34,8 +34,7 @@ if [ -n "$1" ] && [ "$2" != "--no-recurse" ] ; then
   # Ensure a clean build.
   git clean -fdx
 
-  git submodule init
-  git submodule update
+  git submodule update --recursive -f
   # Use the version of the build script that was current when that
   # tag/release/branch was made.
   ./makexpi.sh $1 --no-recurse || exit 1
@@ -47,7 +46,7 @@ if [ -n "$1" ] && [ "$2" != "--no-recurse" ] ; then
   # Now escape from the horrible mess we've made
   cd ..
   XPI_NAME="$APP_NAME-$1"
-  cp $SUBDIR/pkg/$XPI_NAME.xpi pkg/
+  cp $SUBDIR/pkg/$XPI_NAME-eff.xpi pkg/
   if ! cp $SUBDIR/pkg/$XPI_NAME-amo.xpi pkg/ 2> /dev/null ; then
     echo Old version does not support AMO
   fi
@@ -107,8 +106,14 @@ cp -a translations/* pkg/xpi-eff/chrome/locale/
 rm -r pkg/xpi-eff/chrome/content/rules
 [ -e pkg/xpi-amo ] && rm -rf pkg/xpi-amo
 cp -a pkg/xpi-eff/ pkg/xpi-amo/
-# The AMO version of the package cannot contain the updateKey or updateURL tags
-sed -i.bak -e '/updateKey/d' -e '/updateURL/d' pkg/xpi-amo/install.rdf
+# The AMO version of the package cannot contain the updateKey or updateURL tags.
+# Also, it has a different id than the eff-hosted version, because Firefox now
+# requires us to upload the eff-hosted version to an unlisted extension on AMO
+# in order to receive a signature indicating that it is not malware.
+# https://github.com/efforg/https-everywhere/issues/2051
+sed -i.bak -e '/updateKey/d' -e '/updateURL/d' \
+ -e 's,<em:id>https-everywhere-eff@eff.org</em:id>,<em:id>https-everywhere@eff.org</em:id>,' \
+ pkg/xpi-amo/install.rdf
 rm pkg/xpi-amo/install.rdf.bak
 
 # Used for figuring out which branch to pull from when viewing source for rules
@@ -121,16 +126,16 @@ fi
 # Build the XPI!
 rm -f "${XPI_NAME}.xpi"
 rm -f "${XPI_NAME}-amo.xpi"
-python2.7 utils/create_xpi.py -n "${XPI_NAME}.xpi" -x ".build_exclusions" "pkg/xpi-eff"
+python2.7 utils/create_xpi.py -n "${XPI_NAME}-eff.xpi" -x ".build_exclusions" "pkg/xpi-eff"
 python2.7 utils/create_xpi.py -n "${XPI_NAME}-amo.xpi" -x ".build_exclusions" "pkg/xpi-amo"
 
 echo >&2 "Total included rules: `sqlite3 $RULESETS_SQLITE 'select count(*) from rulesets'`"
 echo >&2 "Rules disabled by default: `find src/chrome/content/rules -name "*.xml" | xargs grep -F default_off | wc -l`"
-echo >&2 "Created ${XPI_NAME}.xpi and ${XPI_NAME}-amo.xpi"
+echo >&2 "Created ${XPI_NAME}-eff.xpi and ${XPI_NAME}-amo.xpi"
 
-bash utils/android-push.sh "$XPI_NAME.xpi"
+bash utils/android-push.sh "$XPI_NAME-eff.xpi"
 
 if [ -n "$BRANCH" ]; then
-  cp $SUBDIR/$XPI_NAME.xpi pkg
+  cp $SUBDIR/${XPI_NAME}-eff.xpi $SUBDIR/${XPI_NAME}-amo pkg
   rm -rf $SUBDIR
 fi

--- a/src/install.rdf
+++ b/src/install.rdf
@@ -6,7 +6,7 @@
         <em:name>HTTPS-Everywhere</em:name>
         <em:creator>Mike Perry, Peter Eckersley, &amp; Yan Zhu</em:creator>
         <em:aboutURL>chrome://https-everywhere/content/about.xul</em:aboutURL>
-        <em:id>https-everywhere@eff.org</em:id>
+        <em:id>https-everywhere-eff@eff.org</em:id>
         <em:type>2</em:type> <!-- type: Extension -->
         <em:description>Encrypt the Web! Automatically use HTTPS security on many sites.</em:description>
         <em:version>5.0.9</em:version>
@@ -15,7 +15,7 @@
         <em:optionsURL>chrome://https-everywhere/content/observatory-preferences.xul</em:optionsURL>
         <em:iconURL>chrome://https-everywhere/skin/https-everywhere.png</em:iconURL>
         <em:unpack>true</em:unpack> <!-- Required for Firefox 4 -->
-        <em:updateURL>https://www.eff.org/files/https-everywhere-update-2048.rdf</em:updateURL>
+        <em:updateURL>https://www.eff.org/files/https-everywhere-eff-update-2048.rdf</em:updateURL> <!-- 2015-08-14: New update URL to go with new id (https-everywhere-eff@ef.org) -->
         <em:updateKey>MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA6MR8W/galdxnpGqBsYbqOzQb2eyW15YFjDDEMI0ZOzt8f504obNs920lDnpPD2/KqgsfjOgw2K7xWDJIj/18xUvWPk3LDkrnokNiRkA3KOx3W6fHycKL+zID7zy+xZYBuh2fLyQtWV1VGQ45iNRp9+Zo7rH86cdfgkdnWTlNSHyTLW9NbXvyv/E12bppPcEvgCTAQXgnDVJ0/sqmeiijn9tTFh03aM+R2V/21h8aTraAS24qiPCz6gkmYGC8yr6mglcnNoYbsLNYZ69zF1XHcXPduCPdPdfLlzVlKK1/U7hkA28eG3BIAMh6uJYBRJTpiGgaGdPd7YekUB8S6cy+CQIDAQAB</em:updateKey>
         <!-- Firefox -->
         <em:targetApplication>

--- a/test.sh
+++ b/test.sh
@@ -15,12 +15,12 @@ TEST_ADDON_PATH=./https-everywhere-tests/
 # We'll create a Firefox profile here and install HTTPS Everywhere into it.
 PROFILE_DIRECTORY="$(mktemp -d)"
 trap 'rm -r "$PROFILE_DIRECTORY"' EXIT
-HTTPSE_INSTALL_DIRECTORY=$PROFILE_DIRECTORY/extensions/https-everywhere@eff.org
+HTTPSE_INSTALL_DIRECTORY=$PROFILE_DIRECTORY/extensions/https-everywhere-eff@eff.org
 
 # Build the XPI to run all the validations in makexpi.sh, and to ensure that
 # we test what is actually getting built.
 ./makexpi.sh
-XPI_NAME="pkg/`ls -tr pkg/ | tail -1`"
+XPI_NAME="`ls -tr pkg/*-eff.xpi | tail -1`"
 
 # Set up a skeleton profile and then install into it.
 # The skeleton contains a few files required to trick Firefox into thinking

--- a/utils/make-sqlite.py
+++ b/utils/make-sqlite.py
@@ -33,12 +33,6 @@ c.execute('''DROP TABLE IF EXISTS targets''')
 c.execute('''CREATE TABLE targets
              (host TEXT,
               ruleset_id INTEGER)''')
-c.execute('''DROP TABLE IF EXISTS git_commit''')
-c.execute('''CREATE TABLE git_commit
-             (git_commit TEXT)''')
-
-git_commit = subprocess.check_output("git rev-parse HEAD", shell=True).rstrip("\n")
-c.execute('''INSERT INTO git_commit (git_commit) VALUES(?)''', (git_commit,))
 
 parser = etree.XMLParser(remove_blank_text=True)
 


### PR DESCRIPTION
To get an automated signature from AMO for self-hosting, we need to have
a separate unlisted version of our extension. Because of a problem in AMO,
the unlisted version cannot have the same id as the listed version. So we're
renaming the self-hosted version to https-everywhere-eff@eff.org.

This also includes a change to make-sqlite.py to remove the git commit table.
The new release process will require an initial build, then a signature, then a
second build. Since that second build will be at a different git commit,
rulesets.sqlite would change and cause the signature to no longer match.

@cooperq for review.