### PR TITLE
Fixed BECU.org ruleset.

### DIFF
--- a/src/chrome/content/rules/Boeing-Employees-Credit-Union.xml
+++ b/src/chrome/content/rules/Boeing-Employees-Credit-Union.xml
@@ -1,37 +1,14 @@
-<!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://becuonlinebanking.org/ => https://www.becuonlinebanking.org/: (7, 'Failed to connect to becuonlinebanking.org port 80: No route to host')
-	becu.122.2o7.net/b/ss/becudev/1/H.17/
+<ruleset name="Boeing Employees Credit Union">
 
--->
-<ruleset name="Boeing Employees Credit Union (partial)" default_off='failed ruleset test'>
+    <target host="becu.org" />
+    <target host="www.becu.org" />
+    <target host="onlinebanking.becu.org" />
 
-	<target host="becu.org" />
-	<target host="*.becu.org" />
-	<target host="becuonlinebanking.org" />
-	<target host="*.becuonlinebanking.org" />
+    <test url="http://becu.org/" />
+    <test url="http://www.becu.org/" />
+    <test url="http://onlinebanking.becu.org/" />
 
-
-	<!--	s_ cookies are set by 2o7.net.
-		becuhome is set by the homepage.	-->
-	<securecookie host="^\.becu\.org$" name="^(?:becuhome|s_\w+)$" />
-	<securecookie host="^accessassistant\.becu\.org$" name=".*" />
-	<securecookie host="^.*\.becuonlinebanking\.org$" name=".*" />
-
-
-	<!--	Cert is only valid for www.	-->
-	<rule from="^http://becu\.org/"
-		to="https://www.becu.org/" />
-
-	<!--	Some pages redirect to http.  There may be more that don't.	-->
-	<rule from="^http://www\.becu\.org/($|contact-us\.aspx|css/|Default\.aspx|flash/|images/|js/|mobile-online-banking/|pdfsource/|who-is/becu-is-you\.aspx)"
-		to="https://www.becu.org/$1" />
-
-	<rule from="^http://accessassistant\.becu\.org/"
-		to="https://accessassistant.becu.org/" />
-
-	<!--	Cert is only valid for www.	-->
-	<rule from="^http://(?:www\.)?becuonlinebanking\.org/"
-		to="https://www.becuonlinebanking.org/" />
+    <rule from="^http:"
+        to="https:" />
 
 </ruleset>


### PR DESCRIPTION
BECU.org appears to have enabled HTTPS throughout its entire website. This pull request re-enables the BECU rule with new tests and using the domains that they still use.