### PR TITLE
Updated HTTPS rule for HollywoodReporter.com

### DIFF
--- a/src/chrome/content/rules/Hollywood-Reporter.xml
+++ b/src/chrome/content/rules/Hollywood-Reporter.xml
@@ -33,15 +33,6 @@
 
 	<target host="hollywoodreporter.com" />
 	<target host="*.hollywoodreporter.com" />
-		<!--
-			Avoid user-visible paths:
-							-->
-		<exclusion pattern="^http://(?:www\.)?hollywoodreporter\.com/(?!favicon\.ico|sites/)" />
-		<!--
-			css_c602cf5d0b126628beb7012985fd4591 links to images relative /
-											-->
-		<exclusion pattern="^http://(?:www\.)?hollywoodreporter\.com/sites/default/files/css/(?!css_02b3ba95a2adca47bf1e40d170fcaa56\.css)" />
-
 
 	<securecookie host=".+\.hollywoodreporter\.com$" name=".+" />
 

--- a/src/chrome/content/rules/Hollywood-Reporter.xml
+++ b/src/chrome/content/rules/Hollywood-Reporter.xml
@@ -4,14 +4,10 @@
 
 	CDN buckets:
 
-		- www.hollywoodreporter.com.edgesuite.net
+		- cs422.wac.thetacdn.net
 
 			- a1682.g.akamai.net
-			- thr[1-4].pgmcdn.net
-
-		- hollywoodreporter.mobify.com
-
-			- m
+			- cdn[1-6].thr.com
 
 
 	Nonfunctional subdomains:
@@ -51,7 +47,7 @@
 
 
 	<rule from="^http://(?:www\.)?hollywoodreporter\.com/"
-		to="https://a248.e.akamai.net/f/1682/7219/8m/www.hollywoodreporter.com/" />
+		to="https://www.hollywoodreporter.com/" />
 
 	<rule from="^http://m\.hollywoodreporter\.com/mobify/"
 		to="https://hollywoodreporter.mobify.com/mobify/" />

--- a/src/chrome/content/rules/Hollywood-Reporter.xml
+++ b/src/chrome/content/rules/Hollywood-Reporter.xml
@@ -45,14 +45,14 @@
 
 	<securecookie host=".+\.hollywoodreporter\.com$" name=".+" />
 
+    <test url="http://www.hollywoodreporter.com/" />
+    <test url="http://subscribe.hollywoodreporter.com/" />
+
 
 	<rule from="^http://(?:www\.)?hollywoodreporter\.com/"
 		to="https://www.hollywoodreporter.com/" />
 
-	<rule from="^http://m\.hollywoodreporter\.com/mobify/"
-		to="https://hollywoodreporter.mobify.com/mobify/" />
-
-	<rule from="^http://s(ecure|ubscribe)\.hollywoodreporter\.com/"
-		to="https://s$1.hollywoodreporter.com/" />
+	<rule from="^http://subscribe\.hollywoodreporter\.com/"
+		to="https://subscribe.hollywoodreporter.com/" />
 
 </ruleset>


### PR DESCRIPTION
We moved The Hollywood Reporter from Akamai to Edgecast a year ago and it has fully SSL support.