### PR TITLE
[Nodes.dk] New ruleset

### DIFF
--- a/src/chrome/content/rules/Nodes.dk.xml
+++ b/src/chrome/content/rules/Nodes.dk.xml
@@ -1,0 +1,9 @@
+<ruleset name="Nodes.dk">
+
+	<target host="nodes.dk" />
+	<target host="www.nodes.dk" />
+
+	<rule from="^http:"
+		to="https:" />
+
+</ruleset>


### PR DESCRIPTION
The site specifies a HSTS header but does not redirect to HTTPS on its own.