### PR TITLE
[Deutsches Forschungsnetz] Add exception

### DIFF
--- a/src/chrome/content/rules/Deutsches_Forschungsnetz.xml
+++ b/src/chrome/content/rules/Deutsches_Forschungsnetz.xml
@@ -1,11 +1,20 @@
 <ruleset name="Deutsches Forschungsnetz">
+
     <target host="dfn.de" />
     <target host="*.dfn.de" />
+
+    <exclusion pattern="http://cdp.pca.dfn.de/" />
+    <test url="http://cdp.pca.dfn.de/uni-erlangen-nuernberg-ca/pub/cacert/cacert.pem" />
 
     <securecookie host="^(?:.*\.)?dfn\.de$" name=".+" />
 
     <rule from="^http://dfn\.de/"
         to="https://www.dfn.de/" />
+
     <rule from="^http://([^/:@]+)?\.dfn\.de/"
         to="https://$1.dfn.de/" />
+
+    <test url="http://www.pki.dfn.de/" />
+    <test url="http://info.pca.dfn.de/" />
+
 </ruleset>


### PR DESCRIPTION
Some content such as http://cdp.pca.dfn.de/uni-erlangen-nuernberg-ca/pub/cacert/cacert.pem can not currently be secured.

This fixes GitHub issue https://github.com/EFForg/https-everywhere/issues/3067