### PR TITLE
Add rule for Respekt.cz

### DIFF
--- a/src/chrome/content/rules/respekt.cz.xml
+++ b/src/chrome/content/rules/respekt.cz.xml
@@ -1,0 +1,7 @@
+<ruleset name="Respekt.cz" default_off="Broken login form, may work seamlessly with platform='mixedcontent'">
+	<target host="respekt.cz" />
+	<target host="www.respekt.cz" />
+
+	<rule from="^http:"
+		to="https:" />
+</ruleset>


### PR DESCRIPTION
The rule is disabled by default so that user login form is not broken,
however it's still nice to have the rule around in order to be able to
opt-in for https (as everything else works).

On Tor Browser, the login form may even work with the rule enabled by
default (if it isn't also overriden by cross-origin blocker, see
https://github.com/EFForg/https-everywhere/issues/2695 for details).