### PR TITLE
[Microsoft] Redirect microsoft.com to www.microsoft.com

### DIFF
--- a/src/chrome/content/rules/Microsoft.xml
+++ b/src/chrome/content/rules/Microsoft.xml
@@ -151,6 +151,7 @@
 
 		- microsoft.com subdomains:
 
+			- ^			(mismatched, CN: *.microsoft.com)
 			- (www.)? ¹
 			- adcenter		(expired)
 			- feedback.adcenter	(Dropped)
@@ -748,7 +749,10 @@
 		<test url="http://res2.windows.microsoft.com/" />
 		<test url="http://res2.windows.microsoft.com/resources/4.2/wol/shared/images/merged/gl_social.svg" />
 
-	<rule from="^http://((?:account|accountservices|advertising|ajax|(?:fb\.)?answers|wscont\.apps|assets|azure|blogs|c1?|careers|choice|commerce|compass-ssl|connect|services\.connect|sas\.css|curah|social\.expression|go?|i|ieonline|js|learning|mbs|code\.msdn|msdn|(?:apisandbox|events|lab|social|visualstudiogallery)\.msdn|msevents|mspartner|(?:logobuilder|mspartnerlp)\.mspartner|mvastorage|office(?:15client|2010|preview|redir)?|o15\.officeredir|training\.partner|pinpoint|profile|rad|readytogo|profileapi\.services|signature|(?:services\.)?social|store|corp\.sts|support2?|sxp|tag|(?:gallery\.|social\.)?technet|origin-res\.windows|www)\.)?microsoft\.com/"
+	<rule from="^http://microsoft\.com/"
+		to="https://www.microsoft.com/" />
+
+	<rule from="^http://((?:account|accountservices|advertising|ajax|(?:fb\.)?answers|wscont\.apps|assets|azure|blogs|c1?|careers|choice|commerce|compass-ssl|connect|services\.connect|sas\.css|curah|social\.expression|go?|i|ieonline|js|learning|mbs|code\.msdn|msdn|(?:apisandbox|events|lab|social|visualstudiogallery)\.msdn|msevents|mspartner|(?:logobuilder|mspartnerlp)\.mspartner|mvastorage|office(?:15client|2010|preview|redir)?|o15\.officeredir|training\.partner|pinpoint|profile|rad|readytogo|profileapi\.services|signature|(?:services\.)?social|store|corp\.sts|support2?|sxp|tag|(?:gallery\.|social\.)?technet|origin-res\.windows|www)\.)microsoft\.com/"
 		to="https://$1microsoft.com/" />
 
 </ruleset>


### PR DESCRIPTION
https://microsoft.com currently serves a bad certificate, its CN only covering *.microsoft.com. This fixes https://github.com/EFForg/https-everywhere/issues/3234.