### PR TITLE
Disable Jodel-app.com.xml

### DIFF
--- a/src/chrome/content/rules/Jodel-app.com.xml
+++ b/src/chrome/content/rules/Jodel-app.com.xml
@@ -6,7 +6,7 @@
 	* Unsecurable <= refused`
 
 -->
-<ruleset name="Jodel-app.com">
+<ruleset name="Jodel-app.com" default_off="expired certificate">
 
 	<!--	Direct rewrites:
 				-->


### PR DESCRIPTION
Per the request to split #3805 into separate PRs for each of the rulesets, here's the PR for disabling [Jodel-app.com.xml](https://github.com/EFForg/https-everywhere/blob/master/src/chrome/content/rules/Jodel-app.com.xml) because its certificate has expired.