### PR TITLE
Add www.hs-karlsruhe.de and qis.hs-karlsruhe.de to ruleset

### DIFF
--- a/src/chrome/content/rules/HsKA.xml
+++ b/src/chrome/content/rules/HsKA.xml
@@ -1,0 +1,6 @@
+<ruleset name="HsKA">
+        <target host="www.hs-karlsruhe.de" />
+	<target host="qis.hs-karlsruhe.de" />
+        <rule from="^http:"
+                to="https:" />
+</ruleset>


### PR DESCRIPTION
This commit adds www.hs-karlsruhe.de and qis.hs-karlsruhe.de to the ruleset