### PR TITLE
Fix Laravel rules

### DIFF
--- a/src/chrome/content/rules/Laravel.com.xml
+++ b/src/chrome/content/rules/Laravel.com.xml
@@ -1,23 +1,18 @@
 <!--
 	Insecure cookies are set for these hosts:
 
-		- laravel.com
 		- forge.laravel.com
-		- www.laravel.com
 
 -->
 <ruleset name="Laravel.com">
 
 	<!--	Direct rewrites:
 				-->
-	<target host="laravel.com" />
 	<target host="forge.laravel.com" />
-	<target host="www.laravel.com" />
 
 
 	<!--	Not secured by server:
 					-->
-	<!--securecookie host="^(?:www\.)?laravel\.com$" name="^laravel_session$" /-->
 	<!--securecookie host="^forge\.laravel\.com$" name="^(?:XSRF-TOKEN|[\da-f]{32}|laravel_session)$" /-->
 
 	<securecookie host="." name="." />


### PR DESCRIPTION
`laravel.com` and `www.laravel.com` do not support HTTPS ([source](https://twitter.com/taylorotwell/status/678975762154676224)). This ruleset is listed as "stable" which is kind of annoying.

`forge.laravel.com` does use HTTPS.