### PR TITLE
[Denic.de] New ruleset; [WebGo24.de] Rewrite

### DIFF
--- a/src/chrome/content/rules/Denic.de.xml
+++ b/src/chrome/content/rules/Denic.de.xml
@@ -1,0 +1,17 @@
+<!--
+	Announcement:
+		- https://denic.de/en/denic-in-dialogue/news/4079.html
+		
+	Non-functional subdomains:
+		- secure     -> DNS resolve error
+-->
+<ruleset name="Denic.de">
+    <target host="denic.de" />
+    <target host="www.denic.de" />
+    <target host="www.secure.denic.de" />
+
+    <securecookie host="^(www\.)?(secure\.)?denic\.de$" name=".+" />
+
+    <rule from="^http:"
+            to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/Denic.de.xml
+++ b/src/chrome/content/rules/Denic.de.xml
@@ -2,7 +2,7 @@
 	Announcement:
 		- https://denic.de/en/denic-in-dialogue/news/4079.html
 		
-	Non-functional subdomains:
+	Nonfunctional subdomains:
 		- secure     -> DNS resolve error
 -->
 <ruleset name="Denic.de">

--- a/src/chrome/content/rules/WebGo.xml
+++ b/src/chrome/content/rules/WebGo.xml
@@ -16,10 +16,10 @@
 
 -->
 <ruleset name="WebGo.de">
-	<target host="www.webgo24.de" />
+	<target host="www.webgo.de" />
 	<target host="website.webgo.de" />
 	<target host="www.website.webgo.de" />
-	<target host="login.webgo24.de" />	
+	<target host="login.webgo.de" />	
 	<target host="support.webgo.de" />
 	<!-- <target host="www.support.webgo.de" /> -->
 	

--- a/src/chrome/content/rules/WebGo.xml
+++ b/src/chrome/content/rules/WebGo.xml
@@ -1,0 +1,30 @@
+<!--
+	Nonfunctional subdomains:
+		- $
+		- www.login   -> wrong domain
+		- hilfe       -> wrong domain
+		- partner     -> wrong domain
+		- www.support -> no DNS record
+		- ...
+
+	Subdomains covered:
+		- www
+		- website
+		- www.website
+		- login
+		- support
+
+-->
+<ruleset name="WebGo.de">
+	<target host="www.webgo24.de" />
+	<target host="website.webgo.de" />
+	<target host="www.website.webgo.de" />
+	<target host="login.webgo24.de" />	
+	<target host="support.webgo.de" />
+	<!-- <target host="www.support.webgo.de" /> -->
+	
+	<securecookie host="^(www\.|website\.|www\.website|login\.|support\.)?webgo\.de$" name=".+" />
+
+    <rule from="^http:"
+            to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/WebGo24.de.xml
+++ b/src/chrome/content/rules/WebGo24.de.xml
@@ -33,9 +33,6 @@
 					-->
 	<!--securecookie host="^login\.webgo24\.de$" name=".+" /-->
 	
-	<test url="https://webgo24.de/" />
-	<test url="https://www.webgo24.de/" />
-
     <rule from="^http:"
             to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/WebGo24.de.xml
+++ b/src/chrome/content/rules/WebGo24.de.xml
@@ -2,6 +2,7 @@
 	Nonfunctional subdomains:
 
 		- faq *
+		- support (only /live is securable)
 
 	* Shows another domain
 
@@ -22,7 +23,6 @@
 
 	<target host="webgo24.de" />
 	<target host="www.webgo24.de" />
-	<target host="support.webgo24.de" />
 	<target host="login.webgo24.de" />
 	<target host="hilfe.webgo24.de" />
 	<target host="partner.webgo24.de" />

--- a/src/chrome/content/rules/WebGo24.de.xml
+++ b/src/chrome/content/rules/WebGo24.de.xml
@@ -5,17 +5,13 @@
 
 	* Shows another domain
 
-
-	^: cert only matches *.webgo24.de
-
-
 	Mixed content:
 
 		- Images, on www from:
 
 			- ^ ¹
 			- $self ¹
-			- www.denic.de ²
+			- www.denic.de ¹
 			- badges.mariadb.org ²
 
 	¹ Secured by us
@@ -25,20 +21,21 @@
 <ruleset name="WebGo24.de">
 
 	<target host="webgo24.de" />
-	<target host="*.webgo24.de" />
+	<target host="www.webgo24.de" />
+	<target host="support.webgo24.de" />
+	<target host="login.webgo24.de" />
+	<target host="hilfe.webgo24.de" />
+	<target host="partner.webgo24.de" />
 
-
-	<securecookie host="^www\.webgo24\.de$" name=".+" />
+	<securecookie host="^(www\.|support\.|login\.|hilfe\.|partner\.)?webgo24\.de$" name=".+" />
 	<!--
 		Server sets Secure for:
 					-->
 	<!--securecookie host="^login\.webgo24\.de$" name=".+" /-->
+	
+	<test url="https://webgo24.de/" />
+	<test url="https://www.webgo24.de/" />
 
-
-	<rule from="^http://(?:www\.)?webgo24\.de/"
-		to="https://www.webgo24.de/" />
-
-	<rule from="^http://login\.webgo24\.de/"
-		to="https://login.webgo24.de/" />
-
+    <rule from="^http:"
+            to="https:" />
 </ruleset>


### PR DESCRIPTION
Fixes https://github.com/EFForg/https-everywhere/issues/2875, 301
redirects to HTTPS

As Denic.de was mentioned in WebGo24.de I wanted to change this. However
WebGo24.de was a very bad wildcard ruleset without test URLs and without
any use of the wildcard. So I had to rewrite this too.