### PR TITLE
[Filepicker.io] Rename ruleset, add new domains.

### DIFF
--- a/src/chrome/content/rules/Filepicker.io.xml
+++ b/src/chrome/content/rules/Filepicker.io.xml
@@ -1,25 +1,23 @@
-<!--
-	Insecure cookies are set for these domains:
-
-		- .filepicker.io
-		- .www.filepicker.io
-
--->
-<ruleset name="Filepicker.io">
+<ruleset name="Filestack">
 
 	<!--	Direct rewrites:
 				-->
-	<target host="filepicker.io" />
+	<target host=           "filestack.com" />
+	<target host=      "blog.filestack.com" />
+	<target host=       "dev.filestack.com" />
+	<target host=       "www.filestack.com" />
+	<target host=    "assets.filestackapi.com" />
+	<target host=           "filepicker.com" />
+	<target host="developers.filepicker.com" />
+	<target host=       "www.filepicker.com" />
+	<target host=           "filepicker.io" />
+	<target host=       "cdn.filepicker.io" />
 	<target host="developers.filepicker.io" />
-	<target host="www.filepicker.io" />
+	<target host=    "dialog.filepicker.io" />
+	<target host= "providers.filepicker.io" />
+	<target host=       "www.filepicker.io" />
 
-
-	<!--	Not secured by server:
-					-->
-	<!--securecookie host="^\.(?:www\.)?filepicker\.io$" name="^session$" /-->
-
-	<securecookie host="." name="." />
-
+	<securecookie host="^.*\.?filestack\.com$" name="^.+" />
 
 	<rule from="^http:"
 		to="https:" />


### PR DESCRIPTION
Filepicker has been re-branded to Filestack. Rename ruleset but not filename (to retain history).