### PR TITLE
Memory usage improvements

### DIFF
--- a/chromium/rules.js
+++ b/chromium/rules.js
@@ -47,7 +47,7 @@ function CookieRule(host, cookiename) {
 function RuleSet(set_name, default_state, note) {
   this.name = set_name;
   this.rules = [];
-  this.exclusions = [];
+  this.exclusions = null;
   this.cookierules = null;
   this.active = default_state;
   this.default_state = default_state;
@@ -63,10 +63,12 @@ RuleSet.prototype = {
   apply: function(urispec) {
     var returl = null;
     // If we're covered by an exclusion, go home
-    for(var i = 0; i < this.exclusions.length; ++i) {
-      if (this.exclusions[i].pattern_c.test(urispec)) {
-        log(DBUG,"excluded uri " + urispec);
-        return null;
+    if (this.exclusions !== null) {
+      for (var i = 0; i < this.exclusions.length; ++i) {
+        if (this.exclusions[i].pattern_c.test(urispec)) {
+          log(DBUG, "excluded uri " + urispec);
+          return null;
+        }
       }
     }
 
@@ -200,17 +202,21 @@ RuleSets.prototype = {
     }
 
     var exclusions = ruletag.getElementsByTagName("exclusion");
-    for(var j = 0; j < exclusions.length; j++) {
-      rule_set.exclusions.push(
+    if (exclusions.length > 0) {
+      rule_set.exclusions = [];
+      for (var j = 0; j < exclusions.length; j++) {
+        rule_set.exclusions.push(
             new Exclusion(exclusions[j].getAttribute("pattern")));
+      }
     }
 
     var cookierules = ruletag.getElementsByTagName("securecookie");
     if (cookierules.length > 0) {
       rule_set.cookierules = [];
       for(var j = 0; j < cookierules.length; j++) {
-        rule_set.cookierules.push(new CookieRule(cookierules[j].getAttribute("host"),
-                                             cookierules[j].getAttribute("name")));
+        rule_set.cookierules.push(
+            new CookieRule(cookierules[j].getAttribute("host"),
+                cookierules[j].getAttribute("name")));
       }
     }
 

--- a/chromium/rules.js
+++ b/chromium/rules.js
@@ -48,7 +48,6 @@ function RuleSet(set_name, default_state, note) {
   this.name = set_name;
   this.rules = [];
   this.exclusions = [];
-  this.targets = [];
   this.cookierules = [];
   this.active = default_state;
   this.default_state = default_state;

--- a/chromium/rules.js
+++ b/chromium/rules.js
@@ -48,7 +48,7 @@ function RuleSet(set_name, default_state, note) {
   this.name = set_name;
   this.rules = [];
   this.exclusions = [];
-  this.cookierules = [];
+  this.cookierules = null;
   this.active = default_state;
   this.default_state = default_state;
   this.note = note;
@@ -206,9 +206,12 @@ RuleSets.prototype = {
     }
 
     var cookierules = ruletag.getElementsByTagName("securecookie");
-    for(var j = 0; j < cookierules.length; j++) {
-      rule_set.cookierules.push(new CookieRule(cookierules[j].getAttribute("host"),
-                                           cookierules[j].getAttribute("name")));
+    if (cookierules.length > 0) {
+      rule_set.cookierules = [];
+      for(var j = 0; j < cookierules.length; j++) {
+        rule_set.cookierules.push(new CookieRule(cookierules[j].getAttribute("host"),
+                                             cookierules[j].getAttribute("name")));
+      }
     }
 
     var targets = ruletag.getElementsByTagName("target");
@@ -301,7 +304,7 @@ RuleSets.prototype = {
     var rs = this.potentiallyApplicableRulesets(hostname);
     for (var i = 0; i < rs.length; ++i) {
       var ruleset = rs[i];
-      if (ruleset.active) {
+      if (ruleset.cookierules !== null && ruleset.active) {
         for (var j = 0; j < ruleset.cookierules.length; j++) {
           var cr = ruleset.cookierules[j];
           if (cr.host_c.test(cookie.domain) && cr.name_c.test(cookie.name)) {


### PR DESCRIPTION
(For #1775 & inspired by @blockoperation's awesome work in https://github.com/blockoperation/https-everywhere/tree/chromium-memory-usage-v2 )

Don't create rule arrays when unneeded.