### PR TITLE
[Custhelp.com] Work around mismatch on motorola-global-community.custhelp.com

### DIFF
--- a/src/chrome/content/rules/Custhelp.com.xml
+++ b/src/chrome/content/rules/Custhelp.com.xml
@@ -5,6 +5,7 @@
 
 
 	(www.)?: Mismatched
+	motorola-global-community: Mismatched (CN: forums.motorola.com)
 
 
 	Mixed content:
@@ -47,6 +48,17 @@
 
 		<test url="http://custhelp.com/foo" />
 		<test url="http://www.custhelp.com/foo" />
+
+	<!--	Mismatched (CN: forums.motorola.com)
+
+		http://motorola-global-community.custhelp.com/ redirects to https://forums.motorola.com/ anyway.
+
+		https://github.com/EFForg/https-everywhere/issues/4060 -->
+	<rule from="^http://motorola-global-community\.custhelp\.com/"
+		to="https://forums.motorola.com/" />
+
+		<test url="http://motorola-global-community.custhelp.com/" />
+		<test url="http://motorola-global-community.custhelp.com/pages/afe9e9ba5d" />
 
 	<rule from="^http:"
 		to="https:" />


### PR DESCRIPTION
Fixes #4060 reported by Konomi.

https://motorola-global-community.custhelp.com/ mismatches with forums.motorola.com.

http://motorola-global-community.custhelp.com/ redirects to https://forums.motorola.com/ anyway.