### PR TITLE
adding Tor2web.xml

### DIFF
--- a/src/chrome/content/rules/Tor2web.xml
+++ b/src/chrome/content/rules/Tor2web.xml
@@ -1,0 +1,21 @@
+<!-- This ruleset ensures that Tor Browser Bundle users don't accidentally use a Tor2web node. -->
+
+<ruleset name="Tor2web">
+  <target host="*.tor2web.com" />
+  <target host="*.tor2web.org" />
+
+  <target host="*.onion.cab" />
+  <target host="*.onion.city" />  
+  <target host="*.onion.direct" />  
+  <target host="*.onion.link" /> 
+  <target host="*.onion.nu" />
+
+  <test url="http://thundersplv36ecb.onion.link/" />
+  <test url="http://32rfckwuorlf4dlv.onion.link/" />
+  <test url="https://dirre2hfssh2offv.onion.link/" />
+  <test url="https://torlinkbgs6aabns.onion.link/" />
+  <test url="https://deepdot35wvmeyd5.onion.link/" />
+
+  <rule from="^(http|https)://([a-z0-9\.]*[a-z0-9]{16})\.onion\.(cab|city|direct|link|nu)/" to="http://$2.onion/" downgrade="1" />
+  <rule from="^(http|https)://([a-z0-9\.]*[a-z0-9]{16})\.tor2web\.(com|org)/" to="http://$2.onion/" downgrade="1" />
+</ruleset>


### PR DESCRIPTION
This ruleset ensures that Tor Browser Bundle users don't accidentally use a Tor2web node.       

* Wanted to include <target host="*.onion.to" /> but it wouldn't work due to a bug associated with the keyword "to".

* commit https://github.com/virgil/https-everywhere/commit/2d1104be3cae589a88b27f7ef58bd2a62d946c2f adds Tor2web to the downgrade whitelist

Perhaps it's just my cluelessness, but it's unclear to make patch https://github.com/EFForg/https-everywhere/pull/3034 also be included in the travis-ci build.  But when you combine them together it works.