### PR TITLE
[Phpdoc] Activate ruleset [DNM]

### DIFF
--- a/src/chrome/content/rules/Phpdoc.org.xml
+++ b/src/chrome/content/rules/Phpdoc.org.xml
@@ -1,11 +1,11 @@
 <!--
 
 -->
-<ruleset name="PhpDocumentor" default_off="expired cert">
+<ruleset name="PhpDocumentor">
     <target host="phpdoc.org" />
     <target host="www.phpdoc.org" />
 
-    <!-- <securecookie host="^(www\.)?phpdoc\.org/$" name=".+" /> -->
+    <securecookie host="^(www\.)?phpdoc\.org" name=".+" />
 	
     <rule from="^http:"
             to="https:" />

--- a/src/chrome/content/rules/Phpdoc.org.xml
+++ b/src/chrome/content/rules/Phpdoc.org.xml
@@ -4,6 +4,9 @@
 <ruleset name="PhpDocumentor">
     <target host="phpdoc.org" />
     <target host="www.phpdoc.org" />
+    <target host="demo.phpdoc.org" />
+    <target host="manual.phpdoc.org" />
+    <target host="pear.phpdoc.org" />
 
     <securecookie host="^(www\.)?phpdoc\.org" name=".+" />
 	

--- a/src/chrome/content/rules/Phpdoc.org.xml
+++ b/src/chrome/content/rules/Phpdoc.org.xml
@@ -7,8 +7,9 @@
     <target host="demo.phpdoc.org" />
     <target host="manual.phpdoc.org" />
     <target host="pear.phpdoc.org" />
+    <target host="qa.phpdoc.org" />
 
-    <securecookie host="^(www\.)?phpdoc\.org" name=".+" />
+    <securecookie host="^(www\.|demo\.|manual\.|pear\.|qa\.)?phpdoc\.org" name=".+" />
 	
     <rule from="^http:"
             to="https:" />


### PR DESCRIPTION
Continuing https://github.com/EFForg/https-everywhere/pull/3184

Preparing ruleset for the change of phpdoc to @letsencrypt [they announced](https://twitter.com/phpDocumentor/status/677591475354476544). You can merge this once they have switched.