### PR TITLE
Fix Fastmail sending the wrong certificate

### DIFF
--- a/src/chrome/content/rules/Fastmail.xml
+++ b/src/chrome/content/rules/Fastmail.xml
@@ -33,7 +33,17 @@
 	<rule from="^http://(www\.)?fastmail\.(com|fm)/"
 		to="https://www.fastmail.com/" />
 
+	<test url="http://fastmail.com/" />
+	<test url="http://www.fastmail.com/" />
+	<test url="http://fastmail.fm/" />
+	<test url="http://www.fastmail.fm/" />
+
 	<rule from="^http://(beta|qa)\.fastmail\.(com|fm)/"
 		to="https://$1.fastmail.com/" />
+
+	<test url="http://beta.fastmail.com/" />
+	<test url="http://qa.fastmail.com/" />
+	<test url="http://beta.fastmail.fm/" />
+	<test url="http://qa.fastmail.fm/" />
 
 </ruleset>

--- a/src/chrome/content/rules/Fastmail.xml
+++ b/src/chrome/content/rules/Fastmail.xml
@@ -27,8 +27,13 @@
 
 	<securecookie host="^\.www\.fastmail\.(?:com|fm)$" name=".+" />
 
+	<!--
+		The server sends an incorrect (non-EV) certificate when www. isn't used
+	-->
+	<rule from="^http://(www\.)?fastmail\.(com|fm)/"
+		to="https://www.fastmail.com/" />
 
-	<rule from="^http://((?:beta|qa|www)\.)?fastmail\.(com|fm)/"
-		to="https://$1fastmail.com/" />
+	<rule from="^http://(beta|qa)\.fastmail\.(com|fm)/"
+		to="https://$1.fastmail.com/" />
 
 </ruleset>


### PR DESCRIPTION
The server sends a different, non-EV, certificate if you go to https://fastmail.com rather than https://www.fastmail.com, even though you get redirected to www the non-EV certificate persists.

I let Fastmail know about this a few months ago but they haven't fixed it.