### PR TITLE
Fix kinopoisk.ru charts

### DIFF
--- a/src/chrome/content/rules/Yandex.net.xml
+++ b/src/chrome/content/rules/Yandex.net.xml
@@ -21,6 +21,7 @@
 		- img.encyc *
 		- vec0[1-4].maps ⁴
 		- static.video ⁵
+		- st.kp 6
 
 	¹ 404
 	² Mismatched
@@ -29,6 +30,7 @@
 	* Mismatched, CN: yastatic.net
 	⁴ Unspecified effect[?]
 	⁵ Apparently breaks video
+	6 Breaks charts on kinopoisk
 
 
 	Fully covered subdomains:
@@ -82,7 +84,6 @@
 			- img
 			- img[1-7]-fotki
 			- imgl
-			- st.kp
 			- audio.lingvo
 			- webattach.mail
 			- mailstatic
@@ -178,6 +179,12 @@
 
 			<test url="http://static.video.yandex.net/" />
 			<test url="http://static.video.yandex.net//" />
+		<!--
+			Needed for kinopoisk charts to work:
+								-->
+		<exclusion pattern="^http://st\.kp\.yandex\.net/" />
+
+			<test url="http://st.kp.yandex.net/" />
 
 		<!--
 			Miscellanious:
@@ -225,7 +232,6 @@
 		<test url="http://img.yandex.net/" />
 		<test url="http://img1-fotki.yandex.net/" />
 		<test url="http://imgl.yandex.net/" />
-		<test url="http://st.kp.yandex.net/" />
 		<test url="http://audio.lingvo.yandex.net/" />
 		<test url="http://webattach.mail.yandex.net/" />
 		<test url="http://mailstatic.yandex.net/" />


### PR DESCRIPTION
Kinopoisk.ru use amcharts to draw charts (for example, [here](http://www.kinopoisk.ru/votes/)). Some time ago charts were broken by extension.