### PR TITLE
Secure all subdomains of `service.gov.uk`

### DIFF
--- a/src/chrome/content/rules/Service.gov.uk.xml
+++ b/src/chrome/content/rules/Service.gov.uk.xml
@@ -9,8 +9,7 @@
 -->
 <ruleset name="Service.gov.uk">
 
-	<target host="digitalservicesstore.service.gov.uk" />
-	<target host="www.digitalservicesstore.service.gov.uk" />
+	<target host="*.service.gov.uk" />
 
 
 	<!--	Not secured by server:
@@ -22,5 +21,10 @@
 
 	<rule from="^http:"
 		to="https:" />
+
+	<test url="http://verifyapostille.service.gov.uk/Home/CookieInfo/" />
+	<test url="http://www.lastingpowerofattorney.service.gov.uk/home" />
+	<test url="http://www.vehicletax.service.gov.uk/" />
+	<test url="http://www.viewdrivingrecord.service.gov.uk/driving-record/licence-number" />
 
 </ruleset>


### PR DESCRIPTION
`service.gov.uk` is the subdomain which all government services and transactions in the UK will run on. It's really important to make sure they're secure.

An example is [the service to register to vote in elections](https://www.gov.uk/register-to-vote).

Generally services use subdomains of a `service.gov.uk` subdomain which I believe this rule will catch, for example:

- `www.registertovote.service.gov.uk`
- `assets.registertovote.service.gov.uk`

Here's [the guidance that the Government Digital Service provides to government departments who operate `service.gov.uk` subdomains](https://www.gov.uk/service-manual/operations/operating-servicegovuk-subdomains).

The relevant section is titled "Transport Layer Security":

> Many services will collect personal information from users. It’s very important that this information can’t be intercepted by malicious third parties as it travels over the internet.
>
> Therefore, all services accessed through service.gov.uk domains (including APIs) MUST only be accessible through secure connections. For web-based services this means HTTPS only (often referred to by the acronyms TLS or SSL, which both refer to the protocol underpinning these secure connections). Services must not accept HTTP connections under any circumstances.

Given that this is in the guidance for operating a subdomain, I think it's better to secure all subdomains and add exceptions as needed.