### PR TITLE
Fix radar.zendesk.com

### DIFF
--- a/src/chrome/content/rules/Zendesk.com.xml
+++ b/src/chrome/content/rules/Zendesk.com.xml
@@ -22,9 +22,10 @@
 	Problematic domains:
 
 		- cdn.zendesk.com *
+		- radar.zendesk.com +
 
 	* Mismatched
-
+	+ Hosted on Github Pages
 
 	Fully covered domains:
 
@@ -46,8 +47,8 @@
 
 		<exclusion pattern="^http://video\.zendesk\.com/" />
 
-			<test url="http://video.zendesk.com/" />
-
+		<test url="http://video.zendesk.com/" />
+		
 		<!--	Direct rewrites:
 					-->
 		<test url="http://developer.zendesk.com/" />
@@ -57,6 +58,7 @@
 		<!--	Special cases:
 					-->
 		<test url="http://cdn.zendesk.com/" />
+		<test url="http://radar.zendesk.com/" />
 
 
 	<!--	Not secured by server:
@@ -72,6 +74,9 @@
 
 	<rule from="^http://cdn\.zendesk\.com/"
 		to="https://d16cvnquvjw7pr.cloudfront.net/" />
+		
+	<rule from="^http://radar\.zendesk\.com/"
+		to="https://zendesk.github.io/radar/" />
 
 	<rule from="^http:"
 		to="https:" />


### PR DESCRIPTION
radar.zendesk.com is hosted with Github Pages therefore requires redirection to correct URL to fix SSL error