### PR TITLE
Create new rules, fix two issues and tweak Serveriai.lt.xml

### DIFF
--- a/src/chrome/content/rules/Dedikuoti.lt.xml
+++ b/src/chrome/content/rules/Dedikuoti.lt.xml
@@ -1,0 +1,7 @@
+<ruleset name="Dedikuoti.lt">
+	<target host="dedikuoti.lt" />
+	<target host="www.dedikuoti.lt" />
+	
+	<rule from="^http:"
+			to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/Dedikuoti.lt.xml
+++ b/src/chrome/content/rules/Dedikuoti.lt.xml
@@ -3,5 +3,5 @@
 	<target host="www.dedikuoti.lt" />
 	
 	<rule from="^http:"
-			to="https:" />
+		to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Dizaineriai.lt.xml
+++ b/src/chrome/content/rules/Dizaineriai.lt.xml
@@ -3,5 +3,5 @@
 	<target host="www.dizaineriai.lt" />
 	
 	<rule from="^http:"
-			to="https:" />
+		to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Dizaineriai.lt.xml
+++ b/src/chrome/content/rules/Dizaineriai.lt.xml
@@ -1,0 +1,7 @@
+<ruleset name="Dizaineriai.lt">
+	<target host="dizaineriai.lt" />
+	<target host="www.dizaineriai.lt" />
+	
+	<rule from="^http:"
+			to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/Jodel-app.com.xml
+++ b/src/chrome/content/rules/Jodel-app.com.xml
@@ -6,7 +6,7 @@
 	* Unsecurable <= refused`
 
 -->
-<ruleset name="Jodel-app.com">
+<ruleset name="Jodel-app.com" default_off="expired certificate">
 
 	<!--	Direct rewrites:
 				-->

--- a/src/chrome/content/rules/Serveriai.lt.xml
+++ b/src/chrome/content/rules/Serveriai.lt.xml
@@ -1,10 +1,11 @@
 <ruleset name="serveriai.lt">
 
 	<target host="serveriai.lt" />
-	<target host="*.serveriai.lt" />
+	<target host="www.serveriai.lt" />
+	<target host="whois.serveriai.lt" />
 
 
-	<rule from="^http://(whois\.|www\.)?serveriai\.lt/"
-		to="https://$1serveriai.lt/" />
+	<rule from="^http:"
+			to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Serveriai.lt.xml
+++ b/src/chrome/content/rules/Serveriai.lt.xml
@@ -6,6 +6,6 @@
 
 
 	<rule from="^http:"
-			to="https:" />
+		to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Uneddit.xml
+++ b/src/chrome/content/rules/Uneddit.xml
@@ -3,5 +3,5 @@
 	<target host="www.uneddit.com" />
 	
 	<rule from="^http:"
-			to="https:" />
+		to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Uneddit.xml
+++ b/src/chrome/content/rules/Uneddit.xml
@@ -1,0 +1,7 @@
+<ruleset name="Uneddit">
+	<target host="uneddit.com" />
+	<target host="www.uneddit.com" />
+	
+	<rule from="^http:"
+			to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/irc.lc.xml
+++ b/src/chrome/content/rules/irc.lc.xml
@@ -1,0 +1,6 @@
+<ruleset name="irc.lc" >
+	<target host="irc.lc" />
+	
+	<rule from="http:"
+		to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/irc.lc.xml
+++ b/src/chrome/content/rules/irc.lc.xml
@@ -1,6 +1,6 @@
 <ruleset name="irc.lc" >
 	<target host="irc.lc" />
 	
-	<rule from="http:"
+	<rule from="^http:"
 		to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/pro.hostingas.lt.xml
+++ b/src/chrome/content/rules/pro.hostingas.lt.xml
@@ -2,5 +2,5 @@
 	<target host="pro.hostingas.lt" />
 	
 	<rule from="^http:"
-			to="https:" />
+		to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/pro.hostingas.lt.xml
+++ b/src/chrome/content/rules/pro.hostingas.lt.xml
@@ -1,0 +1,6 @@
+<ruleset name="pro.hostingas.lt">
+	<target host="pro.hostingas.lt" />
+	
+	<rule from="^http:"
+			to="https:" />
+</ruleset>


### PR DESCRIPTION
Here are 5 more websites that fail to redirect to HTTPS, despite supporting it. This also tweaks [Serveriai.lt.xml](https://github.com/EFForg/https-everywhere/blob/master/src/chrome/content/rules/Serveriai.lt.xml) to remove the unnecessary wildcard and disables [Jodel-app.com.xml](https://github.com/EFForg/https-everywhere/blob/master/src/chrome/content/rules/Jodel-app.com.xml) because the website's certificate has expired.