### PR TITLE
Update Overleaf.com.xml

### DIFF
--- a/src/chrome/content/rules/Overleaf.com.xml
+++ b/src/chrome/content/rules/Overleaf.com.xml
@@ -1,19 +1,18 @@
 <!--
 	STS header includes includeSubDomains.
-
 -->
 <ruleset name="Overleaf.com">
 
-	<!--	Direct rewrites:
-				-->
+	<!-- Direct rewrites: -->
 	<target host="overleaf.com" />
 	<target host="*.overleaf.com" />
+	
+	<exclusion pattern="^http://email\.overleaf\.com/" />
 
-		<test url="http://www.overleaf.com/" />
-
+	<test url="http://www.overleaf.com/" />
+	<test url="http://email.overleaf.com/" />
 
 	<securecookie host="." name="." />
-
 
 	<rule from="^http:"
 		to="https:" />


### PR DESCRIPTION
email.overleaf.com has an invalid SSL certificate (wrong domain name)

I hope this PR meets style guidelines.