### PR TITLE
[wisc.edu] Add multiple subdomains

### DIFF
--- a/src/chrome/content/rules/University_of_Wisconsin-Madison.xml
+++ b/src/chrome/content/rules/University_of_Wisconsin-Madison.xml
@@ -45,6 +45,7 @@
 			- research
 			- www           (requires redirect to www.cs.wisc.edu)
 
+		- housing               (required redirect to www.housing.wisc.edu)
 		- learnuw
 		- ecs.library
 		- www.library           (requires redirect to www.library.wisc.edu)
@@ -71,12 +72,28 @@
 				-->
 		<exclusion pattern="^http://pages\.cs\.wisc\.edu/+~" />
 
+		<test url="http://pages.cs.wisc.edu/hartzheim" />
+
 
 	<rule from="^http://((?:condor-wiki|htcondor-wiki|pages|research)\.cs|learnuw|(ecs|search)\.library|login|my|mywebspace|wayf|wiscmail)\.wisc\.edu/"
 	      to="https://$1.wisc.edu/" />
 
+	<test url="http://condor-wiki.cs.wisc.edu/" />
+	<test url="http://htcondor-wiki.cs.wisc.edu/" />
+	<test url="http://pages.cs.wisc.edu/" />
+	<test url="http://learnuw.wisc.edu/" />
+	<test url="http://ecs.library.wisc.edu/" />
+	<test url="http://search.library.wisc.edu/" />
+	<test url="http://login.wisc.edu/" />
+	<test url="http://my.wisc.edu/" />
+	<test url="http://mywebspace.wisc.edu/" />
+	<test url="http://wiscmail.wisc.edu/" />
+
 	<!-- Requires redirect to www.* to use SSL -->
-	<rule from="^http://(?:www\.)?(cs|library)\.wisc\.edu/"
+	<rule from="^http://(?:www\.)?(cs|housing|library)\.wisc\.edu/"
 	      to="https://www.$1.wisc.edu/" />
+
+	<test url="http://library.wisc.edu/" />
+	<test url="http://www.library.wisc.edu/" />
 
 </ruleset>

--- a/src/chrome/content/rules/University_of_Wisconsin-Madison.xml
+++ b/src/chrome/content/rules/University_of_Wisconsin-Madison.xml
@@ -43,6 +43,7 @@
 			- condor-wiki
 			- htcondor-wiki
 			- research
+			- www           (requires redirect to www.cs.wisc.edu)
 
 		- learnuw
 		- ecs.library
@@ -75,7 +76,7 @@
 	      to="https://$1.wisc.edu/" />
 
 	<!-- Requires redirect to www.* to use SSL -->
-	<rule from="^http://(?:www\.)?(library)\.wisc\.edu/"
+	<rule from="^http://(?:www\.)?(cs|library)\.wisc\.edu/"
 	      to="https://www.$1.wisc.edu/" />
 
 </ruleset>

--- a/src/chrome/content/rules/University_of_Wisconsin-Madison.xml
+++ b/src/chrome/content/rules/University_of_Wisconsin-Madison.xml
@@ -80,7 +80,7 @@
 	<exclusion pattern="^http://pages\.cs\.wisc\.edu/+~" />
 	<test url="http://pages.cs.wisc.edu/~hartzheim" />
 
-	<rule from="^http://((?:condor-wiki|htcondor-wiki|pages|research)\.cs|discovery|doit|go|kb|learnuw|(ecs|search)\.library|login|my|mywebspace|wayf|wiscmail)\.wisc\.edu/"
+	<rule from="^http://((?:condor-wiki|htcondor-wiki|pages|research)\.cs|discovery|(www\.)?doit|go|kb|learnuw|(ecs|search)\.library|login|my|mywebspace|wayf|wiscmail)\.wisc\.edu/"
 	to="https://$1.wisc.edu/" />
 
 	<test url="http://condor-wiki.cs.wisc.edu/" />
@@ -88,6 +88,7 @@
 	<test url="http://pages.cs.wisc.edu/" />
 	<test url="http://discovery.wisc.edu/" />
 	<test url="http://doit.wisc.edu/" />
+	<test url="http://www.doit.wisc.edu/" />
 	<test url="http://go.wisc.edu/" />
 	<test url="http://kb.wisc.edu/" />
 	<test url="http://learnuw.wisc.edu/" />

