### PR TITLE
[Tisarana.ca] Change to Mixedcontent

### DIFF
--- a/src/chrome/content/rules/Tisarana.ca.xml
+++ b/src/chrome/content/rules/Tisarana.ca.xml
@@ -1,4 +1,4 @@
-<ruleset name="Tisarana Buddhist Monastery">
+<ruleset name="Tisarana Buddhist Monastery" platform="mixedcontent">
     <target host="tisarana.ca" />
     <target host="www.tisarana.ca" />
 


### PR DESCRIPTION
Site has new content that causes this ruleset to trigger active mixed content blocking, which breaks parts of the site. Changing to `platform=mixedcontent` to fix it.