### PR TITLE
Uncomment formerly rc4-only viginmedia.com subdomains

### DIFF
--- a/src/chrome/content/rules/Virgin_Media.com.xml
+++ b/src/chrome/content/rules/Virgin_Media.com.xml
@@ -115,8 +115,8 @@
 -->
 <ruleset name="Virgin Media.com (partial)">
 
-	<!--<target host="identity.virginmedia.com" />-->
-	<!--<target host="national.virginmedia.com" />-->
+	<target host="identity.virginmedia.com" />
+	<target host="national.virginmedia.com" />
 
 	<target host="virginmedia.com" />
 	<target host="allyours.virginmedia.com" />


### PR DESCRIPTION
national.virginmedia.com and identity.virginmedia.com now support proper cipher suites and no longer support RC4 (see links below), so they should be uncommented in Virgin Media's ruleset.

https://www.ssllabs.com/ssltest/analyze.html?d=identity.virginmedia.com

https://www.ssllabs.com/ssltest/analyze.html?d=national.virginmedia.com