### PR TITLE
[National Grid] Update ruleset; disable most of it

### DIFF
--- a/src/chrome/content/rules/National_Grid.xml
+++ b/src/chrome/content/rules/National_Grid.xml
@@ -1,9 +1,27 @@
-<ruleset name="National Grid">
-    <target host="nationalgrid.com" />
-    <target host="*.nationalgrid.com" />
+<!--
+	Problematic domains:
 
-    <rule from="^http://nationalgrid\.com/"
-        to="https://www.nationalgrid.com/"/>
-    <rule from="^http://([^/:@]+)?\.nationalgrid\.com/"
-        to="https://$1.nationalgrid.com/" />
+		- ^ ¹³
+		- www ¹
+
+		- agm ³
+		- careers ²
+		- fes ⁴
+		- investors ³
+		- media ⁴
+		- www2 ²
+
+	¹: Redirect to www2
+	²: Connection refused
+	³: Mismatched
+	⁴: Timeout
+-->
+<ruleset name="National Grid (partial)">
+
+	<target host="nationalgrid.com" />
+	<target host="www.nationalgrid.com" />
+
+	<rule from="^http://(www\.)?nationalgrid\.com/"
+		to="https://www.nationalgrid.com/" />
+
 </ruleset>

--- a/src/chrome/content/rules/National_Grid.xml
+++ b/src/chrome/content/rules/National_Grid.xml
@@ -5,9 +5,13 @@
 		- www ¹
 
 		- agm ³
+		- beforeyoudig ³
 		- careers ²
+		- ecm ⁶
 		- fes ⁴
 		- investors ³
+		- ir ³
+		- kingslynnconsultation ⁵
 		- media ⁴
 		- www2 ²
 
@@ -15,13 +19,26 @@
 	²: Connection refused
 	³: Mismatched
 	⁴: Timeout
+	⁵: Expired
+	⁶: Connection refused on port 80
 -->
 <ruleset name="National Grid (partial)">
 
 	<target host="nationalgrid.com" />
 	<target host="www.nationalgrid.com" />
 
-	<rule from="^http://(www\.)?nationalgrid\.com/"
+	<target host="beforeyoudig.nationalgrid.com" />
+	<target host="www.beforeyoudig.nationalgrid.com" />
+	<target host="ecm.nationalgrid.com" />
+	<target host="m.nationalgrid.com" />
+
+	<rule from="^http://nationalgrid\.com/"
 		to="https://www.nationalgrid.com/" />
+
+	<rule from="^http://beforeyoudig\.nationalgrid\.com/"
+		to="https://www.beforeyoudig.nationalgrid.com/" />
+
+	<rule from="^http:"
+		to="https:" />
 
 </ruleset>


### PR DESCRIPTION
All tested subdomains have issues. In particular, nationalgrid.com and www.nationalgrid.com redirect to www2.nationalgrid.com which does not accept SSL connections.

This fixes #2979.