### PR TITLE
[Wdr.de] Disable www1

### DIFF
--- a/src/chrome/content/rules/Wdr.de.xml
+++ b/src/chrome/content/rules/Wdr.de.xml
@@ -1,7 +1,14 @@
+<!--
+
+	Problematic domains:
+
+		- www1 ¹
+
+	¹ Redirect to HTTP
+-->
 <ruleset name="Westdeutscher Rundfunk">
 
 	<target host="www.wdr.de"/>
-	<target host="www1.wdr.de"/>
 	<target host="www.einslive.de"/>
 	<target host="www.wdr2.de"/>
 	<target host="www.wdr3.de"/>


### PR DESCRIPTION
All content on www1.wdr.de appears to redirect to HTTP. Disabling it also fixes https://github.com/EFForg/https-everywhere/issues/3347.