### PR TITLE
Don't redirect gettingstarted.exposure.co to HTTPS

### DIFF
--- a/src/chrome/content/rules/Exposure.co.xml
+++ b/src/chrome/content/rules/Exposure.co.xml
@@ -9,6 +9,7 @@
 	Nonfunctional hosts in *exposure.co:
 
 		- changes *
+		- gettingstarted *
 
 	* Tumblr
 
@@ -41,9 +42,10 @@
 	<target host="exposure.co" />
 	<target host="*.exposure.co" />
 
-		<exclusion pattern="^http://(?:changes|support)\.exposure\.co/" />
+		<exclusion pattern="^http://(?:changes|gettingstarted|support)\.exposure\.co/" />
 
 			<test url="http://changes.exposure.co/" />
+			<test url="http://gettingstarted.exposure.co/" />
 			<test url="http://support.exposure.co/" />
 
 		<test url="http://charitywater.exposure.co/" />


### PR DESCRIPTION
It runs on Tumblr and only supports HTTP.