### PR TITLE
[carleton.ca] Disable ruleset for people.scs.carleton.ca

### DIFF
--- a/src/chrome/content/rules/Carleton.ca.xml
+++ b/src/chrome/content/rules/Carleton.ca.xml
@@ -94,6 +94,7 @@
 		<exclusion pattern="^http://(?:alumni|graduate|newsroom|sprott)\.carleton\.ca/(?!wp-content/|wp-includes/)" />
 		<exclusion pattern="^http://events\.carleton\.ca/(?!cu_global/|wp-content/|wp-includes/)" />
 		<exclusion pattern="^http://researchworks\.carleton\.ca/(?!cu/wp-content/|cu/wp-includes/)" />
+		<exclusion pattern="^http://people\.scs\.carleton\.ca/" />
 
 
 	<!--	Not secured by server:


### PR DESCRIPTION
```
~ > nmap -p80,443 people.scs.carleton.ca

Starting Nmap 6.49SVN ( https://nmap.org ) at 2015-09-11 14:18 EDT
Nmap scan report for people.scs.carleton.ca (134.117.29.41)
Host is up (0.092s latency).
PORT    STATE    SERVICE
80/tcp  open     http
443/tcp filtered https

Nmap done: 1 IP address (1 host up) scanned in 1.90 seconds
```