### PR TITLE
[New ruleset] PHPDoc

### DIFF
--- a/src/chrome/content/rules/Phpdoc.org.xml
+++ b/src/chrome/content/rules/Phpdoc.org.xml
@@ -1,0 +1,12 @@
+<!--
+
+-->
+<ruleset name="PhpDocumentor" default_off="expired cert">
+    <target host="phpdoc.org" />
+    <target host="www.phpdoc.org" />
+
+    <!-- <securecookie host="^(www\.)?phpdoc\.org/$" name=".+" /> -->
+	
+    <rule from="^http:"
+            to="https:" />
+</ruleset>


### PR DESCRIPTION
disabled because expired cert; [I've asked](https://twitter.com/rugkme/status/664158508808581121) what PhpDoc wants to do about this.