### PR TITLE
Fix justrun CLI params.

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -55,6 +55,7 @@ pushd $TEST_ADDON_PATH
 # If you just want to run Firefox with the latest code:
 if [ "$1" == "--justrun" ]; then
   echo "running firefox"
+  shift
   firefox -no-remote -profile "$PROFILE_DIRECTORY" "$@"
 else
   echo "running tests"


### PR DESCRIPTION
Prior to this, Firefox would get the `--justrun` flag, which would prevent it from processing the next arg passed.

cc @cooperq for review