### PR TITLE
Add and update UK Police Forces

### DIFF
--- a/src/chrome/content/rules/AvonandSomersetConstabulary.xml
+++ b/src/chrome/content/rules/AvonandSomersetConstabulary.xml
@@ -1,0 +1,6 @@
+<ruleset name="Avon and Somerset Constabulary">
+	<target host="avonandsomerset.police.uk" />
+	<target host="www.avonandsomerset.police.uk" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/AvonandSomersetConstabulary.xml
+++ b/src/chrome/content/rules/AvonandSomersetConstabulary.xml
@@ -2,5 +2,5 @@
 	<target host="avonandsomerset.police.uk" />
 	<target host="www.avonandsomerset.police.uk" />
 
-	<rule from="^http:" to="https:" />
+	<rule from="^http://(www\.)?avonandsomerset\.police\.uk/" to="https://www.avonandsomerset.police.uk/" />
 </ruleset>

--- a/src/chrome/content/rules/CambridgeshireConstabulary.xml
+++ b/src/chrome/content/rules/CambridgeshireConstabulary.xml
@@ -2,7 +2,7 @@
 	^cambs.police.uk doesn't exist.
 
 -->
-<ruleset name="Cambs.police.uk">
+<ruleset name="Cambridgeshire Constabulary">
   <target host="www.cambs.police.uk" />
 
   <rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/CityofLondonPolice.xml
+++ b/src/chrome/content/rules/CityofLondonPolice.xml
@@ -1,0 +1,6 @@
+<ruleset name="City of London Police">
+	<target host="cityoflondon.police.uk" />
+	<target host="www.cityoflondon.police.uk" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/CityofLondonPolice.xml
+++ b/src/chrome/content/rules/CityofLondonPolice.xml
@@ -1,6 +1,22 @@
+<!--
+	For City of London Police
+
+		Works:
+
+			- $
+			- www
+			- academy
+
+		Mismatch:
+
+			- wwwstage.cityoflondon.police.uk
+			- editcolp.cityoflondon.police.uk
+
+-->
 <ruleset name="City of London Police">
 	<target host="cityoflondon.police.uk" />
 	<target host="www.cityoflondon.police.uk" />
+	<target host="academy.cityoflondon.police.uk" />
 
 	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/ClevelandPolice.xml
+++ b/src/chrome/content/rules/ClevelandPolice.xml
@@ -1,0 +1,6 @@
+<ruleset name="Cleveland Police">
+	<target host="cleveland.police.uk" />
+	<target host="www.cleveland.police.uk" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/CumbriaConstabulary.xml
+++ b/src/chrome/content/rules/CumbriaConstabulary.xml
@@ -1,6 +1,18 @@
+<!--
+	For Cumbria Constabulary
+
+		Works:
+
+			- www
+
+		Doesn't Work:
+
+			- $ (gives a 404)
+
+-->
 <ruleset name="Cumbria Constabulary">
 	<target host="cumbria.police.uk" />
 	<target host="www.cumbria.police.uk" />
 
-	<rule from="^http:" to="https:" />
+	<rule from="^http://(?:www\.)?cumbria\.police\.uk/" to="https://www.cumbria.police.uk/"/>
 </ruleset>

--- a/src/chrome/content/rules/CumbriaConstabulary.xml
+++ b/src/chrome/content/rules/CumbriaConstabulary.xml
@@ -1,0 +1,6 @@
+<ruleset name="Cumbria Constabulary">
+	<target host="cumbria.police.uk" />
+	<target host="www.cumbria.police.uk" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/DevonandCornwallPolice.xml
+++ b/src/chrome/content/rules/DevonandCornwallPolice.xml
@@ -1,6 +1,22 @@
+<!--
+	For Devon and Cornwall Police
+
+		Works:
+
+			- $
+			- www
+			- services
+
+		Doesn't work:
+
+			- dogsection.devon-cornwall.police.uk
+			- digitalmediablog.devon-cornwall.police.uk
+
+-->
 <ruleset name="Devon and Cornwall Police">
 	<target host="devon-cornwall.police.uk" />
 	<target host="www.devon-cornwall.police.uk" />
+	<target host="services.devon-cornwall.police.uk" />
 
 	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/DevonandCornwallPolice.xml
+++ b/src/chrome/content/rules/DevonandCornwallPolice.xml
@@ -1,0 +1,6 @@
+<ruleset name="Devon and Cornwall Police">
+	<target host="devon-cornwall.police.uk" />
+	<target host="www.devon-cornwall.police.uk" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/DurhamConstabulary.xml
+++ b/src/chrome/content/rules/DurhamConstabulary.xml
@@ -1,0 +1,6 @@
+<ruleset name="Durham Constabulary">
+	<target host="durham.police.uk" />
+	<target host="www.durham.police.uk" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/EssexPolice.xml
+++ b/src/chrome/content/rules/EssexPolice.xml
@@ -1,4 +1,4 @@
-<ruleset name="Essex.police.uk">
+<ruleset name="Essex Police">
   <target host="essex.police.uk" />
   <target host="www.essex.police.uk" />
 

