### PR TITLE
[Itpol.dk] Update and enable ruleset

### DIFF
--- a/src/chrome/content/rules/Itpol.dk.xml
+++ b/src/chrome/content/rules/Itpol.dk.xml
@@ -1,16 +1,22 @@
 <!--
-	Problematic subdomains
+	Problematic domains
 
-		- wiki ¹
+		- admin ¹²
+		- pad ¹³
+		- wiki ¹³
 
 	¹: Redirects to ^, yet HSTS includeSubDomains is specified for itpol.dk.
+	²: 'Unknown protocol' on HELLO
+	³: Bad CN in cert.
 -->
 <ruleset name="Itpol.dk">
 
+	<target host="it-pol.dk" />
+	<target host="www.it-pol.dk" />
 	<target host="itpol.dk" />
 	<target host="www.itpol.dk" />
 
-	<rule from="^http:"
-		to="https:" />
+	<rule from="^http://(www\.)?it-?pol\.dk/"
+		to="https://$1itpol.dk/" />
 
 </ruleset>

--- a/src/chrome/content/rules/Itpol.dk.xml
+++ b/src/chrome/content/rules/Itpol.dk.xml
@@ -1,27 +1,14 @@
 <!--
 	Problematic subdomains
 
-		- ^ ²
-		- www ¹²
-		- wiki ¹²³
+		- wiki ¹
 
-	¹: Hostname not in cert (CN: itpol.dk).
-	²: CA (CAcert) not in stores.
-	³: Redirects to ^.
+	¹: Redirects to ^, yet HSTS includeSubDomains is specified for itpol.dk.
 -->
-<ruleset name="Itpol.dk" platform="cacert">
+<ruleset name="Itpol.dk">
 
-	<!--	Direct rewrites:
-				-->
 	<target host="itpol.dk" />
-
-	<!--	Complications:
-				-->
 	<target host="www.itpol.dk" />
-
-
-	<rule from="^http://www\.itpol\.dk/"
-		to="https://itpol.dk/" />
 
 	<rule from="^http:"
 		to="https:" />


### PR DESCRIPTION
itpol.dk and www.itpol.dk now serve a LE-signed certificate and can be used. Note that wiki.itpol.dk still serves the incorrect content over HTTPS, even though itpol.dk itself serves a HSTS includeSubDomains header; this is clearly a misconfiguration and the devs have been informed.