### PR TITLE
Fixed Colorado_Secretary_of_State.xml regexp

### DIFF
--- a/src/chrome/content/rules/Colorado_Secretary_of_State.xml
+++ b/src/chrome/content/rules/Colorado_Secretary_of_State.xml
@@ -9,7 +9,7 @@
 	<target host="www.sos.state.co.us" />
 
 
-	<rule from="^http://(?:www\.)sos\.state\.co\.us/pubs/"
+	<rule from="^http://(www\.)sos\.state\.co\.us/pubs/"
 		to="https://$1sos.state.co.us/pubs/" />
 
 </ruleset>


### PR DESCRIPTION
Using a non-selecting group for the www. broke the result and users were sent to https://$1sos.state.co.us/pubs/info_center/holidayCalendar.html - as there was no $1 selected to be re-inserted. I barely know regexp but brief testing with https://regex101.com/ suggests my change works - but it needs some oversight.