--- a/src/chrome/content/rules/University_of_Wisconsin-Madison.xml
+++ b/src/chrome/content/rules/University_of_Wisconsin-Madison.xml
@@ -26,12 +26,13 @@
 
 		- krakatau.doit		(expired, self-signed)
 		- services.ldap		(weak crypto)
-		- www.uhs.wisc.edu	(breaks Google site search) 
+		- www.uhs.wisc.edu	(breaks Google site search)
 
 	Partially covered subdomains:
 
 		- (www.)library		(at least the homepage redirects to http)
 		- pages.cs ²
+		- www.doit.wisc.edu	(search page redirects to HTTP)
 
 	² Personal pages 404
 
@@ -75,13 +76,14 @@
 	<exclusion pattern="^http://pages\.cs\.wisc\.edu/+~" />
 	<test url="http://pages.cs.wisc.edu/~hartzheim" />
 
-	<rule from="^http://((?:condor-wiki|htcondor-wiki|pages|research)\.cs|discovery|kb|learnuw|(ecs|search)\.library|login|my|mywebspace|wayf|wiscmail)\.wisc\.edu/"
+	<rule from="^http://((?:condor-wiki|htcondor-wiki|pages|research)\.cs|discovery|doit|kb|learnuw|(ecs|search)\.library|login|my|mywebspace|wayf|wiscmail)\.wisc\.edu/"
 	to="https://$1.wisc.edu/" />
 
 	<test url="http://condor-wiki.cs.wisc.edu/" />
 	<test url="http://htcondor-wiki.cs.wisc.edu/" />
 	<test url="http://pages.cs.wisc.edu/" />
 	<test url="http://discovery.wisc.edu/" />
+	<test url="http://doit.wisc.edu/" />
 	<test url="http://kb.wisc.edu/" />
 	<test url="http://learnuw.wisc.edu/" />
 	<test url="http://ecs.library.wisc.edu/" />
@@ -89,6 +91,7 @@
 	<test url="http://login.wisc.edu/" />
 	<test url="http://my.wisc.edu/" />
 	<test url="http://mywebspace.wisc.edu/" />
+	<test url="http://wayf.wisc.edu/" />
 	<test url="http://wiscmail.wisc.edu/" />
 
 	<!-- Requires redirect to www.* to use SSL -->

--- a/src/chrome/content/rules/University_of_Wisconsin-Madison.xml
+++ b/src/chrome/content/rules/University_of_Wisconsin-Madison.xml
@@ -5,6 +5,7 @@
 		- (www.)aos *
 		- www.geology		(shows geoscience; mismatched, CN: geoscience.wisc.edu)
 		- geoscience		(403/404)
+		- library               (mismatched, CN: www.library.wisc.edu)
 		- depot.library *
 		- digital.library
 		- m.library **
@@ -13,13 +14,13 @@
 		- studyrooms.library **
 		- uwdc.library **
 		- xerxes.library
-		- (www.)today ***
+		- www.today             (mismatched, CN: today.wisc.edu)
 		- vip ***
 		- www *
 
 	* Times out
 	** Redirects to www.library
-	*** Shows krakatau.doit
+	*** Shows (servername).doit
 
 
 	Problematic subdomains:

--- a/src/chrome/content/rules/University_of_Wisconsin-Madison.xml
+++ b/src/chrome/content/rules/University_of_Wisconsin-Madison.xml
@@ -45,6 +45,7 @@
 			- research
 			- www           (requires redirect to www.cs.wisc.edu)
 
+		- discovery
 		- housing               (required redirect to www.housing.wisc.edu)
 		- kb
 		- learnuw
@@ -77,12 +78,13 @@
 		<test url="http://pages.cs.wisc.edu/hartzheim" />
 
 
-	<rule from="^http://((?:condor-wiki|htcondor-wiki|pages|research)\.cs|kb|learnuw|(ecs|search)\.library|login|my|mywebspace|wayf|wiscmail)\.wisc\.edu/"
+	<rule from="^http://((?:condor-wiki|htcondor-wiki|pages|research)\.cs|discovery|kb|learnuw|(ecs|search)\.library|login|my|mywebspace|wayf|wiscmail)\.wisc\.edu/"
 	      to="https://$1.wisc.edu/" />
 
 	<test url="http://condor-wiki.cs.wisc.edu/" />
 	<test url="http://htcondor-wiki.cs.wisc.edu/" />
 	<test url="http://pages.cs.wisc.edu/" />
