### PR TITLE
Update Jekyll ruleset to include Jekyll Talk

### DIFF
--- a/src/chrome/content/rules/jekyllrb.com.xml
+++ b/src/chrome/content/rules/jekyllrb.com.xml
@@ -5,13 +5,14 @@
 <ruleset name="Jekyll">
     <target host="jekyllrb.com" />
     <target host="www.jekyllrb.com" />
+    <target host="talk.jekyllrb.com" />
 
-    <securecookie host="^(www\.)?jekyllrb\.com$" name=".+" />
-
-    <!-- Fix this redirection -->
     <rule from="^http(s)?://www.jekyllrb.com/"
             to="https://jekyllrb.com/" />
 
     <rule from="^http:"
             to="https:" />
+
+    <securecookie host="^(www\.)?jekyllrb\.com$" name=".+" />
+    <securecookie host="^talk\.jekyllrb\.com$" name=".+" />
 </ruleset>


### PR DESCRIPTION
This update adds Jekyll discussion forum page `(talk.jekyllrb.com)` to the ruleset.
A comment also removed because redirection from `www` subdomain to secure HTTPS works.
I have tested this ruleset in the browser.