### PR TITLE
Make ./test.sh --justrun work on OS X

### DIFF
--- a/test/firefox.sh
+++ b/test/firefox.sh
@@ -61,7 +61,11 @@ pushd $TEST_ADDON_PATH
 if [ "$1" == "--justrun" ]; then
   echo "running firefox"
   shift
-  firefox -no-remote -profile "$PROFILE_DIRECTORY" "$@"
+  if [ $(uname) == Darwin ]; then
+    open /Applications/Firefox.app --wait-apps --new --args -no-remote -profile "$PROFILE_DIRECTORY" "$@"
+  else
+    firefox -no-remote -profile "$PROFILE_DIRECTORY" "$@"
+  fi
 else
   echo "running tests"
   cfx test --profiledir="$PROFILE_DIRECTORY" --verbose


### PR DESCRIPTION
I've tested the OS X side of this fairly thoroughly. In theory it should also be tested on GNU/Linux, but the change is so simple, who cares. I'm sure it works.