### PR TITLE
[GroupMe.com] New ruleset

### DIFF
--- a/src/chrome/content/rules/GroupMe.com.xml
+++ b/src/chrome/content/rules/GroupMe.com.xml
@@ -26,4 +26,3 @@
 		to="https:" />
 
 </ruleset>
-

--- a/src/chrome/content/rules/GroupMe.com.xml
+++ b/src/chrome/content/rules/GroupMe.com.xml
@@ -1,0 +1,29 @@
+<!--
+
+	Problematic domains:
+
+		- blog ³
+		- help ¹
+		- status ²
+
+	¹: Bad CN in cert
+	²: Times out
+	³: Connection refused
+
+-->
+<ruleset name="GroupMe.com (partial)">
+
+	<target host="groupme.com" />
+	<target host="www.groupme.com" />
+
+	<target host="dev.groupme.com" />
+	<target host="i.groupme.com" />
+
+	<!-- Test to illustrate purpose of i.groupme.com: -->
+	<test url="http://i.groupme.com/180x180.png.dec19e90ef21013176f922000b340376.large" />
+
+	<rule from="^http:"
+		to="https:" />
+
+</ruleset>
+


### PR DESCRIPTION
Domains ^, www, and dev already serve HSTS headers but some resources from i.groupme.com are not secured without this ruleset.

Fixes #2996