### PR TITLE
[LinuxTV] Update and activate ruleset

### DIFF
--- a/src/chrome/content/rules/LinuxTV.org.xml
+++ b/src/chrome/content/rules/LinuxTV.org.xml
@@ -1,22 +1,12 @@
-<!--
-	Nonfunctional subdomains:
+<ruleset name="LinuxTV.org">
 
-		- (www.) *
-		- git *
+	<target host="linuxtv.org" />
+	<target host="www.linuxtv.org" />
 
-	* Shows patchwork
-
-
-	- Expired 2007-06-26
-	- Mismatched, CN: www.linuxtv.org
-
--->
-<ruleset name="LinuxTV.org (partial)" default_off="expired, mismatched, self-signed">
-
+	<target host="git.linuxtv.org" />
 	<target host="patchwork.linuxtv.org" />
 
-
-	<rule from="^http://patchwork\.linuxtv\.org/"
-		to="https://patchwork.linuxtv.org/" />
+	<rule from="^http:"
+		to="https:" />
 
 </ruleset>


### PR DESCRIPTION
As mentioned in https://github.com/EFForg/https-everywhere/issues/3357, the site no longer serves an untrusted certificate.