### PR TITLE
Added Tor2web.xml

### DIFF
--- a/src/chrome/content/rules/Tor2web.xml
+++ b/src/chrome/content/rules/Tor2web.xml
@@ -1,0 +1,25 @@
+<!--
+This ruleset ensures that Tor Browser Bundle users don't accidentally use a Tor2web node. 
+
+Wanted to include <target host="*.onion.to" /> but it wouldn't work due to a bug associated with the keyword "to".
+Need to add Tor2web to the downgrade whitelist
+
+-->
+
+<ruleset name="Tor2web">
+  <target host="*.tor2web.org" />
+  <target host="*.tor2web.com" />
+  <target host="*.onion.link" /> 
+  <target host="*.onion.city" />
+  <target host="*.onion.nu" />
+  <target host="*.onion.cab" />
+  <target host="*.onion.direct" />
+
+  <test url="http://thundersplv36ecb.onion.link/" />
+  <test url="http://32rfckwuorlf4dlv.onion.link/" />
+  <test url="https://dirre2hfssh2offv.onion.link/" />
+  <test url="https://torlinkbgs6aabns.onion.link/" />
+  <test url="https://deepdot35wvmeyd5.onion.link/" />
+
+  <rule from="^(http|https)://([a-z0-9\.]*[a-z0-9]{16})\.onion\.link/" to="http://$2.onion/" downgrade="1" />
+</ruleset>


### PR DESCRIPTION
These are the modifying rules for ensuring a Tor Browser Bundle user doesn't accidentally use a Tor2web node.

* I do not know to ensure this only occurs for Tor Browser Bundle users and not all HTTPS-everywhere users.  I presume the admins of this repository do.

* I will be doing an additional modification for adding Tor2web to the downgrade whitelist