### PR TITLE
[Codeplex.com] Added (new?) download domain, small cleanup

### DIFF
--- a/src/chrome/content/rules/Codeplex.xml
+++ b/src/chrome/content/rules/Codeplex.xml
@@ -27,5 +27,5 @@
 	<securecookie host="^(?:.*\.)?codeplex\.com$" name=".+" />
 
     <rule from="^http:"
-		to="https:" />
+	    to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Codeplex.xml
+++ b/src/chrome/content/rules/Codeplex.xml
@@ -6,6 +6,7 @@
 
 	<target host="codeplex.com" />
 	<target host="*.codeplex.com" />
+	<target host="download-codeplex.sec.s-msft.com" />
 
 		<exclusion pattern="^http://(?:download|i[123])\.codeplex\.com/" />
 
@@ -25,8 +26,6 @@
 
 	<securecookie host="^(?:.*\.)?codeplex\.com$" name=".+" />
 
-
-	<rule from="^http://([\w-]+\.)?codeplex\.com/"
-		to="https://$1codeplex.com/" />
-
+    <rule from="^http:"
+		to="https:" />
 </ruleset>


### PR DESCRIPTION
To help fix some non-HTTPS downloads of CodePlex. See also https://veracrypt.codeplex.com/workitem/251