### PR TITLE
Add a few strings for localisation in the 'about' window

### DIFF
--- a/src/chrome/content/about.xul
+++ b/src/chrome/content/about.xul
@@ -43,17 +43,17 @@
     
     <groupbox>
       <caption label="&https-everywhere.about.created_by;" />
-      <label>Mike Perry, Peter Eckersley, and Yan Zhu</label>
+      <label>Mike Perry, Peter Eckersley&https-everywhere.about.and; Yan Zhu</label>
     </groupbox>
     
     <groupbox>
       <caption label="&https-everywhere.about.librarians;" />
-      <label>J0WI, MB, Nick Semenkovich, Sam Reed, and Søren Fuglede Jørgensen</label>
+      <label>J0WI, MB, Nick Semenkovich, Sam Reed&https-everywhere.about.and; Søren Fuglede Jørgensen</label>
     </groupbox>
 
     <groupbox>
       <caption label="&https-everywhere.about.thanks;" />
-      <label>Many many contributors, including Aaron Swartz, Alec Moskvin,
+      <label>&https-everywhere.about.many_contributors; Aaron Swartz, Alec Moskvin,
       Aleksey Kosterin, Alex Xu, Anas Qtiesh, Andreas Jonsson, Artyom Gavrichenkov, Brian
       Carpenter, Chris Palmer, Christian Inci, Christopher Liu, Claudio
       Moretti, Colonel Graff, Dan Auerbach, Daniel Kahn Gillmor, dm0, The
@@ -64,9 +64,7 @@
       nitrox, Pablo Castellano, Paul Wise, Pavel Kazakov, Phol Paucar, Richard
       Green, Roan Kattouw, Rules Moore, Seth Schoen, Stefan Tomanek, Sam Reed, Steve
       Milner, Sujit Rao, TK-999, Vendo, Victor Garin, Weiland Hoffmann, Whizz
-      Mo and Yan Zhu.  Also, portions of HTTPS Everywhere are based on code
-      from NoScript, by Giorgio Maone and others.  We are grateful for their
-      excellent work!</label>
+      Mo and Yan Zhu. &https-everywhere.about.noscript;</label>
     </groupbox>
   </vbox>
 </dialog>

--- a/src/chrome/locale/en/https-everywhere.dtd
+++ b/src/chrome/locale/en/https-everywhere.dtd
@@ -3,8 +3,11 @@
 <!ENTITY https-everywhere.about.ext_description "Encrypt the Web! Automatically use HTTPS security on many sites.">
 <!ENTITY https-everywhere.about.version "Version">
 <!ENTITY https-everywhere.about.created_by "Created by">
+<!ENTITY https-everywhere.about.and ", and">
 <!ENTITY https-everywhere.about.librarians "Ruleset Librarians">
 <!ENTITY https-everywhere.about.thanks "Thanks to">
+<!ENTITY https-everywhere.about.many_contributors "Many many contributors, including">
+<!ENTITY https-everywhere.about.noscript "Also, portions of HTTPS Everywhere are based on code from NoScript, by Giorgio Maone and others.  We are grateful for their excellent work!">
 <!ENTITY https-everywhere.about.contribute  "If you like HTTPS Everywhere, you might consider">
 <!ENTITY https-everywhere.about.donate_tor "Donating to Tor">
 <!ENTITY https-everywhere.about.tor_lang_code "en">


### PR DESCRIPTION
This changes a few hardcoded strings so as to allow for localisation. ~~Obviously the way this is done is not ideal, though, as translations are handled through a torproject.org based git submodule. The corresponding changes to this, which in turn is based on Transifex in a way that I do not remember, would be of the same form as those in https://github.com/fuglede/torproject_translation/commit/67875f8bf227798d8b46b77a4f6557e70cd365c3 which contains the changes to the English and Danish language strings. Cc @jsha for review/lesson on what I should have actually done ...~~

Scratch that; I remembered the logic.