### PR TITLE
[QRpedia.org] New ruleset

### DIFF
--- a/src/chrome/content/rules/Qrpedia.org.xml
+++ b/src/chrome/content/rules/Qrpedia.org.xml
@@ -22,7 +22,9 @@
     <target host="qrpedia.org" />
     <target host="www.qrpedia.org" />
 	
-	<!--	
+	<!--
+	https://regex101.com/r/sA9iH2/1
+	
     <exclusion pattern="^http://qrpedia.org/blog" />
     <test url="http://qrpedia.org/blog/" />
 	-->

--- a/src/chrome/content/rules/Qrpedia.org.xml
+++ b/src/chrome/content/rules/Qrpedia.org.xml
@@ -1,0 +1,32 @@
+<!--
+    Problems:
+	    - missing chain certificate (https://whatsmychaincert.com/?qrpedia.org)
+
+    Mixed content:
+	    - on main site
+		    - http://code.jquery.com/jquery.min.js *
+		
+		- on blog
+		    - qrpedia.org *
+		    - www.youtube.com *
+			- chart.apis.google.com *
+			- upload.wikimedia.org *
+			- admin.brightcove.com
+		
+	    * Secured by us
+	
+    Related:
+	    - QR code domain qrwp.org unfunctional because of wrong domain in cert (valid for *.wikimedia.org.uk, wikimedia.org.uk)
+-->
+<ruleset name="QRpedia.org" default_off="missing chain cert" platform="mixedcontent">
+    <target host="qrpedia.org" />
+    <target host="www.qrpedia.org" />
+	
+	<!--	
+    <exclusion pattern="^http://qrpedia.org/blog" />
+    <test url="http://qrpedia.org/blog/" />
+	-->
+
+    <rule from="^http:"
+            to="https:" />
+</ruleset>


### PR DESCRIPTION
Causes mixed content errors; disabled by default because of missing chain.

I've contacted the site authors - maybe they'll fix it: https://twitter.com/rugkme/status/664840438503899136