### PR TITLE
Fix ReadTheDocs rules

### DIFF
--- a/src/chrome/content/rules/ReadTheDocs.xml
+++ b/src/chrome/content/rules/ReadTheDocs.xml
@@ -1,10 +1,6 @@
 <!--
 	readthedocs.org and readthedocs.com work correctly.
 	
-	Working subdomains on readthedocs.org / readthedocs.com:
-		- www
-		- media
-
 	All other *.readthedocs.(com|org) and *.rtfd.org
 	use the '*.readthedocs.org' certificate.
 -->
@@ -19,24 +15,16 @@
 	<target host="rtfd.org" />
 	<target host="*.rtfd.org" />
 	
-	<exclusion pattern="^https://www\.readthedocs\.com/" />
-	<exclusion pattern="^https://media\.readthedocs\.com/" />
-	
 	<test url="http://www.readthedocs.com/" />
 	<test url="http://media.readthedocs.com/" />
-	<test url="https://www.readthedocs.com/" />
-	<test url="https://media.readthedocs.com/" />
 	
 	<test url="http://testing.readthedocs.org/" />
-	<test url="http://testing.readthedocs.com/" />
-	<test url="https://testing.readthedocs.com/" />
+	<test url="http://blog.readthedocs.com/" />
 	<test url="http://testing.rtfd.org/" />
 
 	<securecookie host="^readthedocs\.org$" name=".+" />
 	<securecookie host="^readthedocs\.com$" name=".+" />
 	
-	<rule from="^http://(www|media)\.readthedocs\.com/" to="https://$1.readthedocs.com/" />
-	<rule from="^https?://(.+)\.readthedocs\.com/" to="https://$1.readthedocs.org/" />
 	<rule from="^https?://(.+\.)?rtfd\.org/" to="https://$1readthedocs.org/" />
 	<rule from="^http:" to="https:" />
 </ruleset>


### PR DESCRIPTION
Fixes GH-2847

/cc @ericholscher

Both .com and .org are fully https with *.readthedocs.org and *.readthedocs.com certificates.

So I _think_ this change will just 100% redirect everything correctly? Not 100% sure how to test.