### PR TITLE
Update Blendle ruleset

### DIFF
--- a/src/chrome/content/rules/Blendle.xml
+++ b/src/chrome/content/rules/Blendle.xml
@@ -19,7 +19,7 @@
 
   <test url="http://blog.blendle.nl/" />
 
-  <securecookie host="^\.blendle\.com$" name=".+" />
+  <securecookie host="^\.?blendle\.com$" name=".+" />
 
   <rule from="^http:" to="https:" />
 

--- a/src/chrome/content/rules/Blendle.xml
+++ b/src/chrome/content/rules/Blendle.xml
@@ -14,11 +14,10 @@
   <test url="http://widgets.blendle.nl/" />
   <test url="http://ws.blendle.nl/" />
 
-  <!-- Tumblr blog and UserVoice page are the only services reachable over plaintext HTTP -->
-  <exclusion pattern="^http://(blog|contact)\.blendle\.nl/" />
+  <!-- Tumblr blog is the only service reachable over plaintext HTTP -->
+  <exclusion pattern="^http://blog.blendle\.nl/" />
 
   <test url="http://blog.blendle.nl/" />
-  <test url="http://contact.blendle.nl/" />
 
   <securecookie host="^blendle\.com$" name=".+" />
 

--- a/src/chrome/content/rules/Blendle.xml
+++ b/src/chrome/content/rules/Blendle.xml
@@ -19,7 +19,7 @@
 
   <test url="http://blog.blendle.nl/" />
 
-  <securecookie host="^blendle\.com$" name=".+" />
+  <securecookie host="^\.blendle\.com$" name=".+" />
 
   <rule from="^http:" to="https:" />
 


### PR DESCRIPTION
This removes the exclusion for the UserVoice sub domain, because it's no longer available. It also extends the `securecookie` rule to include all sub domains.