### PR TITLE
Set the size of favicons to 16x16 on Chrome extension

### DIFF
--- a/chromium/popup.css
+++ b/chromium/popup.css
@@ -25,6 +25,8 @@ section.rules {
 
 /* Favicons */
 .rule img {
+  width: 16px;
+  height: 16px;
   margin-left: 0.6em;
   vertical-align: bottom;
 }


### PR DESCRIPTION
On high DPI/Retina displays, Chrome uses a higher resolution image for the generic favicon. This can cause some odd layout placement on the popup page.

<img width="390" alt="screen shot 2015-09-09 at 5 42 26 pm" src="https://cloud.githubusercontent.com/assets/6135313/9758760/21720676-571b-11e5-962a-3a65a4124fcc.png">

The fix is to just simply set the width and height of the ```<img>``` tag to 16.

<img width="377" alt="screen shot 2015-09-09 at 5 42 57 pm" src="https://cloud.githubusercontent.com/assets/6135313/9758763/247948ac-571b-11e5-93a1-c2f44ead3f56.png">