### PR TITLE
Exclude irc.t411.io from rewrite

### DIFF
--- a/src/chrome/content/rules/T411.xml
+++ b/src/chrome/content/rules/T411.xml
@@ -7,9 +7,15 @@
   <test url="http://wiki.t411.io/" />
   <test url="http://www.t411.io/" />
   <test url="http://forum.t411.io/" />
+  <test url="http://api.t411.io/" />
   <test url="http://wiki.t411.me/" />
   <test url="http://www.t411.me/" />
   <test url="http://forum.t411.me/" />
+  <test url="http://api.t411.me/" />
+  
+  <exclusion pattern="^http://irc\.t411\.(io|me)/" />
+  <test url="http://irc.t411.me/" />
+  <test url="http://irc.t411.io/" />
   
   <rule from="^http:" to="https:" />
   <securecookie host="^.*t411\.(io|me)$" name=".*" />


### PR DESCRIPTION
Special server irc.t411.io (also accessible through irc.t411.me) doesn't
provide any secured channel. Trying to access the server with https will
fail. An exclusion rule has been added thus.

Also added a coverage test for the server api.t411.io (and its .me
counterpart).

Note: yes, the server includes a specific web server, in addition to the
IRC service. The IRC service can be accessed with SSL on a specific
port, the web service cannot. The web server at irc.t411.io is a
different one than www.t411.io.

Signed-off-by: Cilyan Olowen <gaknar@gmail.com>