### PR TITLE
Add an on/off switch for Chrome

### DIFF
--- a/chromium/background.js
+++ b/chromium/background.js
@@ -183,7 +183,9 @@ var redirectCounter = {};
  * */
 function onBeforeRequest(details) {
   // If HTTPSe has been disabled by the user, return immediately.
-  if (!isExtensionEnabled) { return; }
+  if (!isExtensionEnabled) {
+    return;
+  }
 
   var uri = document.createElement('a');
   uri.href = details.url;

--- a/chromium/background.js
+++ b/chromium/background.js
@@ -37,6 +37,11 @@ var switchPlannerEnabledFor = {};
 // rw / nrw stand for "rewritten" versus "not rewritten"
 var switchPlannerInfo = {};
 
+// Is HTTPSe enabled, or has it been manually disabled by the user?
+var isExtensionEnabled = true;
+// The setBadgeText API has an abandoned bug: https://crbug.com/170413
+chrome.browserAction.setBadgeText({ text: "" });
+
 // Load prefs about whether http nowhere is on. Structure is:
 //  { httpNowhere: true/false }
 var httpNowhereOn = false;
@@ -177,6 +182,9 @@ var redirectCounter = {};
  * @param details of the handler, see Chrome doc
  * */
 function onBeforeRequest(details) {
+  // If HTTPSe has been disabled by the user, return immediately.
+  if (!isExtensionEnabled) { return; }
+
   var uri = document.createElement('a');
   uri.href = details.url;
 
@@ -459,7 +467,7 @@ function switchPlannerDetailsHtmlSection(tab_id, rewritten) {
  * @param changeInfo Cookie changed info, see Chrome doc
  * */
 function onCookieChanged(changeInfo) {
-  if (!changeInfo.removed && !changeInfo.cookie.secure) {
+  if (!changeInfo.removed && !changeInfo.cookie.secure && isExtensionEnabled) {
     if (all_rules.shouldSecureCookie(changeInfo.cookie, false)) {
       var cookie = {name:changeInfo.cookie.name,
                     value:changeInfo.cookie.value,

--- a/chromium/popup.html
+++ b/chromium/popup.html
@@ -13,6 +13,12 @@
 <header>
   <h1 i18n="about_ext_name"></h1>
 </header>
+<section id="disableButton" class="options">
+  <div class="onoffswitch">
+    <input id="onoffswitch" type="checkbox" checked>
+    <label i18n="menu_globalEnable" for="onoffswitch"></label>
+</div>
+</section>
 <section id="HttpNowhere" class="options">
   <input id="http-nowhere-checkbox" type="checkbox" value="httpNowhere"/>
   <label i18n="menu_blockHttpRequests" for="http-nowhere-checkbox"

--- a/chromium/popup.html
+++ b/chromium/popup.html
@@ -17,12 +17,11 @@
   <div class="onoffswitch">
     <input id="onoffswitch" type="checkbox" checked>
     <label i18n="menu_globalEnable" for="onoffswitch"></label>
-</div>
+  </div>
 </section>
 <section id="HttpNowhere" class="options">
   <input id="http-nowhere-checkbox" type="checkbox" value="httpNowhere"/>
-  <label i18n="menu_blockHttpRequests" for="http-nowhere-checkbox"
-    ></label>
+  <label i18n="menu_blockHttpRequests" for="http-nowhere-checkbox"></label>
 </section>
 <section>
   <a href="#" id="add-rule-link" i18n="menu_add_rule"></a>

--- a/chromium/popup.js
+++ b/chromium/popup.js
@@ -105,7 +105,7 @@ function gotTab(tab) {
 document.addEventListener("DOMContentLoaded", function () {
   stableRules = document.getElementById("StableRules");
   unstableRules = document.getElementById("UnstableRules");
-  chrome.tabs.getSelected(null, gotTab);
+  chrome.tabs.query({ active: true, currentWindow: true }, gotTab);
 
   // Print the extension's current version.
   var the_manifest = chrome.runtime.getManifest();
@@ -150,7 +150,7 @@ function show(elem) {
  * Handles the manual addition of rules
  */
 function addManualRule() {
-  chrome.tabs.getSelected(null, function(tab) {
+  chrome.tabs.query({ active: true, currentWindow: true }, function(tab) {
     hide(e("add-rule-link"));
     show(e("add-new-rule-div"));
     var newUrl = document.createElement('a');

--- a/chromium/popup.js
+++ b/chromium/popup.js
@@ -93,8 +93,8 @@ function toggleEnabledDisabled() {
     backgroundPage.isExtensionEnabled = true;
     chrome.browserAction.setBadgeText({ text: "" });
   }
-   updateEnabledDisabledButtonState();
-  // The extension state changed, to reload this tab.
+  updateEnabledDisabledButtonState();
+  // The extension state changed, so reload this tab.
   chrome.tabs.reload();
 }
 


### PR DESCRIPTION
Allow users to enable/disable HTTPSe from the extension popup itself -- otherwise it's hard to temporarily suspend the extension.

Two notes:
- On Chrome restart, the extension is always enabled
- I tried allowing users to disable HTTPSe per-tab [see commits], but that's a mess — pre-rendered tabs randomly replace current tabs, cookie rules don't understand the concept of a tab, etc.


This looks like:
![screen shot 2015-12-16 at 5 24 12 pm](https://cloud.githubusercontent.com/assets/167135/11856932/ed1336d8-a419-11e5-8c72-fc14cd2ca593.png)
![screen shot 2015-12-16 at 5 24 23 pm](https://cloud.githubusercontent.com/assets/167135/11856934/eff95bde-a419-11e5-800a-cefa2989c924.png)



Closes #760

Signed-off-by: Nick Semenkovich \<semenko@alum.mit.edu\>