### PR TITLE
[Agar.io] Reenable ruleset

### DIFF
--- a/src/chrome/content/rules/Agar.io.xml
+++ b/src/chrome/content/rules/Agar.io.xml
@@ -1,9 +1,11 @@
-<ruleset name="Agar.io" default_off="webmaster request">
+<ruleset name="Agar.io">
 	<target host="agar.io" />
 	<target host="www.agar.io" />
+
+	<target host="gc.agar.io" />
 	<target host="m.agar.io" />
 
-	<rule from="^http://(www\.)?agar\.io/"
+	<rule from="^http://(?:www\.)?agar\.io/"
 		to="https://agar.io/" />
 
 	<rule from="^http:"


### PR DESCRIPTION
Fixes #2799.

The ruleset was previously disabled upon webmaster request, but the webmaster has now requested that it be reenabled (GH #2799).