### PR TITLE
Add rule for VC-Server

### DIFF
--- a/src/chrome/content/rules/VC-Server.xml
+++ b/src/chrome/content/rules/VC-Server.xml
@@ -1,0 +1,17 @@
+<ruleset name="VC-Server">
+	<target host="vc-server.de" />
+	<target host="www.vc-server.de" />
+	<target host="vpsmanager.vc-server.de" />
+	
+	<target host="vc-kundencenter.de" />
+	<target host="www.vc-kundencenter.de" />
+	
+	<target host="vc-kundenservice.de" />
+	<target host="www.vc-kundenservice.de" />
+
+	<securecookie host="^(?:(?:www|vpsmanager)\.)?vc-server\.de$" name=".+" />
+	<securecookie host="^(?:www\.)?vc-kundencenter\.de$" name=".+" />
+	<securecookie host="^(?:www\.)?vc-kundenservice\.de$" name=".+" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>


### PR DESCRIPTION
This handles three `vc-server.de` domains and also `(www.)vc-kundencenter.de` plus `(www.)vc-kundenservice.de`.