### PR TITLE
Update Transport for London

### DIFF
--- a/src/chrome/content/rules/Transport_for_London.xml
+++ b/src/chrome/content/rules/Transport_for_London.xml
@@ -7,14 +7,20 @@
 	<target host="tfl.gov.uk" />
 	<target host="*.tfl.gov.uk" />
 
+	<exclusion pattern="^http://art\.tfl\.gov\.uk/" />
+	<exclusion pattern="^http://blog\.tfl\.gov\.uk/" />
+	<exclusion pattern="^http://countdown\.tfl\.gov\.uk/" />
+	<exclusion pattern="^http://cyclestories\.tfl\.gov\.uk/" />
+	<exclusion pattern="^http://info\.tfl\.gov\.uk/" />
+	<exclusion pattern="^http://visitorshop\.tfl\.gov\.uk/" />
 
-	<!--	- Cert only matches www
-		- At least some pages 30 to http
-						-->
-	<rule from="^http://(?:www\.)?tfl\.gov\.uk/(assets/|helpandcontact/?$|microsites/|\w+-global/)"
-		to="https://www.tfl.gov.uk/$1" />
+	<rule from="^http:" to="https:" />
 
-	<rule from="^http://custserv\.tfl\.gov\.uk/"
-		to="https://custserv.tfl.gov.uk/" />
+	<test url="http://art.tfl.gov.uk/contact/" />
+	<test url="http://blog.tfl.gov.uk/house-rules/" />
+	<test url="http://countdown.tfl.gov.uk/MyStops/" />
+	<test url="http://cyclestories.tfl.gov.uk/cyclists-beth.shtml" />
+	<test url="http://info.tfl.gov.uk/licenses/aboutEcm.jsp" />
+	<test url="http://visitorshop.tfl.gov.uk/help/" />
 
 </ruleset>


### PR DESCRIPTION
TfL has got a lot better since this rule was written in September 2012. Almost everything supports HTTPS and there are just a few subdomains which don't. The certificate is a wildcard cert now.