### PR TITLE
[EDRi.org] Reenable

### DIFF
--- a/src/chrome/content/rules/EDRi.org.xml
+++ b/src/chrome/content/rules/EDRi.org.xml
@@ -11,7 +11,7 @@
 	* Secured by us
 
 -->
-<ruleset name="EDRi.org" default_off="connection dropped">
+<ruleset name="EDRi.org">
 
 	<!--	Direct rewrites:
 				-->


### PR DESCRIPTION
Site was default_off'ed due to dropped connections. Seems to work just fine though.