### PR TITLE
[Avm.de] Add exclusions

### DIFF
--- a/src/chrome/content/rules/Avm.de.xml
+++ b/src/chrome/content/rules/Avm.de.xml
@@ -14,10 +14,10 @@
 -->
 <ruleset name="AVM.de (partial)">
 
-<target host="avm.de"/>
+	<target host="avm.de"/>
 	<target host="en.avm.de"/>
 	<!--target host="piwik.avm.de"/-->
-<target host="www.avm.de"/>
+	<target host="www.avm.de"/>
 
 		<!--	Redirects to http:
 						-->
@@ -25,7 +25,7 @@
 		<!--
 			Exceptions:
 					-->
-		<exclusion pattern="^http://en\.avm\.de/+(?!favicon\.ico|fileadmin/|typo3conf/|typo3temp/)" />
+		<exclusion pattern="^http://(en\.)?avm\.de/+(?!favicon\.ico|fileadmin/|typo3conf/|typo3temp/)" />
 
 			<!--	+ve:
 					-->
@@ -35,6 +35,11 @@
 			<test url="http://en.avm.de/products/" />
 			<test url="http://en.avm.de/service/" />
 
+			<test url="http://avm.de/produkte/" />
+			<test url="http://avm.de/service/" />
+			<test url="http://avm.de/ratgeben/" />
+			<test url="http://avm.de/aktuelles/" />
+
 			<!--	+ve:
 					-->
 			<test url="http://en.avm.de/favicon.ico" />
@@ -42,6 +47,10 @@
 			<test url="http://en.avm.de/typo3conf/ext/avm/Resources/Public/Images/logo.png" />
 			<test url="http://en.avm.de/typo3temp/compressor/merged-608c235dc169b392ffdc9ad6bd972759.css?1437379980" />
 
+			<test url="http://avm.de/favicon.ico" />
+			<test url="http://avm.de/fileadmin/user_upload/Global/Verschiedenes/icon_news_43x34.png" />
+			<test url="http://avm.de/typo3conf/ext/avm/Resources/Public/Images/logo.png" />
+			<test url="http://avm.de/typo3temp/compressor/merged-608c235dc169b392ffdc9ad6bd972759.css?1437379980" />
 
 	<rule from="^http:"
 		to="https:" />


### PR DESCRIPTION
This excludes most of the content on avm.de, adding the existing exclusions from en.avm.de to this main domain as well. This fixes a redirect loop on the front page and false mixed content blocking on several subpages (cf. the test URLs). In particular, this fixes https://github.com/EFForg/https-everywhere/issues/3346.