--- a/src/chrome/content/rules/EssexPolice.xml
+++ b/src/chrome/content/rules/EssexPolice.xml
@@ -1,3 +1,15 @@
+<!--
+  For Essex Police
+
+    Works:
+
+      - www
+
+    Mismatch:
+
+      - $
+
+-->
 <ruleset name="Essex Police">
   <target host="essex.police.uk" />
   <target host="www.essex.police.uk" />

--- a/src/chrome/content/rules/GloucestershireConstabulary.xml
+++ b/src/chrome/content/rules/GloucestershireConstabulary.xml
@@ -1,0 +1,6 @@
+<ruleset name="Gloucestershire Constabulary">
+	<target host="gloucestershire.police.uk" />
+	<target host="www.gloucestershire.police.uk" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/HertfordshireConstabulary.xml
+++ b/src/chrome/content/rules/HertfordshireConstabulary.xml
@@ -1,3 +1,16 @@
+<!--
+  For Hertfordshire Constabulary
+
+    Works:
+
+      - $
+      - www
+
+    Mismatch:
+
+      - snt.herts.police.uk
+
+-->
 <ruleset name="Hertfordshire Constabulary">
   <target host="herts.police.uk" />
   <target host="www.herts.police.uk" />

--- a/src/chrome/content/rules/HertfordshireConstabulary.xml
+++ b/src/chrome/content/rules/HertfordshireConstabulary.xml
@@ -1,4 +1,4 @@
-<ruleset name="Herts.police.uk">
+<ruleset name="Hertfordshire Constabulary">
   <target host="herts.police.uk" />
   <target host="www.herts.police.uk" />
 

--- a/src/chrome/content/rules/LeicestershirePolice.xml
+++ b/src/chrome/content/rules/LeicestershirePolice.xml
@@ -1,0 +1,6 @@
+<ruleset name="Leicestershire Police">
+	<target host="leics.police.uk" />
+	<target host="www.leics.police.uk" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/LeicestershirePolice.xml
+++ b/src/chrome/content/rules/LeicestershirePolice.xml
@@ -1,3 +1,16 @@
+<!--
+	For Leicestershire Police
+
+		Works:
+
+			- $
+			- www
+
+		Mismatch:
+
+			- helicopter.leics.police.uk
+
+-->
 <ruleset name="Leicestershire Police">
 	<target host="leics.police.uk" />
 	<target host="www.leics.police.uk" />

--- a/src/chrome/content/rules/PoliceUK.xml
+++ b/src/chrome/content/rules/PoliceUK.xml
@@ -1,0 +1,6 @@
+<ruleset name="Police UK">
+	<target host="police.uk" />
+	<target host="www.police.uk" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/PoliceUK.xml
+++ b/src/chrome/content/rules/PoliceUK.xml
@@ -11,21 +11,21 @@
 
     Individual rulesets can be found for:
 
-      - AvonandSomersetConstabulary
-      - CambridgeshireConstabulary
-      - CityofLondonPolice
-      - ClevelandPolice
-      - CumbriaConstabulary
-      - DevonandCornwallPolice
-      - DurhamConstabulary
-      - EssexPolice
-      - GloucestershireConstabulary
-      - HertfordshireConstabulary
-      - LeicestershirePolice
-      - StaffordshirePolice
-      - WarwickshirePolice
-      - WestMerciaPolice
-      - WestMidlandsPolice
+      - AvonandSomersetConstabulary.xml
+      - CambridgeshireConstabulary.xml
+      - CityofLondonPolice.xml
+      - ClevelandPolice.xml
+      - CumbriaConstabulary.xml
+      - DevonandCornwallPolice.xml
+      - DurhamConstabulary.xml
+      - EssexPolice.xml
+      - GloucestershireConstabulary.xml
+      - HertfordshireConstabulary.xml
+      - LeicestershirePolice.xml
+      - StaffordshirePolice.xml
+      - WarwickshirePolice.xml
+      - WestMerciaPolice.xml
+      - WestMidlandsPolice.xml
 -->
 <ruleset name="Police UK">
 	<target host="police.uk" />

--- a/src/chrome/content/rules/PoliceUK.xml
+++ b/src/chrome/content/rules/PoliceUK.xml
@@ -1,6 +1,35 @@
+<!--
+  For Police.uk
+
+    Works:
+
+      - www
+
+    Timeout:
+
+      - $
+
+    Individual rulesets can be found for:
+
+      - Avon and Somerset Constabulary
+      - Cambridgeshire Constabulary
+      - City of London Police
+      - Cleveland Police
+      - Cumbria Constabulary
+      - Devon and Cornwall Police
+      - Durham Constabulary
+      - Essex Police
+      - Gloucestershire Constabulary
+      - Hertfordshire Constabulary
+      - Leicestershire Police
+      - Staffordshire Police
+      - Warwickshire Police
+      - West Mercia Police
+      - West Midlands Police
+-->
 <ruleset name="Police UK">
 	<target host="police.uk" />
 	<target host="www.police.uk" />
 
