### PR TITLE
Regexp reduction for trivial rules + cookie names

### DIFF
--- a/chromium/background.js
+++ b/chromium/background.js
@@ -469,7 +469,7 @@ function switchPlannerDetailsHtmlSection(tab_id, rewritten) {
  * */
 function onCookieChanged(changeInfo) {
   if (!changeInfo.removed && !changeInfo.cookie.secure && isExtensionEnabled) {
-    if (all_rules.shouldSecureCookie(changeInfo.cookie, false)) {
+    if (all_rules.shouldSecureCookie(changeInfo.cookie)) {
       var cookie = {name:changeInfo.cookie.name,
                     value:changeInfo.cookie.value,
                     path:changeInfo.cookie.path,

--- a/chromium/rules.js
+++ b/chromium/rules.js
@@ -284,18 +284,17 @@ RuleSets.prototype = {
 
   /**
    * Check to see if the Cookie object c meets any of our cookierule criteria for being marked as secure.
-   * knownHttps is true if the context for this cookie being set is known to be https.
    * @param cookie The cookie to test
-   * @param knownHttps Is the context for setting this cookie is https ?
    * @returns {*} ruleset or null
    */
-  shouldSecureCookie: function(cookie, knownHttps) {
+  shouldSecureCookie: function(cookie) {
     var hostname = cookie.domain;
     // cookie domain scopes can start with .
-    while (hostname.charAt(0) == ".")
+    while (hostname.charAt(0) == ".") {
       hostname = hostname.slice(1);
+    }
 
-    if (!knownHttps && !this.safeToSecureCookie(hostname)) {
+    if (!this.safeToSecureCookie(hostname)) {
         return null;
     }
 

--- a/chromium/rules.js
+++ b/chromium/rules.js
@@ -30,9 +30,7 @@ function Exclusion(pattern) {
  * @constructor
  */
 function CookieRule(host, cookiename) {
-  this.host = host;
   this.host_c = new RegExp(host);
-  this.name = cookiename;
   this.name_c = new RegExp(cookiename);
 }
 

--- a/chromium/rules.js
+++ b/chromium/rules.js
@@ -31,7 +31,12 @@ function Exclusion(pattern) {
  */
 function CookieRule(host, cookiename) {
   this.host_c = new RegExp(host);
-  this.name_c = new RegExp(cookiename);
+
+  this.name_c = null;  // A null name_c matches all cookie names.
+  if (cookiename !== ".*" && cookiename !== ".+") {
+    // About 50% of cookie rules a more complex regex rule.
+    this.name_c = new RegExp(cookiename);
+  }
 }
 
 /**
@@ -300,7 +305,7 @@ RuleSets.prototype = {
       if (ruleset.cookierules !== null && ruleset.active) {
         for (var j = 0; j < ruleset.cookierules.length; j++) {
           var cr = ruleset.cookierules[j];
-          if (cr.host_c.test(cookie.domain) && cr.name_c.test(cookie.name)) {
+          if (cr.host_c.test(cookie.domain) && (cr.name_c === null || cr.name_c.test(cookie.name))) {
             return ruleset;
           }
         }


### PR DESCRIPTION
Performance & memory usage improvements (for #1775), inspired in part by @blockoperation's suggestions.

- For trivial rules (`^http: -> https:`), set the Rules values equal to null (and handle null as a trivial rule), instead of creating a new, silly RegExp for every single one
- For trivial cookie names (~50% of cookie names are `.*` or `.+`), do the same