### PR TITLE
Fix mktemp crash

### DIFF
--- a/test/chromium.sh
+++ b/test/chromium.sh
@@ -17,7 +17,7 @@ if [ "$1" == "--justrun" ]; then
 	shift
 	./makecrx.sh
 	echo "running Chromium"
-	./utils/mktemp.sh
+	source utils/mktemp.sh
 
 	PROFILE_DIRECTORY="$(mktemp -d)"
 	trap 'rm -r "$PROFILE_DIRECTORY"' EXIT


### PR DESCRIPTION
```
+ ./utils/mktemp.sh
./utils/mktemp.sh: 9: ./utils/mktemp.sh: Syntax error: "(" unexpected
```

This is what happens when ```test/chromium.sh``` is run with the ```--justrun``` parameter. This PR fixes the error.