### PR TITLE
Update ruleset for T411

### DIFF
--- a/src/chrome/content/rules/T411.xml
+++ b/src/chrome/content/rules/T411.xml
@@ -3,6 +3,8 @@
   <target host="*.t411.io" />
   <target host="t411.me" />
   <target host="*.t411.me" />
+  <target host="t411.in" />
+  <target host="*.t411.in" />
   
   <test url="http://wiki.t411.io/" />
   <test url="http://www.t411.io/" />
@@ -12,11 +14,16 @@
   <test url="http://www.t411.me/" />
   <test url="http://forum.t411.me/" />
   <test url="http://api.t411.me/" />
+  <test url="http://wiki.t411.in/" />
+  <test url="http://www.t411.in/" />
+  <test url="http://forum.t411.in/" />
+  <test url="http://api.t411.in/" />
   
-  <exclusion pattern="^http://irc\.t411\.(io|me)/" />
+  <exclusion pattern="^http://irc\.t411\.(io|me|in)/" />
   <test url="http://irc.t411.me/" />
   <test url="http://irc.t411.io/" />
+  <test url="http://irc.t411.in/" />
   
   <rule from="^http:" to="https:" />
-  <securecookie host="^.*t411\.(io|me)$" name=".*" />
+  <securecookie host="^.*t411\.(io|me|in)$" name=".*" />
 </ruleset>


### PR DESCRIPTION
T411 has migrated to t411.in.
t411.io now redirects there.