### PR TITLE
[Akamai] Exclude imagesmtv-a.akamaihd.net

### DIFF
--- a/src/chrome/content/rules/Akamai.xml
+++ b/src/chrome/content/rules/Akamai.xml
@@ -24,8 +24,9 @@
 -->
 <ruleset name="Akamai">
 
-	<target host="*.abmr.net" />
-	<target host="*.e.akamai.net" />
+	<target host="ak1.abmr.net" />
+	<target host="ak1s.abmr.net" />
+	<target host="a248.e.akamai.net" />
 	<target host="*.akamaihd.net" />
 		<!--
 			Causes many streams to 403 and region restriction to trip inappropriately.
@@ -75,7 +76,7 @@
 										-->
 		<exclusion pattern="^http://zynga\d-a.akamaihd\.net/" />
 
-	<!--securecooie host="^\.abmr\.net$" name="^01AI$" /-->
+	<!--securecookie host="^\.abmr\.net$" name="^01AI$" /-->
 	<securecookie host=".*\.abmr\.net$" name=".+" />
 
 

--- a/src/chrome/content/rules/Akamai.xml
+++ b/src/chrome/content/rules/Akamai.xml
@@ -30,7 +30,7 @@
 		<!--
 			Causes many streams to 403 and region restriction to trip inappropriately.
 
-			https://mail1.eff.org/pipermail/https-everywhere-rules/2012-October/001324.html
+			https://lists.eff.org/pipermail/https-everywhere-rules/2012-October/001322.html
 			https://trac.torproject.org/projects/tor/ticket/6557
 			https://trac.torproject.org/projects/tor/ticket/6871
 			https://trac.torproject.org/projects/tor/ticket/7080

--- a/src/chrome/content/rules/Akamai.xml
+++ b/src/chrome/content/rules/Akamai.xml
@@ -73,6 +73,8 @@
 
 	<rule from="^http://a248\.e\.akamai\.net/"
 		to="https://a248.e.akamai.net/" />
+	<!--	Random URL via Google	-->
+	<test url="http://a248.e.akamai.net/f/248/3214/1d/www.zones.com/images/pdf/datasheet_symantec_managed_pki_for_ssl.pdf" />
 
 	<rule from="^http://([^@:/\.]+)\.akamaihd\.net/"
 		to="https://$1.akamaihd.net/" />

--- a/src/chrome/content/rules/Akamai.xml
+++ b/src/chrome/content/rules/Akamai.xml
@@ -28,6 +28,9 @@
 	<target host="ak1s.abmr.net" />
 	<target host="a248.e.akamai.net" />
 	<target host="*.akamaihd.net" />
+		<!--	Kill problematic implicit test	-->
+		<exclusion pattern="^http://ak1\.abmr\.net/$" />
+
 		<!--
 			Causes many streams to 403 and region restriction to trip inappropriately.
 

--- a/src/chrome/content/rules/Akamai.xml
+++ b/src/chrome/content/rules/Akamai.xml
@@ -37,12 +37,6 @@
 			https://trac.torproject.org/projects/tor/ticket/7577
 										-->
 		<exclusion pattern="^http://[\w-]+-(?:f|i|s|lh|vh)\.akamaihd\.net/" />
-                <!--
-			Apparently causes some Zynga games to fail to load.
-
-			https://trac.torproject.org/projects/tor/ticket/7090
-										-->
-		<exclusion pattern="^http://zynga\d-a.akamaihd\.net/" />
 
                 <!--
 			Breaks Titanfall, Github issue #390
@@ -55,6 +49,13 @@
 										-->
 		<exclusion pattern="^http://steamcommunity-a\.akamaihd\.net/" />
 		<test url="http://steamcommunity-a.akamaihd.net/" />
+
+                <!--
+			Apparently causes some Zynga games to fail to load.
+
+			https://trac.torproject.org/projects/tor/ticket/7090
+										-->
+		<exclusion pattern="^http://zynga\d-a.akamaihd\.net/" />
 
 	<!--securecooie host="^\.abmr\.net$" name="^01AI$" /-->
 	<securecookie host=".*\.abmr\.net$" name=".+" />

--- a/src/chrome/content/rules/Akamai.xml
+++ b/src/chrome/content/rules/Akamai.xml
@@ -37,7 +37,13 @@
 		 	https://trac.torproject.org/projects/tor/ticket/7198
 			https://trac.torproject.org/projects/tor/ticket/7577
 										-->
