### PR TITLE
[Idenyt.dk] New ruleset

### DIFF
--- a/src/chrome/content/rules/Idenyt.dk.xml
+++ b/src/chrome/content/rules/Idenyt.dk.xml
@@ -1,5 +1,12 @@
 <!--
-	Cloudflare SSL
+	Cloudflare SSL on ^ and www
+
+	Problematic domains:
+		foto ¹
+		jul2k8 ¹
+		(www.)tv ¹
+
+	¹: Timeout
 -->
 <ruleset name="Idenyt.dk">
 

--- a/src/chrome/content/rules/Idenyt.dk.xml
+++ b/src/chrome/content/rules/Idenyt.dk.xml
@@ -1,0 +1,14 @@
+<!--
+	Cloudflare SSL
+-->
+<ruleset name="Idenyt.dk">
+
+	<target host="idenyt.dk" />
+	<target host="www.idenyt.dk" />
+
+	<securecookie host=".+" name=".+" />
+
+	<rule from="^http:"
+		to="https:" />
+
+</ruleset>


### PR DESCRIPTION
Some Emediate scripts (secured by us) are blocked as mixed content in Firefox/Chrome but this has no effect on site function.