### PR TITLE
Add trivial rule for Strava

### DIFF
--- a/src/chrome/content/rules/Strava.com.xml
+++ b/src/chrome/content/rules/Strava.com.xml
@@ -1,0 +1,6 @@
+<ruleset name="Strava.com">
+  <target host="strava.com" />
+  <target host="www.strava.com" />
+
+  <rule from="^http:" to="https:" />
+</ruleset>


### PR DESCRIPTION
Both `strava.com` and `www.strava.com` have valid certificates.