### PR TITLE
[Openresty.org.xml] New ruleset

### DIFF
--- a/src/chrome/content/rules/Openresty.org.xml
+++ b/src/chrome/content/rules/Openresty.org.xml
@@ -1,0 +1,13 @@
+<!--
+
+-->
+<ruleset name="Openresty.org">
+    <target host="openresty.de" />
+    <target host="www.openresty.org" />
+    <target host="qa.openresty.org" />
+
+    <securecookie host="^(www\.|qa\.)?openresty\.org$" name=".+" />
+	
+    <rule from="^http:"
+            to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/Openresty.org.xml
+++ b/src/chrome/content/rules/Openresty.org.xml
@@ -5,10 +5,9 @@
 <ruleset name="Openresty.org">
     <target host="openresty.org" />
     <target host="www.openresty.org" />
-    <!-- <target host="qa.openresty.org" /> -->
+    <target host="qa.openresty.org"
 
-    <!-- <securecookie host="^(www\.|qa\.)?openresty\.org$" name=".+" /> -->
-    <securecookie host="^(www\.)?openresty\.org$" name=".+" />
+    <securecookie host="^(www\.|qa\.)?openresty\.org$" name=".+" />
 
     <rule from="^http:"
             to="https:" />

--- a/src/chrome/content/rules/Openresty.org.xml
+++ b/src/chrome/content/rules/Openresty.org.xml
@@ -4,7 +4,7 @@
 <ruleset name="Openresty.org">
     <target host="openresty.org" />
     <target host="www.openresty.org" />
-    <target host="qa.openresty.org"
+    <target host="qa.openresty.org" />
 
     <securecookie host="^(www\.|qa\.)?openresty\.org$" name=".+" />
 

--- a/src/chrome/content/rules/Openresty.org.xml
+++ b/src/chrome/content/rules/Openresty.org.xml
@@ -1,6 +1,5 @@
 <!--
-    Nonfunctional subdomains:
-        - qa    -> Clouldflare SSL error
+
 -->
 <ruleset name="Openresty.org">
     <target host="openresty.org" />

--- a/src/chrome/content/rules/Openresty.org.xml
+++ b/src/chrome/content/rules/Openresty.org.xml
@@ -1,13 +1,15 @@
 <!--
-
+    Nonfunctional subdomains:
+        - qa    -> Clouldflare SSL error
 -->
 <ruleset name="Openresty.org">
-    <target host="openresty.de" />
+    <target host="openresty.org" />
     <target host="www.openresty.org" />
-    <target host="qa.openresty.org" />
+    <!-- <target host="qa.openresty.org" /> -->
 
-    <securecookie host="^(www\.|qa\.)?openresty\.org$" name=".+" />
-	
+    <!-- <securecookie host="^(www\.|qa\.)?openresty\.org$" name=".+" /> -->
+    <securecookie host="^(www\.)?openresty\.org$" name=".+" />
+
     <rule from="^http:"
             to="https:" />
 </ruleset>


### PR DESCRIPTION
No 301 redirect, but the whole website only seems to exist of a few sites.

**Attention:** Do not merge right now. Currently https://qa.openresty.org/ has a TLS error. Hopefully [this will be fixed](https://github.com/openresty/openresty.org/issues/16) soon.