+	<test url="http://discovery.wisc.edu/" />
 	<test url="http://kb.wisc.edu/" />
 	<test url="http://learnuw.wisc.edu/" />
 	<test url="http://ecs.library.wisc.edu/" />

--- a/src/chrome/content/rules/University_of_Wisconsin-Madison.xml
+++ b/src/chrome/content/rules/University_of_Wisconsin-Madison.xml
@@ -13,6 +13,7 @@
 		- studyrooms.library **
 		- uwdc.library **
 		- xerxes.library
+		- news ***
 		- www.today		(mismatched, CN: today.wisc.edu)
 		- vip ***
 		- www *
@@ -26,7 +27,9 @@
 
 		- krakatau.doit		(expired, self-signed)
 		- services.ldap		(weak crypto)
-		- www.uhs.wisc.edu	(breaks Google site search)
+		- ssc			(breaks Google site search)
+		- www.ssec		(breaks Google site search)
+		- www.uhs		(breaks Google site search)
 
 	Partially covered subdomains:
 
@@ -98,6 +101,8 @@
 	<rule from="^http://(?:www\.)?(cs|housing|library|math)\.wisc\.edu/"
 	to="https://www.$1.wisc.edu/" />
 
+	<test url="http://cs.wisc.edu/" />
+	<test url="http://housing.wisc.edu/" />
 	<test url="http://library.wisc.edu/" />
 	<test url="http://www.library.wisc.edu/" />
 	<test url="http://math.wisc.edu/" />

--- a/src/chrome/content/rules/University_of_Wisconsin-Madison.xml
+++ b/src/chrome/content/rules/University_of_Wisconsin-Madison.xml
@@ -50,6 +50,7 @@
 			- www		(requires redirect to www.cs.wisc.edu)
 
 		- discovery
+		- go
 		- housing		(required redirect to www.housing.wisc.edu)
 		- kb
 		- learnuw
@@ -79,7 +80,7 @@
 	<exclusion pattern="^http://pages\.cs\.wisc\.edu/+~" />
 	<test url="http://pages.cs.wisc.edu/~hartzheim" />
 
-	<rule from="^http://((?:condor-wiki|htcondor-wiki|pages|research)\.cs|discovery|doit|kb|learnuw|(ecs|search)\.library|login|my|mywebspace|wayf|wiscmail)\.wisc\.edu/"
+	<rule from="^http://((?:condor-wiki|htcondor-wiki|pages|research)\.cs|discovery|doit|go|kb|learnuw|(ecs|search)\.library|login|my|mywebspace|wayf|wiscmail)\.wisc\.edu/"
 	to="https://$1.wisc.edu/" />
 
 	<test url="http://condor-wiki.cs.wisc.edu/" />
@@ -87,6 +88,7 @@
 	<test url="http://pages.cs.wisc.edu/" />
 	<test url="http://discovery.wisc.edu/" />
 	<test url="http://doit.wisc.edu/" />
+	<test url="http://go.wisc.edu/" />
 	<test url="http://kb.wisc.edu/" />
 	<test url="http://learnuw.wisc.edu/" />
 	<test url="http://ecs.library.wisc.edu/" />

--- a/src/chrome/content/rules/University_of_Wisconsin-Madison.xml
+++ b/src/chrome/content/rules/University_of_Wisconsin-Madison.xml
@@ -10,7 +10,6 @@
 		- digital.library
 		- m.library **
 		- madcat.library
-		- search.library	(redirects to wayf login)
 		- studyrooms.library **
 		- uwdc.library **
 		- xerxes.library
@@ -47,6 +46,7 @@
 
 		- learnuw
 		- ecs.library
+		- www.library           (requires redirect to www.library.wisc.edu)
 		- login
 		- my
 		- mywebspace
@@ -69,10 +69,13 @@
 			404:
 				-->
 		<exclusion pattern="^http://pages\.cs\.wisc\.edu/+~" />
