### PR TITLE
Update ruleset for eigenLab.

### DIFF
--- a/src/chrome/content/rules/eigenLab.xml
+++ b/src/chrome/content/rules/eigenLab.xml
@@ -1,19 +1,20 @@
-<!--
-	Expired:
-		- owncloud
-	
-	503: 
-		- git
--->
 <ruleset name="eigenLab">
 	<target host="eigenlab.org"/>
 	<target host="www.eigenlab.org"/>
 	<target host="pad.eigenlab.org"/>
+	<target host="etherpad.eigenlab.org"/>
+	<target host="git.eigenlab.org"/>
+	<target host="owncloud.eigenlab.org"/>
 	<target host="wiki.eigenlab.org"/>
 	<target host="efesto.eigenlab.org"/>
+	
+	<target host="exploitpisa.org"/>
+	<target host="www.exploitpisa.org"/>
+	<target host="mappaprecaria.exploitpisa.org"/>
 
 	<securecookie host="^(?:[^:@\.]+\.)?eigenlab\.org$" name=".*"/>
+	<securecookie host="^(?:[^:@\.]+\.)?exploitpisa\.org$" name=".*"/>
 
-	<rule from="^http:"
-		to="https:"/>
+	<rule from="^http://etherpad\.eigenlab\.org/" to="https://pad.eigenlab.org/"/>
+	<rule from="^http:" to="https:"/>
 </ruleset>


### PR DESCRIPTION
- Added etherPad -> pad rule.
- Added eXploitPisa.org rules.
- ownCloud and GitLab will be restored soon. Keep the rules for them in the meantime.

Cheers,
Vittorio