### PR TITLE
Switch to spanning incognito

### DIFF
--- a/chromium/incognito-cache-clearing.js
+++ b/chromium/incognito-cache-clearing.js
@@ -1,0 +1,61 @@
+"use strict";
+// This file keeps track of incognito sessions, and clears any caches after
+// an entire incognito session is closed (i.e. all incognito windows are closed).
+
+let incognito_session_exists = false;
+
+/**
+ * Detect if an incognito session is created, so we can clear caches when it's destroyed.
+ *
+ * @param window: A standard Window object.
+ */
+function detect_incognito_creation(window) {
+    if (window.incognito === true) {
+        incognito_session_exists = true;
+    }
+}
+
+/**
+ * Clear any caches we have.
+ * Called if an incognito session is destroyed.
+ */
+function destroy_caches() {
+    log(DBUG, "Destroying caches.");
+    all_rules.cookieHostCache.clear();
+    all_rules.ruleCache.clear();
+}
+
+/**
+ * Check if any incognito window still exists. If not, destroy caches.
+ * @param arrayOfWindows: A array of all open Window objects.
+ */
+function check_for_incognito_session(arrayOfWindows) {
+    for (let window of arrayOfWindows) {
+        if (window.incognito === true) {
+            // An incognito window still exists, so don't destroy caches yet.
+            return;
+        }
+    }
+    // All incognito windows have been closed.
+    incognito_session_exists = false;
+    destroy_caches();
+}
+
+/**
+ * If a window is destroyed, and an incognito session existed, see if it still does.
+ *
+ * @param windowId: Ignored.
+ */
+function detect_incognito_destruction(windowId) {
+    if (incognito_session_exists) {
+        // Are any current windows incognito?
+        chrome.windows.getAll(check_for_incognito_session);
+    }
+}
+
+
+// Listen to window creation, so we can detect if an incognito window is created
+chrome.windows.onCreated.addListener(detect_incognito_creation);
+
+// Listen to window destruction, so we can clear caches if all incognito windows are destroyed
+chrome.windows.onRemoved.addListener(detect_incognito_destruction);

--- a/chromium/manifest.json
+++ b/chromium/manifest.json
@@ -6,7 +6,8 @@
         "scripts": [
             "rules.js", 
             "util.js", 
-            "background.js"
+            "background.js",
+            "incognito-cache-clearing.js"
         ]
     }, 
     "browser_action": {
@@ -25,7 +26,7 @@
         "16": "icon16.png", 
         "48": "icon48.png"
     }, 
-    "incognito": "split", 
+    "incognito": "spanning",
     "manifest_version": 2, 
     "minimum_chrome_version": "45",
     "name": "__MSG_about_ext_name__", 


### PR DESCRIPTION
Fixes:
- Stops us from ~doubling memory usage on incognito (by instantiating again)
- Rule preferences & custom rules are shared in incognito

This is a little verbose, since:
- There's no easy way to see when incognito sessions are destroyed, and we
don't want to maintain additional state about window IDs.
- We need to clear caches when incognito sessions are destroyed, like Chrome
does for about:net-internals/#dns, for example.


Closes #4034

Signed-off-by: Nick Semenkovich <semenko@alum.mit.edu>