### PR TITLE
[Online2pdf.com] New ruleset

### DIFF
--- a/src/chrome/content/rules/Online2pdf.com.xml
+++ b/src/chrome/content/rules/Online2pdf.com.xml
@@ -1,0 +1,12 @@
+<!--
+
+-->
+<ruleset name="Online2pdf.com">
+    <target host="online2pdf.com" />
+    <target host="s1.online2pdf.com" />
+
+    <securecookie host="^(s1\.)?online2pdf\.com$" name=".+" />
+
+    <rule from="^http:"
+            to="https:" />
+</ruleset>


### PR DESCRIPTION
No 301 redirect to HTTPS, but they have a button on their HTTP site (at
the right top) which links to the HTTPS version, so they explicitly
support HTTPS. This means everything should work without any problems.