### PR TITLE
Support for engineering.riotgames.com.

### DIFF
--- a/src/chrome/content/rules/Riotgames.com.xml
+++ b/src/chrome/content/rules/Riotgames.com.xml
@@ -1,0 +1,6 @@
+<ruleset name="riotgames.com (partial)">
+    <target host="engineering.riotgames.com" />
+
+    <rule from="^http:" to="https:" />
+</ruleset>
+


### PR DESCRIPTION
Created a ruleset for engineering.riotgames.com. Other riotgames domains don't seem to support https.