### PR TITLE
[Postdanmark.dk] Add exclusion

### DIFF
--- a/src/chrome/content/rules/Postdanmark.dk.xml
+++ b/src/chrome/content/rules/Postdanmark.dk.xml
@@ -16,6 +16,9 @@
 
 	<securecookie host="^www2\.postdanmark\.dk$" name=".+" />
 
+        <!-- Mixed content from maps.google.com: -->
+        <exclusion pattern="http://www2\.postdanmark\.dk/iis2-findos2/" />
+        <test url="http://www2.postdanmark.dk/iis2-findos2/default.aspx" />
 
 	<rule from="^http:"
 		to="https:" />


### PR DESCRIPTION
This fixes https://github.com/EFForg/https-everywhere/issues/3166

The page http://postdanmark.dk/da/Sider/Quick%20Finder/LocationFinder.aspx includes content from www2.postdanmark.dk which in turn would fetch (falsely) blocked mixed content from maps.google.com.