### PR TITLE
Revert "reflect certificate changes on fefe.de"

### DIFF
--- a/src/chrome/content/rules/Fefe.xml
+++ b/src/chrome/content/rules/Fefe.xml
@@ -1,8 +1,29 @@
 <!--
+	Nonfunctional hosts in *fefe.de:
+
+		- bulk *
+
+	* Shows ptrace.fefe.de
+
+
+	Problematic hosts in *fefe.de:
+
+		- blog *
+		- cvs *
+		- dl *
+		- a.mx *
+		- ptrace *
+		- www *
+
+	* Server sends no certificate chain, see https://whatsmychaincert.com
+
+
 	Fully covered hosts in *fefe.de:
 
 		- blog
+		- cvs
 		- dl
+		- a.mx
 		- ptrace
 		- www
 
@@ -10,15 +31,18 @@
 	^fefe.de doesn't exist.
 
 -->
-<ruleset name="fefe.de">
+<ruleset name="Fefe.de (partial)" platform="cacert" default_off="missing certificate chain">
 
 	<!--	Direct rewrites:
 				-->
-	<target host="blog.fefe.de" />
+  <target host="blog.fefe.de" />
+	<target host="cvs.fefe.de" />
 	<target host="dl.fefe.de" />
+	<target host="a.mx.fefe.de" />
 	<target host="ptrace.fefe.de" />
 	<target host="www.fefe.de" />
 
 	<rule from="^http:"
 		to="https:" />
 </ruleset>
+


### PR DESCRIPTION
On stable, instead of master.

We should really clean up our mess of branches & tags, and make this a bit clearer for new contributors.

Reverts EFForg/https-everywhere#3581