### PR TITLE
Expand use of Set()

### DIFF
--- a/chromium/background.js
+++ b/chromium/background.js
@@ -224,9 +224,9 @@ function onBeforeRequest(details) {
     activeRulesets.removeTab(details.tabId);
   }
 
-  var rs = all_rules.potentiallyApplicableRulesets(uri.hostname);
+  var potentiallyApplicable = all_rules.potentiallyApplicableRulesets(uri.hostname);
   // If no rulesets could apply, let's get out of here!
-  if (rs.length === 0) { return {cancel: shouldCancel}; }
+  if (potentiallyApplicable.size === 0) { return {cancel: shouldCancel}; }
 
   if (redirectCounter[details.requestId] >= 8) {
     log(NOTE, "Redirect counter hit for " + canonical_url);
@@ -239,10 +239,10 @@ function onBeforeRequest(details) {
 
   var newuristr = null;
 
-  for(var i = 0; i < rs.length; ++i) {
-    activeRulesets.addRulesetToTab(details.tabId, rs[i]);
-    if (rs[i].active && !newuristr) {
-      newuristr = rs[i].apply(canonical_url);
+  for (let ruleset of potentiallyApplicable) {
+    activeRulesets.addRulesetToTab(details.tabId, ruleset);
+    if (ruleset.active && !newuristr) {
+      newuristr = ruleset.apply(canonical_url);
     }
   }
 

--- a/chromium/background.js
+++ b/chromium/background.js
@@ -168,8 +168,8 @@ AppliedRulesets.prototype = {
 // FIXME: change this name
 var activeRulesets = new AppliedRulesets();
 
-var urlBlacklist = {};
-var domainBlacklist = {};
+var urlBlacklist = new Set();
+var domainBlacklist = new Set();
 
 // redirect counter workaround
 // TODO: Remove this code if they ever give us a real counter
@@ -216,7 +216,7 @@ function onBeforeRequest(details) {
     log(INFO, "Original url " + details.url + 
         " changed before processing to " + canonical_url);
   }
-  if (canonical_url in urlBlacklist) {
+  if (urlBlacklist.has(canonical_url)) {
     return {cancel: shouldCancel};
   }
 
@@ -230,9 +230,9 @@ function onBeforeRequest(details) {
 
   if (redirectCounter[details.requestId] >= 8) {
     log(NOTE, "Redirect counter hit for " + canonical_url);
-    urlBlacklist[canonical_url] = true;
+    urlBlacklist.add(canonical_url);
     var hostname = uri.hostname;
-    domainBlacklist[hostname] = true;
+    domainBlacklist.add(hostname);
     log(WARN, "Domain blacklisted " + hostname);
     return {cancel: shouldCancel};
   }

--- a/chromium/rules.js
+++ b/chromium/rules.js
@@ -229,8 +229,8 @@ RuleSets.prototype = {
     var tmp;
     var results = [];
     if (this.targets[host]) {
-      // Copy the host targets so we don't modify them. // TODO: Check if this comment makes sense.
-      results = results.concat(this.targets[host].slice());
+      // Copy the host targets so we don't modify them.
+      results = results.concat(this.targets[host]);
     }
 
     // Replace each portion of the domain with a * in turn
@@ -348,7 +348,9 @@ RuleSets.prototype = {
     log(INFO, "Testing securecookie applicability with " + test_uri);
     var potentiallyApplicable = this.potentiallyApplicableRulesets(domain);
     for (let ruleset of potentiallyApplicable) {
-      if (!ruleset.active) continue;
+      if (!ruleset.active) {
+        continue;
+      }
       if (ruleset.apply(test_uri)) {
         log(INFO, "Cookie domain could be secured.");
         this.cookieHostCache.set(domain, true);
@@ -370,8 +372,9 @@ RuleSets.prototype = {
     var newuri = null;
     var potentiallyApplicable = this.potentiallyApplicableRulesets(host);
     for (let ruleset of potentiallyApplicable) {
-      if (ruleset.active && (newuri = ruleset.apply(urispec)))
+      if (ruleset.active && (newuri = ruleset.apply(urispec))) {
         return newuri;
+      }
     }
     return null;
   }

--- a/chromium/rules.js
+++ b/chromium/rules.js
@@ -213,19 +213,6 @@ RuleSets.prototype = {
   },
 
   /**
-   * Insert any elements from fromList into intoList, if they are not
-   * already there.  fromList may be null.
-   * @param intoList
-   * @param fromList
-   */
-  setInsert: function(intoList, fromList) {
-    if (!fromList) return;
-    for (var i = 0; i < fromList.length; i++)
-      if (intoList.indexOf(fromList[i]) == -1)
-        intoList.push(fromList[i]);
-  },
-
-  /**
    * Return a list of rulesets that apply to this host
    * @param host The host to check
    * @returns {*} (empty) list
@@ -242,8 +229,8 @@ RuleSets.prototype = {
     var tmp;
     var results = [];
     if (this.targets[host]) {
-      // Copy the host targets so we don't modify them.
-      results = this.targets[host].slice();
+      // Copy the host targets so we don't modify them. // TODO: Check if this comment makes sense.
+      results = results.concat(this.targets[host].slice());
     }
 
     // Replace each portion of the domain with a * in turn
@@ -251,24 +238,31 @@ RuleSets.prototype = {
     for (var i = 0; i < segmented.length; ++i) {
       tmp = segmented[i];
       segmented[i] = "*";
-      this.setInsert(results, this.targets[segmented.join(".")]);
+      results = results.concat(this.targets[segmented.join(".")]);
       segmented[i] = tmp;
     }
     // now eat away from the left, with *, so that for x.y.z.google.com we
     // check *.z.google.com and *.google.com (we did *.y.z.google.com above)
     for (var i = 2; i <= segmented.length - 2; ++i) {
       var t = "*." + segmented.slice(i,segmented.length).join(".");
-      this.setInsert(results, this.targets[t]);
+      results = results.concat(this.targets[t]);
     }
+
+    // Clean the results list, which may contain duplicates or undefined entries
+    var resultSet = new Set(results);
+    resultSet.delete(undefined);
+
     log(DBUG,"Applicable rules for " + host + ":");
-    if (results.length == 0)
+    if (resultSet.size == 0) {
       log(DBUG, "  None");
-    else
-      for (var i = 0; i < results.length; ++i)
-        log(DBUG, "  " + results[i].name);
+    } else {
+      for (let target of resultSet.values()) {
+        log(DBUG, "  " + target.name);
+      }
+    }
 
     // Insert results into the ruleset cache
-    this.ruleCache.set(host, results);
+    this.ruleCache.set(host, resultSet);
 
     // Cap the size of the cache. (Limit chosen somewhat arbitrarily)
     if (this.ruleCache.size > 1000) {
@@ -276,7 +270,7 @@ RuleSets.prototype = {
       this.ruleCache.delete(this.ruleCache.keys().next().value);
     }
 
-    return results;
+    return resultSet;
   },
 
   /**
@@ -296,9 +290,8 @@ RuleSets.prototype = {
         return null;
     }
 
-    var rs = this.potentiallyApplicableRulesets(hostname);
-    for (var i = 0; i < rs.length; ++i) {
-      var ruleset = rs[i];
+    var potentiallyApplicable = this.potentiallyApplicableRulesets(hostname);
+    for (let ruleset of potentiallyApplicable) {
       if (ruleset.cookierules !== null && ruleset.active) {
         for (var j = 0; j < ruleset.cookierules.length; j++) {
           var cr = ruleset.cookierules[j];
@@ -353,10 +346,10 @@ RuleSets.prototype = {
     }
 
     log(INFO, "Testing securecookie applicability with " + test_uri);
-    var rs = this.potentiallyApplicableRulesets(domain);
-    for (var i = 0; i < rs.length; ++i) {
-      if (!rs[i].active) continue;
-      if (rs[i].apply(test_uri)) {
+    var potentiallyApplicable = this.potentiallyApplicableRulesets(domain);
+    for (let ruleset of potentiallyApplicable) {
+      if (!ruleset.active) continue;
+      if (ruleset.apply(test_uri)) {
         log(INFO, "Cookie domain could be secured.");
         this.cookieHostCache.set(domain, true);
         return true;
@@ -375,9 +368,9 @@ RuleSets.prototype = {
    */
   rewriteURI: function(urispec, host) {
     var newuri = null;
-    var rs = this.potentiallyApplicableRulesets(host);
-    for(var i = 0; i < rs.length; ++i) {
-      if (rs[i].active && (newuri = rs[i].apply(urispec)))
+    var potentiallyApplicable = this.potentiallyApplicableRulesets(host);
+    for (let ruleset of potentiallyApplicable) {
+      if (ruleset.active && (newuri = ruleset.apply(urispec)))
         return newuri;
     }
     return null;

--- a/chromium/rules.js
+++ b/chromium/rules.js
@@ -329,7 +329,7 @@ RuleSets.prototype = {
     // observed and the domain blacklisted, a cookie might already have been
     // flagged as secure.
 
-    if (domain in domainBlacklist) {
+    if (domainBlacklist.has(domain)) {
       log(INFO, "cookies for " + domain + "blacklisted");
       return false;
     }


### PR DESCRIPTION
Replace blacklists and potentiallyApplicableRulesets with actual Set()s, trying to clean up the Chrome code.

Compatible with FF 38 ESR and above per https://kangax.github.io/compat-table/es6/