### PR TITLE
Add rule for openmpt.org. Fixes #3900

### DIFF
--- a/src/chrome/content/rules/OpenMPT.xml
+++ b/src/chrome/content/rules/OpenMPT.xml
@@ -1,0 +1,21 @@
+<ruleset name="OpenMPT">
+	<target host="openmpt.org" />
+	<target host="www.openmpt.org" />
+	<target host="bugs.openmpt.org" />
+	<target host="buildbot.openmpt.org" />
+	<target host="download.openmpt.org" />
+	<target host="forum.openmpt.org" />
+	<target host="lib.openmpt.org" />
+	<target host="resources.openmpt.org" />
+	<target host="source.openmpt.org" />
+	<target host="wiki.openmpt.org" />
+	<target host="wikide.openmpt.org" />
+	<target host="update.openmpt.org" />
+	
+	<rule from="^http://(www\.)?openmpt\.org/"
+		to="https://openmpt.org/" />
+		
+	<rule from="^http:"
+		to="https:" />
+		
+</ruleset>


### PR DESCRIPTION
Neither openmpt.org nor any of its subdomains redirect to HTTPS, despite supporting it.

This fixes #3900.