-	<rule from="^http:" to="https:" />
+  <rule from="^http://(www\.)?police\.uk/" to="https://www.police.uk/" />
 </ruleset>

--- a/src/chrome/content/rules/PoliceUK.xml
+++ b/src/chrome/content/rules/PoliceUK.xml
@@ -11,21 +11,21 @@
 
     Individual rulesets can be found for:
 
-      - Avon and Somerset Constabulary
-      - Cambridgeshire Constabulary
-      - City of London Police
-      - Cleveland Police
-      - Cumbria Constabulary
-      - Devon and Cornwall Police
-      - Durham Constabulary
-      - Essex Police
-      - Gloucestershire Constabulary
-      - Hertfordshire Constabulary
-      - Leicestershire Police
-      - Staffordshire Police
-      - Warwickshire Police
-      - West Mercia Police
-      - West Midlands Police
+      - AvonandSomersetConstabulary
+      - CambridgeshireConstabulary
+      - CityofLondonPolice
+      - ClevelandPolice
+      - CumbriaConstabulary
+      - DevonandCornwallPolice
+      - DurhamConstabulary
+      - EssexPolice
+      - GloucestershireConstabulary
+      - HertfordshireConstabulary
+      - LeicestershirePolice
+      - StaffordshirePolice
+      - WarwickshirePolice
+      - WestMerciaPolice
+      - WestMidlandsPolice
 -->
 <ruleset name="Police UK">
 	<target host="police.uk" />

--- a/src/chrome/content/rules/StaffordshirePolice.xml
+++ b/src/chrome/content/rules/StaffordshirePolice.xml
@@ -3,7 +3,7 @@
 	^staffordshire.police.uk doesn't exist.
 
 -->
-<ruleset name="Staffordshire.police.uk">
+<ruleset name="Staffordshire Police">
   <target host="www.staffordshire.police.uk" />
 
   <rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/WarwickshirePolice.xml
+++ b/src/chrome/content/rules/WarwickshirePolice.xml
@@ -1,0 +1,6 @@
+<ruleset name="Warwickshire Police">
+	<target host="warwickshire.police.uk" />
+	<target host="www.warwickshire.police.uk" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/WestMerciaPolice.xml
+++ b/src/chrome/content/rules/WestMerciaPolice.xml
@@ -1,0 +1,6 @@
+<ruleset name="West Mercia Police">
+	<target host="westmercia.police.uk" />
+	<target host="www.westmercia.police.uk" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/WestMidlandsPolice.xml
+++ b/src/chrome/content/rules/WestMidlandsPolice.xml
@@ -1,3 +1,24 @@
+<!--
+  For West Midlands Police
+
+    Works:
+
+      - www
+
+    Doesn't Work:
+
+      - $ (gives a 404)
+
+    Mixed Content:
+
+      - foi.west-midlands.police.uk
+      - behindthecrime.west-midlands.police.uk
+      - jobs.west-midlands.police.uk
+      - saferstudents.west-midlands.police.uk
+      - safestreet.west-midlands.police.uk
+
+
+-->
 <ruleset name="West Midlands Police">
   <target host="west-midlands.police.uk" />
   <target host="www.west-midlands.police.uk" />

--- a/src/chrome/content/rules/WestMidlandsPolice.xml
+++ b/src/chrome/content/rules/WestMidlandsPolice.xml
@@ -1,4 +1,4 @@
-<ruleset name="West-midlands.police.uk">
+<ruleset name="West Midlands Police">
   <target host="west-midlands.police.uk" />
   <target host="www.west-midlands.police.uk" />
 


### PR DESCRIPTION
**Renamed rules for the following UK Police Forces:**

- [Cambridgeshire Constabulary](https://www.cambs.police.uk/)
- [Essex Police](https://www.essex.police.uk/)
- [Hertfordshire Constabulary](https://www.herts.police.uk/)
- [Staffordshire Police](https://www.staffordshire.police.uk/)
- [West Midlands Police](https://www.west-midlands.police.uk/)

to match official names: [https://www.police.uk/forces/](https://www.police.uk/forces/)


**Added rules for the following UK Police Forces:**

- [Avon and Somerset Constabulary](https://www.avonandsomerset.police.uk/)
- [City of London Police](https://www.cityoflondon.police.uk/)
- [Cleveland Police](https://www.cleveland.police.uk/)
- [Cumbria Constabulary](https://www.cumbria.police.uk/)
- [Devon and Cornwall Police](https://www.devon-cornwall.police.uk/)
- [Durham Constabulary](https://www.durham.police.uk/)
- [Gloucestershire Constabulary](https://www.gloucestershire.police.uk/)
- [Leicestershire Police](https://www.leics.police.uk/)
- [Warwickshire Police](https://www.warwickshire.police.uk/)
- [West Mercia Police](https://www.westmercia.police.uk/)


**Added a rule for the main [Police UK website](https://www.police.uk/).**