### PR TITLE
[Wikimedia.xml] mixed content has been fixed

### DIFF
--- a/src/chrome/content/rules/Wikimedia.xml
+++ b/src/chrome/content/rules/Wikimedia.xml
@@ -24,15 +24,6 @@
 		- .wikiversity.org
 
 
-	Mixed content:
-
-		- Images, on:
-
-			- stats.wikimedia.org from upload.wikimedia.org *
-			- stats.wikimedia.org from wikimediafoundation.org *
-
-	* Secured by us
-
 -->
 <ruleset name="Wikimedia">
 


### PR DESCRIPTION
The mixed content issue on https://stats.wikimedia.org/ has been fixed.[1] So remove the mixed content section in the comment.

[1] https://phabricator.wikimedia.org/T93702