### PR TITLE
[EFF.xml] Small changes

### DIFF
--- a/src/chrome/content/rules/EFF.xml
+++ b/src/chrome/content/rules/EFF.xml
@@ -36,7 +36,7 @@
 	<securecookie host="^.*\.eff\.org$" name=".*" />
 
 	<rule from="^http://([^/:@\.]+\.)?eff\.org/"
-		to="https://$1eff.org/" />
+		    to="https://$1eff.org/" />
 
 	<!--
 		This is for promoting HTTPS Everywhere to eff.org visitors, but
@@ -44,13 +44,13 @@
 	-->
 
 	<rule from="^https://www\.eff\.org/sites/all/themes/frontier/images/get-https-e(-chrome)?.png"
-		to="https://www.eff.org/sites/all/themes/frontier/images/got-https-e$1.png" />
+		    to="https://www.eff.org/sites/all/themes/frontier/images/got-https-e$1.png" />
 
 	<!--
 		Other EFF websites that support HTTPS.
 	-->
 
 	<rule from="^http://(www\.)?(defendinnovation|globalchokepoints|httpsnow|ripmixmake)\.org/"
-		to="https://$1$2.org/" />
+		    to="https://$1$2.org/" />
 
 </ruleset>


### PR DESCRIPTION
I also saw that
https://www.eff.org/sites/all/themes/frontier/images/got-https-e-chrome.png
and
https://www.eff.org/sites/all/themes/frontier/images/get-https-e-chrome.png
return 404 errors. So should I remove this redirection as it's obviously
not used?