### PR TITLE
Add Esolangs.org

### DIFF
--- a/src/chrome/content/rules/Esolangs.org.xml
+++ b/src/chrome/content/rules/Esolangs.org.xml
@@ -1,0 +1,9 @@
+<ruleset name="Esolangs.org">
+        <target host="esolangs.org" />
+        <target host="www.esolangs.org" />
+
+        <rule from="^http:"
+                to="https:" />
+                
+        <securecookie host="^(?:www\.)?esolangs\.org$" name="." />
+</ruleset>


### PR DESCRIPTION
Notes:

* The cookie name regex can just be `.`; it just has to match, no need for it to capture the entire string. (In fact, you can do `new RegExp("")` with an empty string, but I don't know how this works under the hood so I used a dot just to be safe.)
* Non-capturing groups perform significantly better than capturing groups.