### PR TITLE
[bitmask.net] cover all but deb in *.bitmask.net

### DIFF
--- a/src/chrome/content/rules/Bitmask.net.xml
+++ b/src/chrome/content/rules/Bitmask.net.xml
@@ -18,9 +18,15 @@
 	<!--	Direct rewrites:
 				-->
 	<target host="bitmask.net" />
-	<target host="demo.bitmask.net" />
-	<target host="dl.bitmask.net" />
+	<target host="*.bitmask.net" />
 
+    <exclusion pattern="^http://deb\.bitmask\.net/" />
+
+    <test url="http://deb.bitmask.net/" />
+
+  <test url="http://bitmask.net" />
+  <test url="http://demo.bitmask.net" />
+  <test url="http://dl.bitmask.net" />
 
 	<rule from="^http:"
 		to="https:" />


### PR DESCRIPTION
https://deb.bitmask.net uses a self-signed cert which CN is not matching
the subdomain.