-		<exclusion pattern="^http://(?:www\.)?library\.wisc\.edu/(?!css/|images/)" />
 
 
-	<rule from="^http://((?:condor-wiki|htcondor-wiki|pages|research)\.cs|learnuw|(?:ecs\.|www\.)?library|login|my|mywebspace|wayf|wiscmail)\.wisc\.edu/"
-		to="https://$1.wisc.edu/" />
+	<rule from="^http://((?:condor-wiki|htcondor-wiki|pages|research)\.cs|learnuw|(ecs|search)\.library|login|my|mywebspace|wayf|wiscmail)\.wisc\.edu/"
+	      to="https://$1.wisc.edu/" />
+
+	<!-- Requires redirect to www.* to use SSL -->
+	<rule from="^http://(?:www\.)?(library)\.wisc\.edu/"
+	      to="https://www.$1.wisc.edu/" />
 
 </ruleset>

--- a/src/chrome/content/rules/University_of_Wisconsin-Madison.xml
+++ b/src/chrome/content/rules/University_of_Wisconsin-Madison.xml
@@ -46,6 +46,7 @@
 			- www           (requires redirect to www.cs.wisc.edu)
 
 		- housing               (required redirect to www.housing.wisc.edu)
+		- kb
 		- learnuw
 		- ecs.library
 		- www.library           (requires redirect to www.library.wisc.edu)
@@ -76,12 +77,13 @@
 		<test url="http://pages.cs.wisc.edu/hartzheim" />
 
 
-	<rule from="^http://((?:condor-wiki|htcondor-wiki|pages|research)\.cs|learnuw|(ecs|search)\.library|login|my|mywebspace|wayf|wiscmail)\.wisc\.edu/"
+	<rule from="^http://((?:condor-wiki|htcondor-wiki|pages|research)\.cs|kb|learnuw|(ecs|search)\.library|login|my|mywebspace|wayf|wiscmail)\.wisc\.edu/"
 	      to="https://$1.wisc.edu/" />
 
 	<test url="http://condor-wiki.cs.wisc.edu/" />
 	<test url="http://htcondor-wiki.cs.wisc.edu/" />
 	<test url="http://pages.cs.wisc.edu/" />
+	<test url="http://kb.wisc.edu/" />
 	<test url="http://learnuw.wisc.edu/" />
 	<test url="http://ecs.library.wisc.edu/" />
 	<test url="http://search.library.wisc.edu/" />

--- a/src/chrome/content/rules/University_of_Wisconsin-Madison.xml
+++ b/src/chrome/content/rules/University_of_Wisconsin-Madison.xml
@@ -5,7 +5,7 @@
 		- (www.)aos *
 		- www.geology		(shows geoscience; mismatched, CN: geoscience.wisc.edu)
 		- geoscience		(403/404)
-		- library               (mismatched, CN: www.library.wisc.edu)
+		- library		(mismatched, CN: www.library.wisc.edu)
 		- depot.library *
 		- digital.library
 		- m.library **
@@ -13,7 +13,7 @@
 		- studyrooms.library **
 		- uwdc.library **
 		- xerxes.library
-		- www.today             (mismatched, CN: today.wisc.edu)
+		- www.today		(mismatched, CN: today.wisc.edu)
 		- vip ***
 		- www *
 
@@ -26,7 +26,7 @@
 
 		- krakatau.doit		(expired, self-signed)
 		- services.ldap		(weak crypto)
-		- www.uhs.wisc.edu      (breaks Google site search) 
+		- www.uhs.wisc.edu	(breaks Google site search) 
 
 	Partially covered subdomains:
 
@@ -43,14 +43,14 @@
 			- condor-wiki
 			- htcondor-wiki
 			- research
-			- www           (requires redirect to www.cs.wisc.edu)
+			- www		(requires redirect to www.cs.wisc.edu)
 
 		- discovery
-		- housing               (required redirect to www.housing.wisc.edu)
+		- housing		(required redirect to www.housing.wisc.edu)
 		- kb
 		- learnuw
 		- ecs.library
-		- www.library           (requires redirect to www.library.wisc.edu)
+		- www.library		(requires redirect to www.library.wisc.edu)
 		- login
 		- www.math
 		- my
@@ -70,16 +70,13 @@
 
 	<target host="*.wisc.edu" />
 	<target host="*.library.wisc.edu" />
