### PR TITLE
Add rule for piquadro.com

### DIFF
--- a/src/chrome/content/rules/Piquadro.xml
+++ b/src/chrome/content/rules/Piquadro.xml
@@ -2,6 +2,14 @@
 	<target host="piquadro.com" />
 	<target host="www.piquadro.com" />
 	
+	<!---
+		Unsupported subdomains:
+		
+		* corporategift.piquadro.com - mismatch
+		* cdnlevel3.piquadro.com - timeout
+		
+	--->
+	
 	<rule from="^http:"
 		to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Piquadro.xml
+++ b/src/chrome/content/rules/Piquadro.xml
@@ -1,14 +1,14 @@
+<!--
+	Unsupported subdomains:
+	
+	* corporategift.piquadro.com - mismatch
+	* cdnlevel3.piquadro.com - timeout
+	
+-->
+	
 <ruleset name="Piquadro">
 	<target host="piquadro.com" />
 	<target host="www.piquadro.com" />
-	
-	<!--
-		Unsupported subdomains:
-		
-		* corporategift.piquadro.com - mismatch
-		* cdnlevel3.piquadro.com - timeout
-		
-	-->
 	
 	<rule from="^http:"
 		to="https:" />

--- a/src/chrome/content/rules/Piquadro.xml
+++ b/src/chrome/content/rules/Piquadro.xml
@@ -1,0 +1,7 @@
+<ruleset name="Piquadro">
+	<target host="piquadro.com" />
+	<target host="www.piquadro.com" />
+	
+	<rule from="^http:"
+		to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/Piquadro.xml
+++ b/src/chrome/content/rules/Piquadro.xml
@@ -6,7 +6,7 @@
 	
 -->
 	
-<ruleset name="Piquadro">
+<ruleset name="Piquadro" default_off="breaks images">
 	<target host="piquadro.com" />
 	<target host="www.piquadro.com" />
 	

--- a/src/chrome/content/rules/Piquadro.xml
+++ b/src/chrome/content/rules/Piquadro.xml
@@ -2,13 +2,13 @@
 	<target host="piquadro.com" />
 	<target host="www.piquadro.com" />
 	
-	<!---
+	<!--
 		Unsupported subdomains:
 		
 		* corporategift.piquadro.com - mismatch
 		* cdnlevel3.piquadro.com - timeout
 		
-	--->
+	-->
 	
 	<rule from="^http:"
 		to="https:" />


### PR DESCRIPTION
[Piquadro.com](https://piquadro.com) fails to redirect to HTTPS despite supporting it.