### PR TITLE
[Calendars] Fix typo

### DIFF
--- a/src/chrome/content/rules/Calendars.com.xml
+++ b/src/chrome/content/rules/Calendars.com.xml
@@ -14,6 +14,6 @@
 
 
 	<rule from="^http://(www\.)?calendars\.com/(css/|img/|user)"
-		to="https://$1calendars.com/$1" />
+		to="https://$1calendars.com/$2" />
 
 </ruleset>

--- a/src/chrome/content/rules/Calendars.com.xml
+++ b/src/chrome/content/rules/Calendars.com.xml
@@ -16,4 +16,9 @@
 	<rule from="^http://(www\.)?calendars\.com/(css/|img/|user)"
 		to="https://$1calendars.com/$2" />
 
+
+	<test url="http://calendars.com/css/common.css" />
+	<test url="http://www.calendars.com/img/common/calendarsLogo.gif" />
+	<test url="http://www.calendars.com/user/login.jsp" />
+
 </ruleset>


### PR DESCRIPTION
This fixes a typo in a rule which broke most site resources. In particular, this fixes https://github.com/EFForg/https-everywhere/issues/3523.