### PR TITLE
Changes to ruleset validation output

### DIFF
--- a/utils/validate.sh
+++ b/utils/validate.sh
@@ -33,19 +33,26 @@ fi
 type xmllint >/dev/null || die "xmllint not available"
 
 GRAMMAR="relaxng.xml"
-# xmllint spams stderr with "<FILENAME> validates, even with the --noout
-# flag. We can't grep -v for that line, because the pipeline will mask error
-# status from xmllint. Instead we run it once going to /dev/null, and if
-# there's an error run it again, showing only error output.
+# xmllint spams stderr with "<FILENAME> validates, even with the --noout flag,
+# so we capture only the results that do not contain 'validates'
 validate_grammar() {
   find ../src/chrome/content/rules -name "*.xml" | \
    xargs xmllint --noout --relaxng $GRAMMAR
 }
-if validate_grammar 2>/dev/null
+grammar_errors=$(validate_grammar 2>&1 | grep -v "validates" || true)
+if [ -z "$grammar_errors" ]
 then
   echo Validation of rulesets against $GRAMMAR succeeded. >&2
 else
-  validate_grammar 2>&1 | grep -v validates
+  echo >&2 "$grammar_errors"
+  # One very common error is to mess up rule attributes, so we check for
+  # this explicitly.
+  if [[ $grammar_errors == *"Element rule failed to validate attributes"* ]]
+  then
+    echo "Two very common reasons for this are the following:"
+    echo "- Missing caret (^) in 'from' attribute: it should be \"^http:\" and not \"http:\"."
+    echo "- Missing trailing slashes in 'from' or 'to' when specifying full hostnames: it should be \"https://eff.org/\" and not \"https://eff.org\"."
+  fi
   die "Validation of rulesets against $GRAMMAR failed."
 fi
 


### PR DESCRIPTION
This achieves a couple of different things:
- Previously, when some rulesets contained errors, xmllint would be run twice when running it only once was sufficient. This thus saves a fair amount of time.
- Previously, the end of the script would never actually be executed since xmllint would break it. In particular, the obtained exit status might not have been the expected one.
- Echo errors to stderr instead of stdout.
- Most importantly: Give some additional output when validation failure is due to one of the two most common ruleset errors, where the existing error output was not particularly helpful.