### PR TITLE
[Koreatimes] Disable ruleset

### DIFF
--- a/src/chrome/content/rules/Koreatimes.co.kr.xml
+++ b/src/chrome/content/rules/Koreatimes.co.kr.xml
@@ -1,6 +1,6 @@
-<ruleset name="Koreatimes">
-<target host="*.koreatimes.co.kr"/>
-<!-- www2 uses an invalid cert , img can't use tls -->
+<ruleset name="Koreatimes" default_off="Certificate expired">
+	<target host="*.koreatimes.co.kr"/>
+	<!-- www2 uses an invalid cert , img can't use tls -->
 
-<rule from="^http://www\.koreatimes\.co\.kr/" to="https://www.koreatimes.co.kr/"/>
+	<rule from="^http://www\.koreatimes\.co\.kr/" to="https://www.koreatimes.co.kr/"/>
 </ruleset>


### PR DESCRIPTION
The site currently provides an expired certificate. In particular, this fixes #3398. Webmasters have been notified.