### PR TITLE
wikimedia: remove smokeping and torrus services

### DIFF
--- a/src/chrome/content/rules/Wikimedia.xml
+++ b/src/chrome/content/rules/Wikimedia.xml
@@ -34,13 +34,11 @@
 	<target host="*.mediawiki.org" />
 	<target host="wikimedia.org" />
 	<target host="*.wikimedia.org" />
-		<exclusion pattern="^http://(?:apt|parsoid-lb\.eqiad|smokeping|status|torrus|ubuntu)\.wikimedia\.org" />
+		<exclusion pattern="^http://(?:apt|parsoid-lb\.eqiad|status|ubuntu)\.wikimedia\.org" />
 		<!-- https://mail1.eff.org/pipermail/https-everywhere-rules/2012-June/001189.html -->
 			<test url="http://apt.wikimedia.org" />
 			<test url="http://parsoid-lb.eqiad.wikimedia.org" />
-			<test url="http://smokeping.wikimedia.org" />
 			<test url="http://status.wikimedia.org" />
-			<test url="http://torrus.wikimedia.org" />
 			<test url="http://ubuntu.wikimedia.org" />
 
 	<target host="wikimediafoundation.org" />


### PR DESCRIPTION
These services have recently been fixed and now use https.

The exceptions can be removed.

https://gerrit.wikimedia.org/r/#/c/256986/
https://gerrit.wikimedia.org/r/#/c/256969/
https://gerrit.wikimedia.org/r/#/c/255463/
https://gerrit.wikimedia.org/r/#/c/256879/