### PR TITLE
Dreamhost subdomain transferapproval.dreamhost.com does not work over https

### DIFF
--- a/src/chrome/content/rules/DreamHost.xml
+++ b/src/chrome/content/rules/DreamHost.xml
@@ -9,8 +9,9 @@
 
 	Nonfunctional domains:
 
-		- blog.dreamhost.com		(times out)
-		- wiki.dreamhost.com		(refused)
+		- blog.dreamhost.com				(times out)
+		- wiki.dreamhost.com				(refused)
+		- transferapproval.dreamhost.com	(refused)
 		- (www.)dreamhoststatus.com
 
 
@@ -25,7 +26,7 @@
 
 	<target host="dreamhost.com" />
 	<target host="*.dreamhost.com" />
-		<exclusion pattern="^http://(?:blog|wiki)\.dreamhost\.com/" />
+		<exclusion pattern="^http://(?:blog|wiki|transferapproval)\.dreamhost\.com/" />
 		<exclusion pattern="\.crl$" />
 		<exclusion pattern="ocsp\.dreamhost" />
 


### PR DESCRIPTION
I modified the exclusion line with the two existing inclusions to include transferapproval.dreamhost.com

Modified the spacing on the header since this new domain is longer and threw off the tabbing