### PR TITLE
[Scene7] Update ruleset; disable wildcard rule

### DIFF
--- a/src/chrome/content/rules/Scene7.xml
+++ b/src/chrome/content/rules/Scene7.xml
@@ -9,9 +9,10 @@
 
 	Problematic subdomains:
 
-		- ^	(mismatched, CN: www.adobe.com)
-		- www	(akamai)
-		- .+	(akamai)
+		- ^		(mismatched, CN: www.adobe.com)
+		- www		(akamai)
+		- s7mbrstream	(breaks embedded video, cf https://github.com/EFForg/https-everywhere/issues/2430)
+		- .+		(akamai)
 
 
 	Fully covered subdomains:
@@ -25,7 +26,9 @@
 <ruleset name="Scene7">
 
 	<target host="scene7.com" />
-	<target host="*.scene7.com" />
+	<target host="www.scene7.com" />
+	<target host="www1.scene7.com" />
+	<target host="s7sps3.scene7.com" />
 
 
 	<securecookie host="^www1\.scene7\.com$" name=".+" />
@@ -34,10 +37,11 @@
 	<rule from="^http://(?:www\.)?scene7\.com/[^\?]*(\?.*)?"
 		to="https://www.adobe.com/products/scene7.html$1" />
 
-	<rule from="^http://www1\.scene7\.com/"
-		to="https://www1.scene7.com/" />
+	<!--<rule from="^http://([\w-]+)\.scene7\.com/"
+		to="https://a248.e.akamai.net/f/248/9086/10h/$1.scene7.com/" />-->
 
-	<rule from="^http://([\w-]+)\.scene7\.com/"
-		to="https://a248.e.akamai.net/f/248/9086/10h/$1.scene7.com/" />
+
+	<rule from="^http:"
+		to="https:" />
 
 </ruleset>


### PR DESCRIPTION
This fixes at least two different issues. One is GH issue #2430, in which the ruleset would cause embedded videos at
  https://www.verizonwireless.com/wcms/overlays/tips-video.html
to not load.

Another is a flawed redirect for http://s7sps3.scene7.com/.

Note that at the moment, the www1 subdomain appears to serve nothing.