### PR TITLE
Remove dropdown triangle from toolbar button.

### DIFF
--- a/src/chrome/skin/https-everywhere.css
+++ b/src/chrome/skin/https-everywhere.css
@@ -6,6 +6,10 @@
   list-style-image: url("chrome://https-everywhere/skin/https-everywhere-24.png");
 }
 
+#https-everywhere-button dropmarker {
+  display: none;
+}
+
 toolbar[iconsize="small"] #https-everywhere-button > .https-everywhere-button {
   list-style-image: url("chrome://https-everywhere/skin/https-everywhere-16.png");
 }


### PR DESCRIPTION
It's unnecessary and incongruous with other modern addons.

cc @SwartzCr @cooperq for review.

Fixes #1697