### PR TITLE
Remove end / included in cookie host

### DIFF
--- a/src/chrome/content/rules/Lets_Encrypt.org.xml
+++ b/src/chrome/content/rules/Lets_Encrypt.org.xml
@@ -9,7 +9,7 @@
 
     <test url="http://letsencrypt.org/repository/" />
 
-    <securecookie host="^(www\.|community\.)?letsencrypt\.org/$" name=".+" />
+    <securecookie host="^(www\.|community\.)?letsencrypt\.org" name=".+" />
 
     <rule from="^http:"
             to="https:" />

--- a/src/chrome/content/rules/Powerlineman.com.xml
+++ b/src/chrome/content/rules/Powerlineman.com.xml
@@ -4,7 +4,7 @@
 	<target host="*.powerlineman.com" />
 
 
-	<securecookie host="^(?:w*\.)?powerlineman\.com/$" name=".+" />
+    <securecookie host="^(?:w*\.)?powerlineman\.com" name=".+" />
 
 
 	<rule from="^http://(www\.)?powerlineman\.com/"

--- a/src/chrome/content/rules/ProjectEuler.xml
+++ b/src/chrome/content/rules/ProjectEuler.xml
@@ -2,7 +2,7 @@
   <target host="www.projecteuler.net" />
   <target host="projecteuler.net" />
 
-  <securecookie host="^projecteuler\.net/$" name=".*" />
+  <securecookie host="^projecteuler\.net" name=".*" />
 
   <rule from="^http://(?:www\.)?projecteuler\.net/" to="https://projecteuler.net/" />
 </ruleset>

--- a/src/chrome/content/rules/Threema.xml
+++ b/src/chrome/content/rules/Threema.xml
@@ -13,7 +13,7 @@
     <test url="http://myid.threema.ch/revoke" />
     <test url="http://avatar.threema.ch/*THREEMA" />
 
-    <securecookie host="^(www.|gateway.|shop\.|myid.)?threema\.ch/$" name=".+" />
+    <securecookie host="^(www.|gateway.|shop\.|myid.)?threema\.ch" name=".+" />
 
     <rule from="^http:"
             to="https:" />

--- a/src/chrome/content/rules/WebAssign.xml
+++ b/src/chrome/content/rules/WebAssign.xml
@@ -2,7 +2,7 @@
   <target host="www.webassign.net" />
   <target host="demo.webassign.net" />
   <target host="webassign.net" />
-  <securecookie host="webassign\.net/" name=".*" />
+  <securecookie host="webassign\.net" name=".*" />
 
   <rule from="^http://(?:www\.)?webassign\.net/" to="https://webassign.net/"/>
   <rule from="^http://demo\.webassign\.net/" to="https://demo.webassign.net/"/>


### PR DESCRIPTION
AFAIK the cookie host is only saved as a domain (`example.com`). However some rulesets contained a following slash `/` which I removed as this would break the securecookie functionality.