### PR TITLE
[Google APIs] Add storage.googleapis.com

### DIFF
--- a/src/chrome/content/rules/GoogleAPIs.xml
+++ b/src/chrome/content/rules/GoogleAPIs.xml
@@ -47,6 +47,7 @@
 			- chart
 			- *.commondatastorage
 			- fonts
+			- storage
 			- *.storage
 			- www
 
@@ -90,6 +91,7 @@
 	<target host="www.googleapis.com" />
 	<target host="*.commondatastorage.googleapis.com" />
 	<target host="*.storage.googleapis.com" />
+	<target host="storage.googleapis.com" />
 
 	<target host="gstatic.com" />
 	<target host="*.gstatic.com" />


### PR DESCRIPTION
Current ruleset doesn't `target` the subdomain, despite having a `test url`.
e.g. http://storage.googleapis.com/bloomsky-video/eaB1rJytnZSmm6q3_-8_2015-11-09.mp4
Noticed this issue while testing for https://github.com/EFForg/https-everywhere/pull/4051.