### PR TITLE
[Oculus.com] Simplify ruleset and update domain.

### DIFF
--- a/src/chrome/content/rules/Oculus_VR.xml
+++ b/src/chrome/content/rules/Oculus_VR.xml
@@ -1,25 +1,9 @@
-<!--
-	At least some pages redirect to http via JS
+<ruleset name="Oculus VR">
+	<target host="oculus.com" />
+	<target host="*.oculus.com" />
 
+  	<securecookie host="^.*\.oculus\.com$" name=".+" />
 
-	Mixed content:
-
-		- Images on www from www *
-
-	* Secured by us
-
--->
-<ruleset name="Oculus VR (partial)">
-
-	<target host="oculusvr.com" />
-	<target host="*.oculusvr.com" />
-		<exclusion pattern="^http://(?:www\.)?oculusvr\.com/(?!_core/|pre-order|wp-content/|wp-includes/)" />
-
-
-	<securecookie host="^(?:careers|developer)\.oculusvr\.com$" name=".+" />
-
-
-	<rule from="^http://((?:careers|developer|www)\.)?oculusvr\.com/"
-		to="https://$1oculusvr.com/" />
-
+	<rule from="^http:"
+		to="https:" />
 </ruleset>


### PR DESCRIPTION
Re-open https://github.com/EFForg/https-everywhere/pull/3246. Addressed https://github.com/EFForg/https-everywhere/pull/3246#issuecomment-164446928
All subdomains should support HTTPS, according to HSTS policy.