### PR TITLE
[Wikimedia.xml] Remove some redundant rules

### DIFF
--- a/src/chrome/content/rules/Wikimedia.xml
+++ b/src/chrome/content/rules/Wikimedia.xml
@@ -131,9 +131,6 @@
 	<rule from="^http://(en|fr)wp\.org/"
 		to="https://$1.wikipedia.org/wiki/" />
 
-	<rule from="^http://(?:www\.)?mediawiki\.org/"
-		to="https://www.mediawiki.org/" />
-
 	<rule from="^http://noboard\.chapters\.wikimedia\.org/"
 		to="https://noboard-chapters.wikimedia.org/" />
 		<test url="http://noboard.chapters.wikimedia.org/" />

--- a/src/chrome/content/rules/Wikimedia.xml
+++ b/src/chrome/content/rules/Wikimedia.xml
@@ -138,10 +138,6 @@
 		to="https://noboard-chapters.wikimedia.org/" />
 		<test url="http://noboard.chapters.wikimedia.org/" />
 
-	<rule from="^http://sitemap\.wikimedia\.org/"
-		to="https://dumps.wikimedia.org/" />
-		<test url="http://sitemap.wikimedia.org/" />
-
 	<rule from="^http://links\.email\.donate\.wikimedia\.org/"
 		to="https://www.links.mkt41.net/" />
 		<test url="http://links.email.donate.wikimedia.org/" />

--- a/src/chrome/content/rules/Wikimedia.xml
+++ b/src/chrome/content/rules/Wikimedia.xml
@@ -43,11 +43,9 @@
 	<target host="*.mediawiki.org" />
 	<target host="wikimedia.org" />
 	<target host="*.wikimedia.org" />
-		<exclusion pattern="^http://(?:apt|cs|cz|parsoid-lb\.eqiad|smokeping|status|torrus|ubuntu)\.wikimedia\.org" />
+		<exclusion pattern="^http://(?:apt|parsoid-lb\.eqiad|smokeping|status|torrus|ubuntu)\.wikimedia\.org" />
 		<!-- https://mail1.eff.org/pipermail/https-everywhere-rules/2012-June/001189.html -->
 			<test url="http://apt.wikimedia.org" />
-			<test url="http://cs.wikimedia.org" />
-			<test url="http://cz.wikimedia.org" />
 			<test url="http://parsoid-lb.eqiad.wikimedia.org" />
 			<test url="http://smokeping.wikimedia.org" />
 			<test url="http://status.wikimedia.org" />
@@ -140,9 +138,8 @@
 		to="https://noboard-chapters.wikimedia.org/" />
 		<test url="http://noboard.chapters.wikimedia.org/" />
 
-	<rule from="^http://(?:download|sitemap)\.wikimedia\.org/"
+	<rule from="^http://sitemap.wikimedia.org/"
 		to="https://dumps.wikimedia.org/" />
-		<test url="http://download.wikimedia.org/" />
 		<test url="http://sitemap.wikimedia.org/" />
 
 	<rule from="^http://links\.email\.donate\.wikimedia\.org/"
@@ -152,10 +149,6 @@
 	<rule from="^http://labs-ns0\.wikimedia\.org/"
 		to="https://wikitech.wikimedia.org/" />	
 		<test url="http://labs-ns0.wikimedia.org/" />
-
-	<rule from="^http://download\.wikipedia\.org/"
-		to="https://dumps.wikimedia.org/" />
-		<test url="http://download.wikipedia.org/" />
 
 	<rule from="^http:"
 		to="https:" />

--- a/src/chrome/content/rules/Wikimedia.xml
+++ b/src/chrome/content/rules/Wikimedia.xml
@@ -138,7 +138,7 @@
 		to="https://noboard-chapters.wikimedia.org/" />
 		<test url="http://noboard.chapters.wikimedia.org/" />
 
-	<rule from="^http://sitemap.wikimedia.org/"
+	<rule from="^http://sitemap\.wikimedia\.org/"
 		to="https://dumps.wikimedia.org/" />
 		<test url="http://sitemap.wikimedia.org/" />
 


### PR DESCRIPTION
https://cs.wikimedia.org/, https://cz.wikimedia.org/, https://download.wikimedia.org/, https://download.wikipedia.org/, https://sitemap.wikimedia.org/ no longer use invalid certificates, so these can be covered by the general http to https rewrite.