### PR TITLE
Add rule for podnapisi.net

### DIFF
--- a/src/chrome/content/rules/Podnapisi.xml
+++ b/src/chrome/content/rules/Podnapisi.xml
@@ -1,0 +1,7 @@
+<ruleset name="Podnapisi">
+	<target host="podnapisi.net" />
+	<target host="www.podnapisi.net" />
+	
+	<rule from="^http:" 
+		to="https:" />
+</ruleset>


### PR DESCRIPTION
podnapisi.net is a subtitle website that supports HTTPS, but sadly does not redirect to it, making you connect via unencrypted HTTP whenever you forget to include the 'S' in HTTPS. An HTTPS Everywhere rule would partially remedy this.