### PR TITLE
Disable PrintFriendly Rules

### DIFF
--- a/src/chrome/content/rules/PrintFriendly.xml
+++ b/src/chrome/content/rules/PrintFriendly.xml
@@ -6,7 +6,7 @@
 	* Desk.com
 
 -->
-<ruleset name="PrintFriendly.com (partial)">
+<ruleset name="PrintFriendly.com (partial)" default_off="webmaster request">
 
 	<!--	Direct rewrites:
 				-->


### PR DESCRIPTION
The rules are invalid currently and HTTPS for our main domain will not
work 100% since we embed third party content which may not be HTTPS