### PR TITLE
Update Blendle ruleset

### DIFF
--- a/src/chrome/content/rules/Blendle.xml
+++ b/src/chrome/content/rules/Blendle.xml
@@ -14,11 +14,6 @@
   <test url="http://widgets.blendle.nl/" />
   <test url="http://ws.blendle.nl/" />
 
-  <!-- Tumblr blog is the only service reachable over plaintext HTTP -->
-  <exclusion pattern="^http://blog.blendle\.nl/" />
-
-  <test url="http://blog.blendle.nl/" />
-
   <securecookie host="^\.?blendle\.com$" name=".+" />
 
   <rule from="^http:" to="https:" />


### PR DESCRIPTION
Both blendle.nl and blendle.com are now HTTPS-only. The exclusion for `blog.blendle.nl` is no longer necessary.