### PR TITLE
Fix access to default_off attribute in RuleSets lib.

### DIFF
--- a/chromium/rules.js
+++ b/chromium/rules.js
@@ -188,7 +188,7 @@ RuleSets.prototype = {
     var default_off = ruletag.getAttribute("default_off");
     if (default_off) {
       default_state = false;
-      note += default_off.value + "\n";
+      note += default_off + "\n";
     }
 
     // If a ruleset declares a platform, and we don't match it, treat it as

--- a/chromium/rules.js
+++ b/chromium/rules.js
@@ -185,9 +185,10 @@ RuleSets.prototype = {
   parseOneRuleset: function(ruletag) {
     var default_state = true;
     var note = "";
-    if (ruletag.attributes.default_off) {
+    var default_off = ruletag.getAttribute("default_off");
+    if (default_off) {
       default_state = false;
-      note += ruletag.attributes.default_off.value + "\n";
+      note += default_off.value + "\n";
     }
 
     // If a ruleset declares a platform, and we don't match it, treat it as


### PR DESCRIPTION
`.attributes.default_off` returns `undefined` since `attributes` returned from `DOMParser` is array-like `NodeList` and not key-value object. Attribute access is correctly implemented via `getAttribute` in all the other places of the code, so this could be just an oversight.

Fixes #2959.