### PR TITLE
Expand "use strict" use & drop (broken) old Opera mixedcontent support

### DIFF
--- a/chromium/background.js
+++ b/chromium/background.js
@@ -22,7 +22,7 @@ function loadExtensionFile(url, returnType) {
 
 
 // Rules are loaded here
-var all_rules = new RuleSets(navigator.userAgent, LRUCache, localStorage);
+var all_rules = new RuleSets(LRUCache, localStorage);
 var rule_list = 'rules/default.rulesets';
 all_rules.addFromXml(loadExtensionFile(rule_list, 'xml'));
 

--- a/chromium/rules.js
+++ b/chromium/rules.js
@@ -261,9 +261,8 @@ RuleSets.prototype = {
     }
     // now eat away from the left, with *, so that for x.y.z.google.com we
     // check *.z.google.com and *.google.com (we did *.y.z.google.com above)
-    var t;
     for (var i = 2; i <= segmented.length - 2; ++i) {
-      t = "*." + segmented.slice(i,segmented.length).join(".");
+      var t = "*." + segmented.slice(i,segmented.length).join(".");
       this.setInsert(results, this.targets[t]);
     }
     log(DBUG,"Applicable rules for " + host + ":");


### PR DESCRIPTION
I found this fun bug while expanding "use strict" for some ES6 features:

Because of the IIFE (immediately-invoked function expression) surrounding `localPlatformRegexp`, it's never worked. `this.userAgent` is undefined during execution, and the else is always taken, resulting in `chromium` being the platform -- always.

Let's just rip this out, since it hasn't worked and `mixedcontent` support has been dead for a while in Chrome (and FF 23+, and Opera 23+).


In the future, we should consider allowing Chrome users to enable `mixedcontent` rules, similar to the FF behavior.



Signed-off-by: Nick Semenkovich \<semenko@alum.mit.edu\>