### PR TITLE
Add rule for www.sainsburys.co.uk

### DIFF
--- a/src/chrome/content/rules/Sainsburys.co.uk.xml
+++ b/src/chrome/content/rules/Sainsburys.co.uk.xml
@@ -1,0 +1,5 @@
+<ruleset name="Sainsburys.co.uk">
+  <target host="www.sainsburys.co.uk" />
+
+  <rule from="^http:" to="https:" />
+</ruleset>


### PR DESCRIPTION
This rule only supports `www` because the bare domain doesn't have a valid SSL certificate.

Some things (like login) are already using HTTPS, but this rule ensures that all pages use HTTPS and we don't end up with silly things like login forms on an HTTP page with an HTTPS action.