### PR TITLE
Disable rule for earwolf.com (expired cert)

### DIFF
--- a/src/chrome/content/rules/Earwolf_Podcast_Network.xml
+++ b/src/chrome/content/rules/Earwolf_Podcast_Network.xml
@@ -30,7 +30,7 @@
 	* Secured by us
 
 -->
-<ruleset name="Earwolf Podcast Network">
+<ruleset name="Earwolf Podcast Network" default_off="expired cert">
 
 	<target host="earwolf.com" />
 	<target host="*.earwolf.com" />


### PR DESCRIPTION
The certificate for earwolf.com is *long* expired.