### PR TITLE
[Levny-hosting.cz] Reenable ruleset (certificate is valid)

### DIFF
--- a/src/chrome/content/rules/Levny-hosting.cz.xml
+++ b/src/chrome/content/rules/Levny-hosting.cz.xml
@@ -1,18 +1,11 @@
-<!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://levny-hosting.cz/ => https://levny-hosting.cz/: (60, 'SSL certificate problem: certificate has expired')
-Fetch error: http://www.levny-hosting.cz/ => https://www.levny-hosting.cz/: (60, 'SSL certificate problem: certificate has expired')
--->
-<ruleset name="Levny-hosting.cz" default_off='failed ruleset test'>
+<ruleset name="Levny-hosting.cz">
 
 	<target host="levny-hosting.cz" />
 	<target host="www.levny-hosting.cz" />
 
-
 	<securecookie host="^www\.levny-hosting\.cz$" name=".+" />
 
-
-	<rule from="^http://(www\.)?levny-hosting\.cz/"
-		to="https://$1levny-hosting.cz/" />
+	<rule from="^http:"
+            to="https:" />
 
 </ruleset>


### PR DESCRIPTION
Reenable ruleset Levny-hosting.cz because certificate is valid.