### PR TITLE
Removed target host www.rzuser.uni-heidelberg.de because it breaks so…

### DIFF
--- a/src/chrome/content/rules/Uni-heidelberg.de.xml
+++ b/src/chrome/content/rules/Uni-heidelberg.de.xml
@@ -6,7 +6,6 @@
   <target host="katalog.ub.uni-heidelberg.de" />
   <target host="www.mathinf.uni-heidelberg.de" />
   <target host="www.math.uni-heidelberg.de" />
-  <target host="www.rzuser.uni-heidelberg.de" />
   <target host="wwwmail.urz.uni-heidelberg.de" />
 
   <rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Uni-heidelberg.de.xml
+++ b/src/chrome/content/rules/Uni-heidelberg.de.xml
@@ -1,3 +1,7 @@
+<!-- 
+  Problematic subdomains:
+    -www.rzuser, see https://github.com/EFForg/https-everywhere/pull/3194
+-->
 <ruleset name="Uni-heidelberg.de">
   <target host="www.uni-heidelberg.de" />
   <target host="urz.uni-heidelberg.de" />


### PR DESCRIPTION
…me sites, e.g. http://www.rzuser.uni-heidelberg.de/~hu020/EWTS/index.html