### PR TITLE
[Sussan.com.au] Update ruleset

### DIFF
--- a/src/chrome/content/rules/Sussan.com.au.xml
+++ b/src/chrome/content/rules/Sussan.com.au.xml
@@ -1,8 +1,26 @@
-<!-- platform="mixedcontent" set due to pagenation using HTTP -->
-<ruleset name="Sussan.com.au" platform="mixedcontent">
+<!--
+	CDN buckets:
+		- dcu0x19cdch9b.cloudfront.net
+
+	Problematic domains:
+		- ^, www ¹
+		- assets ²
+
+	¹: unable to get local issuer certificate
+	²: mismatched
+-->
+<ruleset name="Sussan.com.au" default_off="broken">
+
 	<target host="sussan.com.au" />
 	<target host="www.sussan.com.au" />
+	<target host="assets.sussan.com.au" />
+
+	<rule from="^http://assets\.sussan\.com\.au/"
+		to="https://dcu0x19cdch9b.cloudfront.net/" />
+
+		<test url="http://assets.sussan.com.au/media/upload/2015/December/Homepages/Homepage1/css/main_3_.css" />
 
 	<rule from="^http:"
-			to="https:" />
+		to="https:" />
+
 </ruleset>


### PR DESCRIPTION
Both sussan.com.au and www.sussan.com.au are misconfigured and shouldn't be used, even with platform="mixedcontent". However, assets.sussan.com.au can actually be redirected to cloudfront directly.