### PR TITLE
Fix amara login

### DIFF
--- a/src/chrome/content/rules/Amara.xml
+++ b/src/chrome/content/rules/Amara.xml
@@ -27,7 +27,7 @@
 	<securecookie host="^www\.amara\.org$" name=".+" />
 
 
-	<rule from="^http://(www\.)?amara\.org/"
-		to="https://$1amara.org/" />
+	<rule from="^https?://(www\.)?amara\.org/"
+		to="https://www.amara.org/" />
 
 </ruleset>


### PR DESCRIPTION
Login only saved for non-www domain, therefore it is a pain to manually
add www to access logged version of pages.