### PR TITLE
Fix comment in Virgin_media.com.xml

### DIFF
--- a/src/chrome/content/rules/Virgin_Media.com.xml
+++ b/src/chrome/content/rules/Virgin_Media.com.xml
@@ -77,13 +77,6 @@
 	** certificate name mismatch
 	*** certificate expired
 
-	Future nonfunctional subdomains:
-
-		- identity ****
-		- national ****
-
-	**** This server uses only RC4 suites, which are insecure. From early 2016, modern browsers won't connect to it.
-
 	Partially covered subdomains:
 
 		- ^		(302 redirects to http://www.virginmedia.com except certain directories)
@@ -111,6 +104,8 @@
 		- payments
 		- websafe
 		- www
+		- identity
+		- national
 
 -->
 <ruleset name="Virgin Media.com (partial)">


### PR DESCRIPTION
The target tags for identity.virginmedia.com and national.virginmedia.com were uncommented in   #3998, but the comment in the ruleset wasn't changed to reflect that.

This fixes #4024.