### PR TITLE
Update LegitScript rule

### DIFF
--- a/src/chrome/content/rules/LegitScript.xml
+++ b/src/chrome/content/rules/LegitScript.xml
@@ -2,5 +2,5 @@
   <target host="www.legitscript.com" />
   <target host="legitscript.com" />
 
-  <rule from="^http://(?:www\.)?legitscript\.com/" to="https://secure.legitscript.com/"/>
+  <rule from="^http:" to="https:" />
 </ruleset>


### PR DESCRIPTION
We no longer use a separate hostname for ssl connections