### PR TITLE
ubi.com updates

### DIFF
--- a/src/chrome/content/rules/Ubisoft-Entertainment.xml
+++ b/src/chrome/content/rules/Ubisoft-Entertainment.xml
@@ -87,10 +87,40 @@
 	<securecookie host=".*\.ubi\.com$" name=".+" />
 
 
-	<rule from="^http://static7\.ubi\.com/"
-		to="https://s3.amazonaws.com/static7.ubi.com/" />
+	<test url="http://static1.cdn.ubi.com/" />
+	<test url="http://static3.cdn.ubi.com/" />
+	<test url="http://static4.cdn.ubi.com/" />
+	<test url="http://static6.cdn.ubi.com/" />
+	<test url="http://static7.cdn.ubi.com/" />
+	<test url="http://static9.cdn.ubi.com/" />
+	<test url="http://static10.cdn.ubi.com/" />
+	<test url="http://static11.cdn.ubi.com/" />
+	<test url="http://static13.cdn.ubi.com/" />
+	<test url="http://static14.cdn.ubi.com/" />
+	<test url="http://static17.cdn.ubi.com/" />
+	
+	<rule from="^http://static(1|3|4|6|7|9|10|11|13|14|17)\.cdn\.ubi\.com/"
+		to="https://ubistatic$1-a.akamaihd.net/" />
 
-	<rule from="^http://(cs|engineroom|ghost-recon|hbe|secure|static\d(?:\.cdn)?|support|tomclancy-thedivision|tools|ubibar|uplay|uts)\.ubi\.com/"
+	<test url="http://static7.ubi.com/" />
+	<test url="http://static15.ubi.com/" />
+	<test url="http://static16.ubi.com/" />
+		
+	<rule from="^http://static(7|15|16)\.ubi\.com/"
+		to="https://s3.amazonaws.com/static$1.ubi.com/" />
+
+	<test url="http://cs.ubi.com/" />
+	<test url="http://engineroom.ubi.com/" />
+	<test url="http://hbe.ubi.com/" />
+	<test url="http://secure.ubi.com/" />
+	<test url="http://support.ubi.com/" />
+	<test url="http://tools.ubi.com/" />
+	<test url="http://ubibar.ubi.com/" />
+	<test url="http://uplay.ubi.com/" />
+	<test url="http://uts.ubi.com/" />
+	<test url="http://legal.ubi.com/" />
+		
+	<rule from="^http://(cs|engineroom|hbe|secure|static\d(?:\.cdn)?|support|tools|ubibar|uplay|uts|legal)\.ubi\.com/"
 		to="https://$1.ubi.com/" />
 
 </ruleset>


### PR DESCRIPTION
- [x] Add legal.
- [x] Remove ghost-recon., tomclancy-thedivision. due to mixedcontent
- [x] Thanks `@akamai` and `@aws` that they don't rely on his clients
and use additional https urls.