### PR TITLE
My new rules

### DIFF
--- a/src/chrome/content/rules/BBVA-Bancomer.xml
+++ b/src/chrome/content/rules/BBVA-Bancomer.xml
@@ -1,0 +1,4 @@
+<ruleset name="BBVA-Bancomer">
+	<target host="www.bancomer.com" />
+	<rule from="^http:" to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/TerraMailMX.xml
+++ b/src/chrome/content/rules/TerraMailMX.xml
@@ -1,0 +1,4 @@
+<ruleset name="Terra Mail (MX)">
+	<target host="correo.terra.com.mx" />
+	<rule from="^http:" to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/TerraUserCentralMX.xml
+++ b/src/chrome/content/rules/TerraUserCentralMX.xml
@@ -1,0 +1,4 @@
+<ruleset name="Terra User Central (MX)" default_off="Breaks site">
+	<target host="central.terra.com.mx" />
+	<rule from="^http:" to="https:" />
+</ruleset>


### PR DESCRIPTION
I would like to contribute three new rulesets. Two of them (BBVA-Bancomer.xml and TerraMailMX.xml) pass both the manual tests and ``fetch-test.sh``. The other rule (TerraUserCentralMX.xml), breaks the layout and manual login, so it is turned off by default.

The reason I include the disabled ruleset is that Terra Mail has a (somewhat buried) button that redirects logged users to Terra User Central, logging them automatically to the latter, thus, a cookie obtained through HTTPS is sent to a HTTP site. I could not figure out how to prevent it with ``securecookie``.