### PR TITLE
[Elgiganten] Various updates and fixes

### DIFF
--- a/src/chrome/content/rules/El-Giganten.dk.xml
+++ b/src/chrome/content/rules/El-Giganten.dk.xml
@@ -1,8 +1,0 @@
-<ruleset name="ElgigantenDK">
-	<target host="elgiganten.dk" />
-	<target host="www.elgiganten.dk" />
-
-	<securecookie host="^www\.elgiganten\.dk" name=".*"/>
-	
-	<rule from="^http://(?:www\.)?elgiganten\.dk/" to="https://www.elgiganten.dk/" />
-</ruleset>

--- a/src/chrome/content/rules/Elgiganten.se.xml
+++ b/src/chrome/content/rules/Elgiganten.se.xml
@@ -1,6 +1,0 @@
-<ruleset name="Elgiganten.se">
-	<target host="elgiganten.se" />
-	<rule from="^http://elgiganten\.se/" to="https://www.elgiganten.se/"/>
-	<rule from="^http://www\.elgiganten\.se/" to="https://www.elgiganten.se/"/>
-</ruleset>
-

--- a/src/chrome/content/rules/Elgiganten.xml
+++ b/src/chrome/content/rules/Elgiganten.xml
@@ -1,0 +1,20 @@
+<!--
+	Note: Some product pages trigger false MCB; see
+	https://github.com/EFForg/https-everywhere/issues/3245
+-->
+<ruleset name="Elgiganten (partial)">
+
+	<target host="elgiganten.dk" />
+	<target host="www.elgiganten.dk" />
+
+	<target host="elgiganten.se" />
+	<target host="www.elgiganten.se" />
+
+	<exclusion pattern="http://www.elgiganten.(dk|se)/(product|INTERSHOP)/" />
+	<test url="http://www.elgiganten.dk/product/hvidevarer/vaskemaskine/EWP1472TDW/electrolux-inspiration-vaskemaskine-ewp1472tdw" />
+	<test url="http://www.elgiganten.se/product/hvidevarer/vaskemaskine/EWP1472TDW/electrolux-inspiration-vaskemaskine-ewp1472tdw" />
+	<test url="http://www.elgiganten.dk/INTERSHOP/web/WFS/store-elgigantenDK-Site/da_DK/-/DKK/CC_ViewCollectAtStore-ShowCustomerInfo?SKU=ALCWATCHWH" />
+	<test url="http://www.elgiganten.se/INTERSHOP/web/WFS/store-elgigantenDK-Site/da_DK/-/DKK/CC_ViewCollectAtStore-ShowCustomerInfo?SKU=ALCWATCHWH" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/Elgiganten.xml
+++ b/src/chrome/content/rules/Elgiganten.xml
@@ -1,7 +1,16 @@
 <!--
 	Problematic domains:
-		- metrics.elgiganten.*
-	* Bad CN in cert; might be redirectable to d1.sc.omtrdc.net
+		- annons.elgiganten.se ¹
+		- blog.ebooks.elgiganten.se ¹
+		- (www.)?.ebooks.elgiganten.(dk|se) ²
+		- foto.elgiganten.(dk|se) ¹
+		- metrics.elgiganten.(dk|se) ¹
+		- presentjakten.elgiganten.se ¹
+		- pressroom.elgiganten.dk ¹
+		- tilbudsavis.elgiganten.dk ¹
+		
+	¹ Mismatched
+	² Timeout
 
 	Note: Some product pages trigger false MCB; see
 	https://github.com/EFForg/https-everywhere/issues/3245
@@ -10,9 +19,11 @@
 
 	<target host="elgiganten.dk" />
 	<target host="www.elgiganten.dk" />
+	<target host="onlinebackup.elgiganten.dk" />
 
 	<target host="elgiganten.se" />
 	<target host="www.elgiganten.se" />
+	<target host="onlinebackup.elgiganten.se" />
 
 	<exclusion pattern="http://www.elgiganten.(dk|se)/(product|INTERSHOP)/" />
 	<test url="http://www.elgiganten.dk/product/hvidevarer/vaskemaskine/EWP1472TDW/electrolux-inspiration-vaskemaskine-ewp1472tdw" />

--- a/src/chrome/content/rules/Elgiganten.xml
+++ b/src/chrome/content/rules/Elgiganten.xml
@@ -1,4 +1,8 @@
 <!--
+	Problematic domains:
+		- metrics.elgiganten.*
+	* Bad CN in cert; might be redirectable to d1.sc.omtrdc.net
+
 	Note: Some product pages trigger false MCB; see
 	https://github.com/EFForg/https-everywhere/issues/3245
 -->


### PR DESCRIPTION
This merges the rules for elgiganten.dk and elgiganten.se into a single ruleset. It also excludes all product pages as these produce various (false) mixed content blocking related issues; in particular, this fixes https://github.com/EFForg/https-everywhere/issues/3245. Devs have been informed about those issues.