### PR TITLE
Ruleset for gimp.org domains

### DIFF
--- a/src/chrome/content/rules/gimp.org.xml
+++ b/src/chrome/content/rules/gimp.org.xml
@@ -1,0 +1,12 @@
+<ruleset name="GIMP">
+        <target host="gimp.org" />
+        <target host="developer.gimp.org" />
+        <target host="docs.gimp.org" />
+        <target host="download.gimp.org" />
+        <target host="static.gimp.org" />
+        <target host="testing.gimp.org" />
+        <target host="www.gimp.org" />
+
+        <rule from="^http:"
+                to="https:" />
+</ruleset>


### PR DESCRIPTION
We've recently added HTTPS support via Let's Encrypt, so the majority of gimp.org domains can now be accessed this way.