### PR TITLE
Fix tldrlegal.com

### DIFF
--- a/src/chrome/content/rules/TLDRLegal.com.xml
+++ b/src/chrome/content/rules/TLDRLegal.com.xml
@@ -22,7 +22,7 @@
 	<securecookie host="^\.tldrlegal\.com$" name="^tldrlegal\.sid$" />
 
 
-	<rule from="^http://(www\.)?tldrlegal\.com/"
-		to="https://$1tldrlegal.com/" />
+	<rule from="^https?://(www\.)?tldrlegal\.com/"
+		to="https://tldrlegal.com/" />
 
 </ruleset>


### PR DESCRIPTION
Website cert valid for `tldrlegal.com`, `community.tldrlegal.com`, `dev.tldrlegal.com`, but not for `www.tldrlegal.com`.