### PR TITLE
Add rule for teo.lt

### DIFF
--- a/src/chrome/content/rules/Teo.xml
+++ b/src/chrome/content/rules/Teo.xml
@@ -1,0 +1,7 @@
+<ruleset name="Teo">
+	<target host="teo.lt" />
+	<target host="www.teo.lt" />
+		
+	<rule from="^http:"
+		to="https:" />
+</ruleset>


### PR DESCRIPTION
teo.lt is the website of a Lithuanian ISP that has the same problem as the one described in #3502.