### PR TITLE
Update Favstar.fm rules

### DIFF
--- a/src/chrome/content/rules/Favstar.fm.xml
+++ b/src/chrome/content/rules/Favstar.fm.xml
@@ -1,22 +1,4 @@
-<!--
-	Some (most)? pages redirect to http.
-
--->
-<ruleset name="Favstar.fm (partial)">
-
-	<target host="favstar.fm" />
-	<target host="*.favstar.fm" />
-		<!--
-			Redirect to http:
-						-->
-		<!--exclusion pattern="^http://favstar\.fm/($|authorization/new\?clicked=|users/\w+$|help/how_it_works$)" /-->
-		<!--
-			Exceptions:
-					-->
-		<exclusion pattern="^http://favstar\.fm/+(?!favicon\.ico|pro(?:$|\?))" />
-
-
-	<rule from="^http://(assets0\.|www\.)?favstar\.fm/"
-		to="https://$1favstar.fm/" />
-
+<ruleset name="Favstar.fm">
+	<target host="favstar.fm"/>
+	<rule from="^http://favstar\.fm/" to="https://favstar.fm/"/>
 </ruleset>


### PR DESCRIPTION
Favstar has finally removed their HTTPS to HTTP redirects. See https://twitter.com/TimHaines/status/676986243822014464.