### PR TITLE
makexpi.sh: Fix cp (I think)

### DIFF
--- a/makexpi.sh
+++ b/makexpi.sh
@@ -136,6 +136,6 @@ echo >&2 "Created ${XPI_NAME}-eff.xpi and ${XPI_NAME}-amo.xpi"
 bash utils/android-push.sh "$XPI_NAME-eff.xpi"
 
 if [ -n "$BRANCH" ]; then
-  cp $SUBDIR/${XPI_NAME}-eff.xpi $SUBDIR/${XPI_NAME}-amo pkg
+  cp $SUBDIR/${XPI_NAME}-eff.xpi $SUBDIR/${XPI_NAME}-amo.xpi pkg
   rm -rf $SUBDIR
 fi


### PR DESCRIPTION
I think there's a mistake in a `cp` in the recent changes to `makexpi.sh`, but I don't use that part of it, so I'm not certain.

`cp $SUBDIR/$XPI_NAME.xpi pkg` was changed to `cp $SUBDIR/${XPI_NAME}-eff.xpi $SUBDIR/${XPI_NAME}-amo pkg` -- shouldn't that be `${XPI_NAME}-amo.xpi`?