### PR TITLE
fix Nvidia shield subdomain

### DIFF
--- a/src/chrome/content/rules/NVidia.xml
+++ b/src/chrome/content/rules/NVidia.xml
@@ -190,16 +190,6 @@
 			<test url="http://store.nvidia.com/DRHM/servlet/SecureControllerServlet?Action=DisplayHomePage&amp;SiteID=nvidia&amp;locale=en_US" />
 			<test url="http://store.nvidia.com/sstore?Action=DisplayHomePage&amp;SiteID=nvidia&amp;locale=en_US" />
 
-		<test url="http://shield.nvidia.com/android-tv" />
-		<test url="http://shield.nvidia.com/blog" />
-		<test url="http://shield.nvidia.com/newsletter" />
-		<test url="http://shield.nvidia.com/store" />
-		<test url="http://shield.nvidia.com/store/portable" />
-		<test url="http://shield.nvidia.com/tablet" />
-		<test url="http://shield.nvidia.com/profiles/made2game/themes/m2g_bootstrap_subtheme/images/logo-white.svg" />
-		<test url="http://shield.nvidia.com/profiles/made2game/themes/m2g_bootstrap_subtheme/images/refresh.png" />
-
-
 	<!--	Not secured by server:
 					-->
 	<!--securecookie host="^\.nvidia\.com$" name="^(?:incap_ses_\d+_\d+|idm-\d+|s_\w+|visid_incap_\d+)$" /-->
@@ -225,7 +215,7 @@
 		<test url="http://careers.nvidia.com/?" />
 		<test url="http://careers.nvidia.com//" />
 
-	<rule from="^http://(http\.developer|(?:developer|international|us)\.download|shield)\.nvidia\.com/"
+	<rule from="^http://(http\.developer|(?:developer|international|us)\.download)\.nvidia\.com/"
 		to="https://a248.e.akamai.net/f/248/10/10/$1.nvidia.com/" />
 
 	<rule from="^http://forums\.nvidia\.com/"


### PR DESCRIPTION
- remove shield subdomain from the akamai redirect list
- remove shield test urls