### PR TITLE
[WorldCommunityGrid] Don't redirect to "secure" subdomain

### DIFF
--- a/src/chrome/content/rules/WorldCommunityGrid.xml
+++ b/src/chrome/content/rules/WorldCommunityGrid.xml
@@ -1,4 +1,8 @@
-
+<!--
+	Deep links to worldcommunitygrid.org don't work when using HTTPS.
+	For example, the following link will fail, so forward it to www.
+	https://worldcommunitygrid.org/research/viewAllProjects.do
+-->
 <ruleset name="World Community Grid">
 
 	<target host="worldcommunitygrid.org" />
@@ -9,8 +13,7 @@
 
 	<securecookie host="^\.worldcommunitygrid\.org$" name=".+" />
 
-	<rule from="^http:"
-		to="https:" />
+	<rule from="^http://worldcommunitygrid\.org/" to="https://www.worldcommunitygrid.org/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>
-

--- a/src/chrome/content/rules/WorldCommunityGrid.xml
+++ b/src/chrome/content/rules/WorldCommunityGrid.xml
@@ -12,7 +12,7 @@
 
 
 	<rule from="^http://worldcommunitygrid\.org/"
-		to="https://secure.worldcommunitygrid.org/" />
+		to="https://www.worldcommunitygrid.org/" />
 
  	<rule from="^http://(secure|www)\.worldcommunitygrid\.org/"
 		to="https://$1.worldcommunitygrid.org/" />

--- a/src/chrome/content/rules/WorldCommunityGrid.xml
+++ b/src/chrome/content/rules/WorldCommunityGrid.xml
@@ -1,20 +1,16 @@
-<!--
-	!www: cert only matches *.worldcommunitygrid.org
 
--->
 <ruleset name="World Community Grid">
 
 	<target host="worldcommunitygrid.org" />
-	<target host="*.worldcommunitygrid.org" />
-
+	<target host="www.worldcommunitygrid.org" />
+	<target host="secure.worldcommunitygrid.org" />
+	<target host="scheduler.worldcommunitygrid.org" />
+	<target host="grid.worldcommunitygrid.org" />
 
 	<securecookie host="^\.worldcommunitygrid\.org$" name=".+" />
 
-
-	<rule from="^http://worldcommunitygrid\.org/"
-		to="https://www.worldcommunitygrid.org/" />
-
- 	<rule from="^http://(secure|www)\.worldcommunitygrid\.org/"
-		to="https://$1.worldcommunitygrid.org/" />
+	<rule from="^http:"
+		to="https:" />
 
 </ruleset>
+


### PR DESCRIPTION
Stop redirecting worldcommunitygrid.org requests to
secure.worldcommunitygrid.org. The former now supports HTTPS.

Closes https://github.com/EFForg/https-everywhere/issues/3963