### PR TITLE
fix: Don't use broken akamai for Trulia

### DIFF
--- a/src/chrome/content/rules/Trulia-cdn.com.xml
+++ b/src/chrome/content/rules/Trulia-cdn.com.xml
@@ -14,6 +14,6 @@
 
 
 	<rule from="^http://(css|static)\.trulia-cdn\.com/"
-		to="https://a248.e.akamai.net/f/176/831/8m/$1.trulia-cdn.com/" />
+		to="https://$1.trulia-cdn.com/" />
 
 </ruleset>

--- a/src/chrome/content/rules/Trulia-cdn.com.xml
+++ b/src/chrome/content/rules/Trulia-cdn.com.xml
@@ -12,11 +12,8 @@
 
 	<target host="*.trulia-cdn.com" />
 
-	<test url="http://trulia-cdn.com/" />
-	<test url="http://www.trulia-cdn.com/" />
 	<test url="http://css.trulia-cdn.com/" />
 	<test url="http://static.trulia-cdn.com/" />
-	<test url="http://foo.trulia-cdn.com/" />
 
 	<rule from="^http://(css|static)\.trulia-cdn\.com/"
 		to="https://$1.trulia-cdn.com/" />

--- a/src/chrome/content/rules/Trulia-cdn.com.xml
+++ b/src/chrome/content/rules/Trulia-cdn.com.xml
@@ -12,6 +12,11 @@
 
 	<target host="*.trulia-cdn.com" />
 
+	<test url="http://trulia-cdn.com/" />
+	<test url="http://www.trulia-cdn.com/" />
+	<test url="http://css.trulia-cdn.com/" />
+	<test url="http://static.trulia-cdn.com/" />
+	<test url="http://foo.trulia-cdn.com/" />
 
 	<rule from="^http://(css|static)\.trulia-cdn\.com/"
 		to="https://$1.trulia-cdn.com/" />


### PR DESCRIPTION
Use https trulia-cdn.com instead. Fixes #2233 and #3175