### PR TITLE
Cache Travis's python packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
 cache:
   directories:
     - $HOME/.cache/pip
+    - $HOME/virtualenv/python2.7_with_system_site_packages
 addons:
   apt:
     packages:


### PR DESCRIPTION
Just caching pip only saves the downloads, but the most time is spent compiling.

Signed-off-by: Nick Semenkovich <semenko@alum.mit.edu>