-		<exclusion pattern="^http://[\w-]+-(?:f|i|s|lh|vh)\.akamaihd\.net/" />
+		<exclusion pattern="^http://[\w-_]+-(?:f|i|s|lh|vh)\.akamaihd\.net/" />
+		<!--	Random URLs from VirusTotal	-->
+		<test url="http://svtarchive4a-f.akamaihd.net/crossdomain.xml" />
+		<test url="http://elpaishls-i.akamaihd.net/" />
+		<test url="http://a611avodslnsus-s.akamaihd.net/" />
+		<test url="http://radio_wlyk-lh.akamaihd.net/" />
+		<test url="http://yahoo7p-vh.akamaihd.net/" />
 
                 <!--
 			Breaks Titanfall, Github issue #390
@@ -78,6 +84,9 @@
 
 	<rule from="^http://([^@:/\.]+)\.akamaihd\.net/"
 		to="https://$1.akamaihd.net/" />
+	<!--	Facebook favicon, random dog picture	-->
+	<test url="http://fbstatic-a.akamaihd.net/rsrc.php/yl/r/H3nktOa7ZMg.ico" />
+	<test url="http://igcdn-photos-e-a.akamaihd.net/hphotos-ak-xaf1/t51.2885-15/11377989_454064614773572_1348139679_n.jpg" />
 
 	<!--	This secures some web bugs:
 						-->

--- a/src/chrome/content/rules/Akamai.xml
+++ b/src/chrome/content/rules/Akamai.xml
@@ -45,7 +45,7 @@
 		<test url="http://radio_wlyk-lh.akamaihd.net/" />
 		<test url="http://yahoo7p-vh.akamaihd.net/" />
 
-                <!--
+		<!--
 			Breaks Titanfall
 
 			https://github.com/EFForg/https-everywhere/issues/390
@@ -68,7 +68,7 @@
 		<exclusion pattern="^http://steamcommunity-a\.akamaihd\.net/" />
 		<test url="http://steamcommunity-a.akamaihd.net/" />
 
-                <!--
+		<!--
 			Apparently causes some Zynga games to fail to load.
 
 			https://trac.torproject.org/projects/tor/ticket/7090

--- a/src/chrome/content/rules/Akamai.xml
+++ b/src/chrome/content/rules/Akamai.xml
@@ -46,17 +46,24 @@
 		<test url="http://yahoo7p-vh.akamaihd.net/" />
 
                 <!--
-			Breaks Titanfall, Github issue #390
+			Breaks Titanfall
+
+			https://github.com/EFForg/https-everywhere/issues/390
 										-->
 		<exclusion pattern="^http://eaassets-a\.akamaihd\.net/" />
-		
-                <!--	Breaks images on http://www.mtv.com/news/		-->
+
+		<!--
+			Breaks images on http://www.mtv.com/news/
+
+			https://github.com/EFForg/https-everywhere/pull/2651
+										-->
 		<exclusion pattern="^http://imagesmtv-a\.akamaihd\.net/" />
 		<test url="http://imagesmtv-a.akamaihd.net/uri/mgid:uma:image:mtv.com:10737537?quality=0.8&amp;format=jpg&amp;width=110&amp;height=110" />
 
-				<!--
-					Steamcommunity.com Some Functionality is Broken due to CSP
-					https://github.com/EFForg/https-everywhere/issues/909
+		<!--
+			Steamcommunity.com Some Functionality is Broken due to CSP
+
+			https://github.com/EFForg/https-everywhere/issues/909
 										-->
 		<exclusion pattern="^http://steamcommunity-a\.akamaihd\.net/" />
 		<test url="http://steamcommunity-a.akamaihd.net/" />
@@ -74,7 +81,7 @@
 
 	<rule from="^http://ak1s\.abmr\.net/"
 		to="https://ak1s.abmr.net/" />
-	<!--	just use an URL from the ak1.abmr.net rule below	-->
+	<!--	Just use an URL from the ak1.abmr.net rule below	-->
 	<test url="http://ak1s.abmr.net/is/pixel.mathtag.com?U=/sync/js&amp;V=3-Z%2fH%2fr0WN0ZYjakDDxKo0khM8NMHcJc8atNMBjTJyWU5qDSjB7759WA%3d%3d&amp;I=E33624F6D7AF512&amp;D=mathtag.com&amp;01AD=1&amp;sync=auto&amp;mt_lim=5" />
 
 	<rule from="^http://a248\.e\.akamai\.net/"

--- a/src/chrome/content/rules/Akamai.xml
+++ b/src/chrome/content/rules/Akamai.xml
@@ -68,6 +68,8 @@
 
 	<rule from="^http://ak1s\.abmr\.net/"
 		to="https://ak1s.abmr.net/" />
