### PR TITLE
T411 got a new .in domain

### DIFF
--- a/src/chrome/content/rules/T411.xml
+++ b/src/chrome/content/rules/T411.xml
@@ -3,6 +3,8 @@
   <target host="*.t411.io" />
   <target host="t411.me" />
   <target host="*.t411.me" />
+  <target host="t411.in" />
+  <target host="*.t411.in" />
   
   <test url="http://wiki.t411.io/" />
   <test url="http://www.t411.io/" />
@@ -12,11 +14,16 @@
   <test url="http://www.t411.me/" />
   <test url="http://forum.t411.me/" />
   <test url="http://api.t411.me/" />
+  <test url="http://wiki.t411.in/" />
+  <test url="http://www.t411.in/" />
+  <test url="http://forum.t411.in/" />
+  <test url="http://api.t411.in/" />
   
-  <exclusion pattern="^http://irc\.t411\.(io|me)/" />
+  <exclusion pattern="^http://irc\.t411\.(io|me|in)/" />
   <test url="http://irc.t411.me/" />
   <test url="http://irc.t411.io/" />
+  <test url="http://irc.t411.in/" />
   
   <rule from="^http:" to="https:" />
-  <securecookie host="^.*t411\.(io|me)$" name=".*" />
+  <securecookie host="^.*t411\.(io|me|in)$" name=".*" />
 </ruleset>


### PR DESCRIPTION
The website T411 got an additional domain name.
It already responded to t411.me and t411.io, now it also responds on
t411.in.
The change adds support for this new domain.

Signed-off-by: Cilyan Olowen <gaknar@gmail.com>