### PR TITLE
[DR.dk] Fix radio streaming

### DIFF
--- a/src/chrome/content/rules/DR.dk.xml
+++ b/src/chrome/content/rules/DR.dk.xml
@@ -12,8 +12,17 @@
 	<target host="dr.dk" />
 	<target host="*.dr.dk" />
 
+	<!-- Causes redirect loops: -->
+	<exclusion pattern="^http://www\.dr\.dk/(?:radio/.|mu/|assets/js/004/dr/elements/dist/swf/)" />
+
+	<test url="http://www.dr.dk/radio/ondemand/p1/bagklog-pa-p1-12" />
+	<test url="http://www.dr.dk/mu/programcard/expanded/bagklog-pa-p1-12" />
+	<test url="http://www.dr.dk/assets/js/004/dr/elements/dist/swf/audioplayer_4ba05f7811c0ca29a75c10115162a1b3.swf" />
 
 	<rule from="^http://(asset\.|www\.)?dr\.dk/"
 		to="https://$1dr.dk/" />
+
+	<test url="http://www.dr.dk/" />
+	<test url="http://asset.dr.dk/" />
 
 </ruleset>


### PR DESCRIPTION
Radio links currently give rise to a https<->http redirect loop. Simply
excluding the relevant radio pages gives rise to CORS issues instead, and
after excluding the URLs giving rise to those, the Flash radio player still
needs to be fetched over HTTP for whatever reason.