### PR TITLE
[THC.org] Disable ruleset due to expired cert

### DIFF
--- a/src/chrome/content/rules/THC.xml
+++ b/src/chrome/content/rules/THC.xml
@@ -1,11 +1,11 @@
 <!--
-	Fully covered subdomains:
+	Cert expired on 01/08/15 15:29
 
+	Fully covered subdomains:
 		- ircs-web
 		- wiki
-
 -->
-<ruleset name="The Hacker's Choice">
+<ruleset name="The Hacker's Choice" default_off="expired cert">
 
 	<target host="thc.org"/>
 	<target host="freeworld.thc.org"/>


### PR DESCRIPTION
Cert expired a month ago (01/08/15 15:29).