### PR TITLE
Add ruleset for docs.saltstack.com.

### DIFF
--- a/src/chrome/content/rules/SaltStack.com.xml
+++ b/src/chrome/content/rules/SaltStack.com.xml
@@ -1,4 +1,5 @@
 <ruleset name="SaltStack">
+	<target host="saltstack.com" />
 	<target host="docs.saltstack.com" />
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/SaltStack.com.xml
+++ b/src/chrome/content/rules/SaltStack.com.xml
@@ -1,0 +1,6 @@
+<ruleset name="SaltStack">
+	<target host="docs.saltstack.com" />
+
+	<rule from="^http:"
+		to="https:" />
+</ruleset>


### PR DESCRIPTION
The main site (saltstack.com) currently has mixed content warnings over HTTPS. I'm not sure if it's still ok to add to the ruleset or not (I don't think any functionality breaks, it looks like it's just some favicons?), so I would appreciate some guidance on that.