### PR TITLE
[Spiegel.de] fix Fußball live

### DIFF
--- a/src/chrome/content/rules/Spiegel.xml
+++ b/src/chrome/content/rules/Spiegel.xml
@@ -88,7 +88,7 @@
 		<!--
 			Combined:
 					-->
-		<exclusion pattern="^http://www\.spiegel\.de/(?!images/|layout/|pics/|static/(?!flash/)|staticgen/)" />
+		<exclusion pattern="^http://www\.spiegel\.de/(?!images/|layout/|pics/)" />
 
 			<!--	+ve:
 					-->
@@ -105,7 +105,6 @@
 			<test url="http://www.spiegel.de/layout/jscfg/http/global-V6-7.js" />
 			<test url="http://www.spiegel.de/pics/43/0,1020,308043,00.jpg" />
 			<test url="http://www.spiegel.de/static/sys/dimensionspixel.gif" />
-			<test url="http://www.spiegel.de/staticgen/fussballticker/heatmaps/BUNDESLIGA/201213/18/spiegel_heatmap_138361_35099_440_330.jpg" />
 
 
 	<!--	Not secured by server:


### PR DESCRIPTION
This fixes this page for example:
http://www.spiegel.de/sport/fussball/bundesliga-live-ticker-tabelle-ergebnisse-spielplan-statistik-a-842988.html#contest=bl1

This page uses javascript and it fails to load the additional parts without this change.