### PR TITLE
[Dispenser.tf] Update ruleset

### DIFF
--- a/src/chrome/content/rules/Dispenser.tf.xml
+++ b/src/chrome/content/rules/Dispenser.tf.xml
@@ -1,6 +1,9 @@
+<!--
+  Note: www.dispenser.tf serves a 400 on both HTTP and HTTPS.     
+-->
 <ruleset name="Dispenser.tf">
   <target host="dispenser.tf" />
   <target host="www.dispenser.tf" />
 
-  <rule from="^http://(www\.)?dispenser\.tf/" to="https://www.dispenser.tf/" />
+  <rule from="^http://(www\.)?dispenser\.tf/" to="https://dispenser.tf/" />
 </ruleset>


### PR DESCRIPTION
Both http://www.dispenser.tf and https://www.dispenser.tf serve 404 Bad requests; we update the ruleset to avoid the www part altogether.

This fixes https://github.com/EFForg/https-everywhere/issues/3119