### PR TITLE
Updated creativecommons.org, now contains rule for subdomain search

### DIFF
--- a/src/chrome/content/rules/CreativeCommons.xml
+++ b/src/chrome/content/rules/CreativeCommons.xml
@@ -12,8 +12,10 @@
 
 	<target host="creativecommons.net" />
 	<target host="creativecommons.org" />
-	<target host="search.creativecommons.org" /> 
-	<target host="donate.creativecommons.org" /> 
+	<target host="search.creativecommons.org" />
+	<target host="donate.creativecommons.org" />
+	<target host="i.creativecommons.org" />
+	<target host="api.creativecommons.org" />
 
 <rule from="^http:"
             to="https:" />

--- a/src/chrome/content/rules/CreativeCommons.xml
+++ b/src/chrome/content/rules/CreativeCommons.xml
@@ -12,13 +12,10 @@
 
 	<target host="creativecommons.net" />
 	<target host="creativecommons.org" />
-	<target host="*.creativecommons.org" />
+	<target host="search.creativecommons.org" /> 
+	<target host="donate.creativecommons.org" /> 
 
-
-	<rule from="^http://creativecommons\.net/"
-		to="https://creativecommons.net/" />
-
-	<rule from="^http://(i\.|api\.)?creativecommons\.org/"
-		to="https://$1creativecommons.org/" />
+<rule from="^http:"
+            to="https:" />
 
 </ruleset>


### PR DESCRIPTION
Should fix #2619.