### PR TITLE
[WePromise.EU] Change default_off explanation

### DIFF
--- a/src/chrome/content/rules/WePromise.EU.xml
+++ b/src/chrome/content/rules/WePromise.EU.xml
@@ -2,7 +2,7 @@
 	For other EDRi coverage, see EDRi.org.xml.
 
 -->
-<ruleset name="WePromise.EU" default_off="connection dropped">
+<ruleset name="WePromise.EU" default_off="Certificate expired">
 
 	<!--	Direct rewrites:
 				-->


### PR DESCRIPTION
Site seems to work just fine but it does serve an expired certificate (unless I'm being MITMed).