### PR TITLE
[Wikimedia.xml] Remove already preloaded domains

### DIFF
--- a/src/chrome/content/rules/Wikimedia.xml
+++ b/src/chrome/content/rules/Wikimedia.xml
@@ -30,8 +30,6 @@
 	<target host="enwp.org" />
 	<target host="frwp.org" />
 
-	<target host="mediawiki.org" />
-	<target host="*.mediawiki.org" />
 	<target host="wikimedia.org" />
 	<target host="*.wikimedia.org" />
 		<exclusion pattern="^http://(?:apt|parsoid-lb\.eqiad|status|ubuntu)\.wikimedia\.org" />
@@ -40,60 +38,6 @@
 			<test url="http://parsoid-lb.eqiad.wikimedia.org" />
 			<test url="http://status.wikimedia.org" />
 			<test url="http://ubuntu.wikimedia.org" />
-
-	<target host="wikimediafoundation.org" />
-	<target host="*.wikimediafoundation.org" />
-
-	<!-- Wikimedia projects (also some wikimedia.org subdomains) -->
-	<target host="wikibooks.org" />
-	<target host="*.wikibooks.org" />
-	<target host="wikidata.org" />
-	<target host="*.wikidata.org" />
-	<target host="wikinews.org" />
-	<target host="*.wikinews.org" />
-	<target host="wikipedia.org" />
-	<target host="*.wikipedia.org" />
-	<target host="wikiquote.org" />
-	<target host="*.wikiquote.org" />
-	<target host="wikisource.org" />
-	<target host="*.wikisource.org" />
-	<target host="wikiversity.org" />
-	<target host="*.wikiversity.org" />
-	<target host="wikivoyage.org" />
-	<target host="*.wikivoyage.org" />
-	<target host="wiktionary.org" />
-	<target host="*.wiktionary.org" />
-
-	<test url="http://en.wikibooks.org" />
-	<test url="http://en.wikinews.org" />
-	<test url="http://en.wikipedia.org" />
-	<test url="http://en.wikiquote.org" />
-	<test url="http://en.wikisource.org" />
-	<test url="http://en.wikiversity.org" />
-	<test url="http://en.wikivoyage.org" />
-	<test url="http://en.wiktionary.org" />
-	<test url="http://de.wikibooks.org" />
-	<test url="http://de.wikinews.org" />
-	<test url="http://de.wikipedia.org" />
-	<test url="http://de.wikiquote.org" />
-	<test url="http://de.wikisource.org" />
-	<test url="http://de.wikiversity.org" />
-	<test url="http://de.wikivoyage.org" />
-	<test url="http://de.wiktionary.org" />
-	<test url="http://ru.wikibooks.org" />
-	<test url="http://ru.wikinews.org" />
-	<test url="http://ru.wikipedia.org" />
-	<test url="http://ru.wikiquote.org" />
-	<test url="http://ru.wikisource.org" />
-	<test url="http://ru.wikiversity.org" />
-	<test url="http://ru.wikivoyage.org" />
-	<test url="http://ru.wiktionary.org" />
-
-	<test url="http://www.wikidata.org" />
-	<test url="http://www.wikimedia.org" />
-	<test url="http://www.wikimediafoundation.org" />
-	<test url="http://m.wikimediafoundation.org" />
-	<test url="http://m.mediawiki.org" />
 
 	<!-- Wikimedia Tool Labs -->
 	<target host="tools.wmflabs.org" />


### PR DESCRIPTION
The removed domains have been included in Chrome's HSTS-preloaded list for quite a long time. So no need to include them in HTTPS Everywhere. Wikimedia.org is not currently HSTS-enabled, so it remains here.