### PR TITLE
[vimeo.com] Re-enable ruleset

### DIFF
--- a/src/chrome/content/rules/Vimeo.xml
+++ b/src/chrome/content/rules/Vimeo.xml
@@ -6,53 +6,33 @@
 
 	CDN buckets:
 
-		- av.vimeo.com.edgesuite.net
-
-			- a808.g.akamai.net
-
-		- pdl.vimeocdn.com.edgesuite.net
-
-			- a1189.g.akamai.net
-
-
-	Problematic subdomains:
-
-		- av	(pdl.../crossdomain.xml restricts to port 80)
-		- pdl	(works, akamai)
-
-
-	Partially covered subdomains:
-
-		- developer	(some pages redirect to http)
+		- fastly.net
 
 
 	Fully covered subdomains:
+		- vimeo.com
+			- (www.)
+			- developer
+			- player
+			- secure
 
-		- (www.)
-		- secure
+		- vimeocdn.com
+			- i
+			- f
 
-	
+
 	Insecure cookies are set for these hosts:
 
 		- vimeo.com
 		- www.vimeo.com
 
 
-Default off per https://trac.torproject.org/projects/tor/ticket/7569 -->
-<ruleset name="Vimeo (default off)" default_off="breaks some video embedding">
+-->
+<ruleset name="Vimeo">
 
 	<target host="vimeo.com" />
 	<target host="*.vimeo.com" />
-		<!--exclusion pattern="^http://developer\.vimeo\.com/($|\?|(apps|guidelines|help|player)($|[?/]))" /-->
-		<exclusion pattern="^http://developer\.vimeo\.com/(?!apis(?:$|[?/])|favicon\.ico)" />
 	<target host="*.vimeocdn.com" />
-		<!--
-			Uses crossdomain.xml from s3.amazonaws.com, which sets secure="false"
-
-				https://mail1.eff.org/pipermail/https-everywhere/2012-October/001583.html
-			-->
-		<exclusion pattern="^http://a\.vimeocdn\.com/p/flash/moogaloop/" />
-
 
 	<!--	Not secured by server:
 					-->
@@ -63,15 +43,8 @@ Default off per https://trac.torproject.org/projects/tor/ticket/7569 -->
 	<securecookie host="^\.(?:player\.)?vimeo\.com$" name="^__utm\w$" />
 
 
-	<rule from="^http://((?:developer|player|secure|www)\.)?vimeo\.com/"
-		to="https://$1vimeo.com/" />
-
-	<!--	a & b: Akamai	-->
-	<rule from="^http://(?:secure-)?([ab])\.vimeocdn\.com/"
-		to="https://secure-$1.vimeocdn.com/" />
-
-	<rule from="^http://i\.vimeocdn\.com/"
-		to="https://i.vimeocdn.com/" />
+	<rule from="^http:"
+		to="https:" />
 
 </ruleset>
 


### PR DESCRIPTION
Vimeo now supports HSTS (including subdomains). Still no secure cookie though.