-		<!--
-			404:
-				-->
-		<exclusion pattern="^http://pages\.cs\.wisc\.edu/+~" />
 
-		<test url="http://pages.cs.wisc.edu/hartzheim" />
-
+	<!-- 404: Individual users must enable SSL for their personal pages. -->
+	<exclusion pattern="^http://pages\.cs\.wisc\.edu/+~" />
+	<test url="http://pages.cs.wisc.edu/~hartzheim" />
 
 	<rule from="^http://((?:condor-wiki|htcondor-wiki|pages|research)\.cs|discovery|kb|learnuw|(ecs|search)\.library|login|my|mywebspace|wayf|wiscmail)\.wisc\.edu/"
-	      to="https://$1.wisc.edu/" />
+	to="https://$1.wisc.edu/" />
 
 	<test url="http://condor-wiki.cs.wisc.edu/" />
 	<test url="http://htcondor-wiki.cs.wisc.edu/" />
@@ -96,7 +93,7 @@
 
 	<!-- Requires redirect to www.* to use SSL -->
 	<rule from="^http://(?:www\.)?(cs|housing|library|math)\.wisc\.edu/"
-	      to="https://www.$1.wisc.edu/" />
+	to="https://www.$1.wisc.edu/" />
 
 	<test url="http://library.wisc.edu/" />
 	<test url="http://www.library.wisc.edu/" />

--- a/src/chrome/content/rules/University_of_Wisconsin-Madison.xml
+++ b/src/chrome/content/rules/University_of_Wisconsin-Madison.xml
@@ -47,11 +47,11 @@
 			- condor-wiki
 			- htcondor-wiki
 			- research
-			- www		(requires redirect to www.cs.wisc.edu)
+			- www
 
 		- discovery
 		- go
-		- housing		(required redirect to www.housing.wisc.edu)
+		- housing		(requires redirect to www.housing.wisc.edu)
 		- kb
 		- learnuw
 		- ecs.library
@@ -100,7 +100,7 @@
 	<test url="http://wayf.wisc.edu/" />
 	<test url="http://wiscmail.wisc.edu/" />
 
-	<!-- Requires redirect to www.* to use SSL -->
+	<!-- Require redirect to www.* to use SSL -->
 	<rule from="^http://(?:www\.)?(cs|housing|library|math)\.wisc\.edu/"
 	to="https://www.$1.wisc.edu/" />
 

--- a/src/chrome/content/rules/University_of_Wisconsin-Madison.xml
+++ b/src/chrome/content/rules/University_of_Wisconsin-Madison.xml
@@ -50,6 +50,7 @@
 		- ecs.library
 		- www.library           (requires redirect to www.library.wisc.edu)
 		- login
+		- www.math
 		- my
 		- mywebspace
 		- wayf
@@ -90,10 +91,11 @@
 	<test url="http://wiscmail.wisc.edu/" />
 
 	<!-- Requires redirect to www.* to use SSL -->
-	<rule from="^http://(?:www\.)?(cs|housing|library)\.wisc\.edu/"
+	<rule from="^http://(?:www\.)?(cs|housing|library|math)\.wisc\.edu/"
 	      to="https://www.$1.wisc.edu/" />
 
 	<test url="http://library.wisc.edu/" />
 	<test url="http://www.library.wisc.edu/" />
+	<test url="http://math.wisc.edu/" />
 
 </ruleset>

--- a/src/chrome/content/rules/University_of_Wisconsin-Madison.xml
+++ b/src/chrome/content/rules/University_of_Wisconsin-Madison.xml
@@ -26,7 +26,7 @@
 
 		- krakatau.doit		(expired, self-signed)
 		- services.ldap		(weak crypto)
-
+		- www.uhs.wisc.edu      (breaks Google site search) 
 
 	Partially covered subdomains:
 


### PR DESCRIPTION
Add support for subdomains:
* cs.wisc.edu
* discovery.wisc.edu
* doit.wisc.edu
* go.wisc.edu
* housing.wisc.edu
* kb.wisc.edu
* library.wisc.edu
* math.wisc.edu

Updated rule documentation (old comments not valid for all domains). Further updated this documentation with new domains to explain why they are not yet supported (for example, mixed content warnings caused by Google site search).