### PR TITLE
Provide a fallback chromedriver for other Linuxes as well

### DIFF
--- a/test/chromium/script.py
+++ b/test/chromium/script.py
@@ -41,6 +41,9 @@ elif sys.platform.startswith("linux"):
         #Debian is lowercase when platform.linux_distribution() is used.
         #This is not a mistake.
         chromedriver_path = "/usr/lib/chromium/chromedriver"
+    else:
+        # Let's hope it's in the user's path.
+        chromedriver_path = "chromedriver"
 else:
     # Let's hope it's in the user's path.
     chromedriver_path = "chromedriver"


### PR DESCRIPTION
When running the test scripts (and thus pre-commit hook) on a Linux distribution which is neither Ubuntu or Debian, the `chromedriver_path` variable isn't set at all, and the script will then always fail with a error such as this:

```plain
Traceback (most recent call last):
  File "test/chromium/script.py", line 51, in <module>
    driver = webdriver.Chrome(chromedriver_path, chrome_options=chromeOps)
NameError: name 'chromedriver_path' is not defined
```

This fixes that by providing the fallback value of just "chromedriver" to other Linux distributions, which at least makes it work on my machine (running Arch Linux).