### PR TITLE
load FAQ after install only if requested

### DIFF
--- a/src/chrome/content/toolbar_button.js
+++ b/src/chrome/content/toolbar_button.js
@@ -146,11 +146,15 @@ httpsEverywhere.toolbarButton = {
         'https-everywhere',
         'chrome://https-everywhere/skin/https-everywhere-24.png',
         nBox.PRIORITY_WARNING_MEDIUM,
-      [],
-      function(action) {
-        // see https://developer.mozilla.org/en-US/docs/XUL/Method/appendNotification#Notification_box_events
-        gBrowser.selectedTab = gBrowser.addTab(faqURL);
-      });
+        [
+          { accessKey: 'F',
+            callback: function(ntf, btn) {
+                // see https://developer.mozilla.org/en-US/docs/XUL/Method/appendNotification#Notification_box_events
+                gBrowser.selectedTab = gBrowser.addTab(faqURL);
+            },
+            label: 'FAQ…',
+          }
+        ]);
     }
     gBrowser.removeEventListener("DOMContentLoaded", tb.handleShowHint, true);
   },


### PR DESCRIPTION
The first time the browser is started after installing
https-everywhere, a notification bar is shown, informing of
the fact that some https enforcement is active and pointing to the
toolbar button for options.

What is bad about that is that when the notification is dismissed, the
browser is forced to open https://www.eff.org/https-everywhere/faq

This is a privacy breach, as it informs the authors (and user's ISP)
that there is a new installation of https-everywhere.

This change adds a dedicated button to the notification bar.
Pressing that button loads the FAQ page as before, and just dismissing
the notification bar does nothing. In other words, it makes the user
*request* the FAQ before loading it.

Fixes #769.