### PR TITLE
Add ruleset for roblox.com

### DIFF
--- a/src/chrome/content/rules/Roblox.xml
+++ b/src/chrome/content/rules/Roblox.xml
@@ -1,0 +1,6 @@
+<ruleset name="Roblox">
+  <target host="api.roblox.com" />
+  <test url="http://api.roblox.com/docs" />
+
+  <rule from="^http:" to="https:" />
+</ruleset>


### PR DESCRIPTION
At the moment only api.roblox.com supports HTTPS for all visitors, but other subdomains will probably support it in the future, so it will be possible to add them to the `Roblox.xml` ruleset.