### PR TITLE
Fix standalone chromium profile runner in Debian

### DIFF
--- a/test/chromium.sh
+++ b/test/chromium.sh
@@ -21,7 +21,13 @@ if [ "$1" == "--justrun" ]; then
 
 	PROFILE_DIRECTORY="$(mktemp -d)"
 	trap 'rm -r "$PROFILE_DIRECTORY"' EXIT
-	chromium-browser \
+	
+	# Chromium package name is 'chromium' in Debian 7 (wheezy) and later
+	BROWSER="chromium-browser"
+	if [[ "$(lsb_release -is)" == "Debian" ]]; then
+	  BROWSER="chromium"
+	fi
+	$BROWSER \
 		--user-data-dir="$PROFILE_DIRECTORY" \
 		--load-extension=pkg/crx/
 else


### PR DESCRIPTION
Fixes `bash test/chromium.sh --justrun` on Debian systems, where the chromium package is named differently than on Ubuntu.

The package name logic is copied from the existing `install-dev-dependencies.sh` script: https://github.com/EFForg/https-everywhere/blob/5effa1541a5a8dd9299a9a7820cec2a6a8052655/install-dev-dependencies.sh#L8