### PR TITLE
makexpi.sh: Replace `cp` with `rsync` to save copying & deleting rules

### DIFF
--- a/makexpi.sh
+++ b/makexpi.sh
@@ -100,12 +100,9 @@ fi
 
 # Prepare packages suitable for uploading to EFF and AMO, respectively.
 [ -d pkg ] || mkdir pkg
-[ -e pkg/xpi-eff ] && rm -rf pkg/xpi-eff
-cp -a src/ pkg/xpi-eff/
+rsync -a --delete --delete-excluded --exclude /chrome/content/rules src/ pkg/xpi-eff
 cp -a translations/* pkg/xpi-eff/chrome/locale/
-rm -r pkg/xpi-eff/chrome/content/rules
-[ -e pkg/xpi-amo ] && rm -rf pkg/xpi-amo
-cp -a pkg/xpi-eff/ pkg/xpi-amo/
+rsync -a --delete pkg/xpi-eff/ pkg/xpi-amo
 # The AMO version of the package cannot contain the updateKey or updateURL tags.
 # Also, it has a different id than the eff-hosted version, because Firefox now
 # requires us to upload the eff-hosted version to an unlisted extension on AMO


### PR DESCRIPTION
Reduces runtime of an optimal `make` (rules unchanged, everything in fs cache) by 75% on one of my systems.

The locales are still by and large deleted and then copied again, but it's speedy and difficult to fix.

This *does* add `rsync` as a dependency of `make`. I'll note that 1.) rsync is lovely and everyone should install it, 2.) `test.sh` already depends on it. I could add back the slow path, too.