### PR TITLE
Add rule for tickets.gwr.com

### DIFF
--- a/src/chrome/content/rules/Tickets.gwr.com.xml
+++ b/src/chrome/content/rules/Tickets.gwr.com.xml
@@ -1,5 +1,7 @@
 <ruleset name="Tickets.gwr.com">
 	<target host="tickets.gwr.com" />
 
+	<test url="http://tickets.gwr.com/" />
+
 	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Tickets.gwr.com.xml
+++ b/src/chrome/content/rules/Tickets.gwr.com.xml
@@ -1,0 +1,5 @@
+<ruleset name="Tickets.gwr.com">
+	<target host="tickets.gwr.com" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>


### PR DESCRIPTION
tickets.gwr.com uses http (despite seemingly supporting https with no issues) whilst all other subdomains of gwr.com use https.