+	<!--	just use an URL from the ak1.abmr.net rule below	-->
+	<test url="http://ak1s.abmr.net/is/pixel.mathtag.com?U=/sync/js&amp;V=3-Z%2fH%2fr0WN0ZYjakDDxKo0khM8NMHcJc8atNMBjTJyWU5qDSjB7759WA%3d%3d&amp;I=E33624F6D7AF512&amp;D=mathtag.com&amp;01AD=1&amp;sync=auto&amp;mt_lim=5" />
 
 	<rule from="^http://a248\.e\.akamai\.net/"
 		to="https://a248.e.akamai.net/" />
@@ -79,5 +81,8 @@
 						-->
 	<rule from="^http://ak1\.abmr\.net/is/(www.imiclk|pixel\.mathtag)\.com(?=$|\?)"
 		to="https://ak1s.abmr.net/is/$1.com" />
+	<!--	URLs from VirusTotal logs	-->
+	<test url="http://ak1.abmr.net/is/www.imiclk.com?U=/cgi/r.cgi&amp;V=3-tN8HyxniOqgs9sXSs1oQAeDmaU+wHxXRMcQxYf408a0m1hiIZDE2DY1Gni9Uk4d2&amp;I=67CD51D18E7F617&amp;D=www.imiclk.com&amp;01AD=1&amp;did=email&amp;m=3&amp;mid=CuCACD9s&amp;sp=1" />
+	<test url="http://ak1.abmr.net/is/pixel.mathtag.com?U=/sync/js&amp;V=3-Z%2fH%2fr0WN0ZYjakDDxKo0khM8NMHcJc8atNMBjTJyWU5qDSjB7759WA%3d%3d&amp;I=E33624F6D7AF512&amp;D=mathtag.com&amp;01AD=1&amp;sync=auto&amp;mt_lim=5" />
 
 </ruleset>

--- a/src/chrome/content/rules/Akamai.xml
+++ b/src/chrome/content/rules/Akamai.xml
@@ -37,7 +37,7 @@
 		 	https://trac.torproject.org/projects/tor/ticket/7198
 			https://trac.torproject.org/projects/tor/ticket/7577
 										-->
-		<exclusion pattern="^http://[\w-_]+-(?:f|i|s|lh|vh)\.akamaihd\.net/" />
+		<exclusion pattern="^http://[\w_-]+-(?:f|i|s|lh|vh)\.akamaihd\.net/" />
 		<!--	Random URLs from VirusTotal	-->
 		<test url="http://svtarchive4a-f.akamaihd.net/crossdomain.xml" />
 		<test url="http://elpaishls-i.akamaihd.net/" />

--- a/src/chrome/content/rules/Akamai.xml
+++ b/src/chrome/content/rules/Akamai.xml
@@ -50,7 +50,7 @@
 
 				<!--
 					Steamcommunity.com Some Functionality is Broken due to CSP
-					GitHub Issue #909
+					https://github.com/EFForg/https-everywhere/issues/909
 										-->
 		<exclusion pattern="^http://steamcommunity-a\.akamaihd\.net/" />
 		<test url="http://steamcommunity-a.akamaihd.net/" />

--- a/src/chrome/content/rules/Akamai.xml
+++ b/src/chrome/content/rules/Akamai.xml
@@ -11,6 +11,7 @@
 	Nonfunctional domains:
 
 		- http14432.storage.akadns.net		(CN: contentstorage.akamai.com)
+		- imagesmtv-a.akamaihd.net		("An error occurred while processing your request.")
 		- cp44823.edgefcs.net			(reset)
 
 
@@ -43,6 +44,10 @@
 										-->
 		<exclusion pattern="^http://eaassets-a\.akamaihd\.net/" />
 		
+                <!--	Breaks images on http://www.mtv.com/news/		-->
+		<exclusion pattern="^http://imagesmtv-a\.akamaihd\.net/" />
+		<test url="http://imagesmtv-a.akamaihd.net/uri/mgid:uma:image:mtv.com:10737537?quality=0.8&amp;format=jpg&amp;width=110&amp;height=110" />
+
 				<!--
 					Steamcommunity.com Some Functionality is Broken due to CSP
 					GitHub Issue #909

--- a/utils/duplicate-whitelist.txt
+++ b/utils/duplicate-whitelist.txt
@@ -9,6 +9,7 @@ adyadvantage.com
 affair-guide.com
 afp548.com
 aftenposten.no
+a248.e.akamai.net
 livewire.amnesty.org
 anunciou.com
 arch-stuff.org


### PR DESCRIPTION
http://imagesmtv-a.akamaihd.net/ needs to be excluded to avoid breaking all the images on <http://www.mtv.com/news/>.

Edit: Several paragraphs about testing removed. I was able to mint enough mediocre tests for the other rules in the ruleset to satisfy the scripts.