### PR TITLE
Improve the rule for thecthulhu.com

### DIFF
--- a/src/chrome/content/rules/Thecthulhu.com.xml
+++ b/src/chrome/content/rules/Thecthulhu.com.xml
@@ -1,5 +1,5 @@
 <!--
-	Fully covered hosts in *thecthulhu.com:
+	Fully covered hosts in *.thecthulhu.com:
 
 		- (www.)?
 		- atlas
@@ -7,9 +7,15 @@
 		- hacked
 		- tor
 		- whonix
+		- citizenfour
+		- compass
+		- onionoo
+		- tails
+		- sin
+		- am
 
 -->
-<ruleset name="The Cthulhu.com">
+<ruleset name="Thecthulhu.com">
 
 	<!--	Direct rewrites:
 				-->
@@ -20,6 +26,12 @@
 	<target host="tor.thecthulhu.com" />
 	<target host="whonix.thecthulhu.com" />
 	<target host="www.thecthulhu.com" />
+	<target host="citizenfour.thecthulhu.com" />
+	<target host="compass.thecthulhu.com" />
+	<target host="onionoo.thecthulhu.com" />
+	<target host="tails.thecthulhu.com" />
+	<target host="sin.thecthulhu.com" />
+	<target host="am.thecthulhu.com" />
 
 
 	<rule from="^http:"


### PR DESCRIPTION
The rule for thecthulhu.com is missing a few subdomains, some of which do not redirect to HTTPS and therefore are in need of an HTTPS Everywhere rule.

This would also rename the rule to "Thecthulhu.com", since the space that is there is unnecessary.