### PR TITLE
Fix static.websimages.com rewrite

### DIFF
--- a/src/chrome/content/rules/Webs.xml
+++ b/src/chrome/content/rules/Webs.xml
@@ -71,8 +71,10 @@
 	<target host="static.websimages.com" />
 
 
-	<rule from="^http://images\.(?:free)?webs\.com/"
-		to="https://a248.e.akamai.net/f/1129/8333/3m/$1s.com/" />
+	<rule from="^http://(images\.(?:free)?webs\.com)/"
+		to="https://a248.e.akamai.net/f/1129/8333/3m/$1/" />
+
+		<test url="http://images.webs.com/static/global/js/webs/usersites/ie6subnav.js" />
 
 	<!--	Protocol-relative links on members.webs.com:
 								-->

--- a/src/chrome/content/rules/Webs.xml
+++ b/src/chrome/content/rules/Webs.xml
@@ -76,8 +76,8 @@
 
 	<!--	Protocol-relative links on members.webs.com:
 								-->
-	<rule from="^https?://static\.websimages\.com/"
-		to="https://a248.e.akamai.net/f/1129/8333/3m/$1s.com/" />
+	<rule from="^https?://(static\.websimages\.com)/"
+		to="https://a248.e.akamai.net/f/1129/8333/3m/$1/" />
 
 		<test url="https://static.websimages.com/v27bc832/active-static/target/external/css/index.css" />
 


### PR DESCRIPTION
Current rewrite was either typo or something changed, anyway test URL below failed.