### PR TITLE
Added Tor2web rules to downgrade-whitelist

### DIFF
--- a/utils/downgrade-whitelist.txt
+++ b/utils/downgrade-whitelist.txt
@@ -23,6 +23,7 @@ Phoronix Media
 Qz.com (partial)
 SRG SSR (partial)
 Stack Exchange (partial)
+Tor2web
 University of Alaska Anchorage (partial)
 Visa (partial)
 xxxbunker.com (partial)


### PR DESCRIPTION
The needed whitelist change for: https://github.com/EFForg/https-everywhere/pull/3033