### PR TITLE
[Einstein@Home] Add .org rule

### DIFF
--- a/src/chrome/content/rules/EinsteinAtHome.org.xml
+++ b/src/chrome/content/rules/EinsteinAtHome.org.xml
@@ -4,6 +4,11 @@
 	<target host="www.einsteinathome.org" />
 	<target host="scheduler.einsteinathome.org" />
 
+	<target host="albertathome.org" />
+	<target host="www.albertathome.org" />
+
+	<securecookie host=".+" name=".+" />
+
 	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/EinsteinAtHome.org.xml
+++ b/src/chrome/content/rules/EinsteinAtHome.org.xml
@@ -1,0 +1,9 @@
+<ruleset name="Einstein@Home">
+
+	<target host="einsteinathome.org" />
+	<target host="www.einsteinathome.org" />
+	<target host="scheduler.einsteinathome.org" />
+
+	<rule from="^http:" to="https:" />
+
+</ruleset>

--- a/src/chrome/content/rules/University-of-Wisconsin-Milwaukee.xml
+++ b/src/chrome/content/rules/University-of-Wisconsin-Milwaukee.xml
@@ -1,18 +1,25 @@
 <ruleset name="University of Wisconsin–Milwaukee (partial)">
 
-	<!-- www is currently forwarded to www4 by the server -->
-	<!-- <target host="www.uwm.edu" /> -->
+	<target host="www.uwm.edu" />
 	<target host="uwm.edu" />
 	<target host="www4.uwm.edu" />
 	<target host="kb.uwm.edu" />
 	<target host="jobs.uwm.edu" />
+	<target host="cipr.uwm.edu" />
+	<target host="go.uwm.edu" />
+	<target host="people.uwm.edu" />
+	<target host="paws.uwm.edu" />
+	<target host="oar.uwm.edu" />
 	<target host="einstein.phys.uwm.edu" />
 
+	<securecookie host="^(people|paws)\.uwm\.edu$" name=".+" />
 	<!-- university tracking cookies -->
 	<securecookie host="^\.uwm\.edu$" name=".+" />
 	<!-- einstein@home auth cookie -->
 	<securecookie host="^einstein\.phys\.uwm\.edu$" name=".+" />
 
+	<!-- www is currently forwarded to www4 by the server -->
+	<rule from="^http://www\.uwm\.edu/" to="https://www4.uwm.edu/" />
 	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/University-of-Wisconsin-Milwaukee.xml
+++ b/src/chrome/content/rules/University-of-Wisconsin-Milwaukee.xml
@@ -1,3 +1,37 @@
+<!--
+	Timeout:
+		bookstore.uwm.edu
+		access*.r2d2.uwm.edu
+
+	Refused:
+		www.cs.uwm.edu
+		collections.lib.uwm.edu
+		studentorgs.uwm.edu
+		entech-dev.cuir.uwm.edu
+		entech.cuir.uwm.edu
+		everyday.uwm.edu
+
+	Mismatch:
+		dc.uwm.edu
+		guides.library.uwm.edu
+		greatlakesgenomics.uwm.edu
+		www.r2d2.uwm.edu
+		photoarchive.uwm.edu
+		surface.chem.uwm.edu
+		d2l.uwm.edu
+
+	Self-Signed:
+		ccr-test.uits.uwm.edu
+		onemolecule.chem.uwm.edu
+		derecho.math.uwm.edu
+		home.freshwater.uwm.edu
+
+	Access-Restricted, unable to fully test:
+		web.sa.uwm.edu
+		apps.sa.uwm.edu
+		apps.uwm.edu
+		techmallshop.uwm.edu
+-->
 <ruleset name="University of Wisconsin–Milwaukee (partial)">
 
 	<target host="www.uwm.edu" />
@@ -10,13 +44,14 @@
 	<target host="people.uwm.edu" />
 	<target host="paws.uwm.edu" />
 	<target host="oar.uwm.edu" />
+	<target host="pantherfile.uwm.edu" />
+	<target host="www4dev.uwm.edu" />
+	<target host="innovwthrdev.uwm.edu" />
+	<target host="roomscheduling.uwm.edu" />
+	<target host="www.lsc-group.phys.uwm.edu" />
 	<target host="einstein.phys.uwm.edu" />
 
-	<securecookie host="^(people|paws)\.uwm\.edu$" name=".+" />
-	<!-- university tracking cookies -->
-	<securecookie host="^\.uwm\.edu$" name=".+" />
-	<!-- einstein@home auth cookie -->
-	<securecookie host="^einstein\.phys\.uwm\.edu$" name=".+" />
+	<securecookie host="\.uwm\.edu$" name=".+" />
 
 	<!-- www is currently forwarded to www4 by the server -->
 	<rule from="^http://www\.uwm\.edu/" to="https://www4.uwm.edu/" />

--- a/src/chrome/content/rules/University-of-Wisconsin-Milwaukee.xml
+++ b/src/chrome/content/rules/University-of-Wisconsin-Milwaukee.xml
@@ -1,19 +1,18 @@
 <ruleset name="University of Wisconsin–Milwaukee (partial)">
 
-	<target host="einstein.phys.uwm.edu" />
-	<target host="www.uwm.edu" />
+	<!-- www is currently forwarded to www4 by the server -->
+	<!-- <target host="www.uwm.edu" /> -->
+	<target host="uwm.edu" />
 	<target host="www4.uwm.edu" />
+	<target host="kb.uwm.edu" />
+	<target host="jobs.uwm.edu" />
+	<target host="einstein.phys.uwm.edu" />
 
 	<!-- university tracking cookies -->
 	<securecookie host="^\.uwm\.edu$" name=".+" />
 	<!-- einstein@home auth cookie -->
 	<securecookie host="^einstein\.phys\.uwm\.edu$" name=".+" />
 
-	<!-- www doesn't work over https -->
-	<rule from="^http://www\.uwm\.edu/$"
-		to="https://www4.uwm.edu/" />
-
-	<rule from="^http://einstein\.phys\.uwm\.edu/"
-		to="https://einstein.phys.uwm.edu/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/University-of-Wisconsin-Milwaukee.xml
+++ b/src/chrome/content/rules/University-of-Wisconsin-Milwaukee.xml
@@ -4,8 +4,12 @@
 	<target host="www.uwm.edu" />
 	<target host="www4.uwm.edu" />
 
+	<!-- university tracking cookies -->
+	<securecookie host="^\.uwm\.edu$" name=".+" />
+	<!-- einstein@home auth cookie -->
+	<securecookie host="^einstein\.phys\.uwm\.edu$" name=".+" />
 
-	<!--	www doesn't work over https.	-->
+	<!-- www doesn't work over https -->
 	<rule from="^http://www\.uwm\.edu/$"
 		to="https://www4.uwm.edu/" />
 


### PR DESCRIPTION
Adds rules for einstein@home's alternative .org domain and securecookie
entry for its uwm.edu domain.