### PR TITLE
Add a few rules

### DIFF
--- a/src/chrome/content/rules/La_Naya_Chocolate.xml
+++ b/src/chrome/content/rules/La_Naya_Chocolate.xml
@@ -1,0 +1,7 @@
+<ruleset name="La Naya Chocolate">
+	<target host="lanayachocolate.com" />
+	<target host="www.lanayachocolate.com" />
+	
+	<rule from="^http:"
+		to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/TorrentButler.xml
+++ b/src/chrome/content/rules/TorrentButler.xml
@@ -1,0 +1,7 @@
+<ruleset name="TorrentButler">
+	<target host="torrentbutler.eu" />
+	<target host="www.torrentbutler.eu" />
+	
+	<rule from="^http:"
+		to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/Zimperium.xml
+++ b/src/chrome/content/rules/Zimperium.xml
@@ -1,0 +1,8 @@
+<ruleset name="Zimperium">
+	<target host="zimperium.com" />
+	<target host="www.zimperium.com" />
+	<target host="blog.zimperium.com" />
+	
+	<rule from="^http:"
+		to="https:" />
+</ruleset>


### PR DESCRIPTION
zimperium.com is a website that supports but fails to redirect to HTTPS and therefore is in need of an HTTPS Everywhere rule.