### PR TITLE
Make tests headless with the help of xvfb

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,10 @@ env:
   - FIREFOX_VERSION=firefox-latest
   - FIREFOX_VERSION=firefox-esr-latest
 before_script:
-  - sh -e /etc/init.d/xvfb start
   - sudo apt-get install chromium-chromedriver
   - wget -O /tmp/firefox.tar.bz2 'https://download.mozilla.org/?os=linux64&lang=en-US&product='$FIREFOX_VERSION
   - tar xpjf /tmp/firefox.tar.bz2
-  - export DISPLAY=:99.0 FIREFOX=$PWD/firefox/firefox
+  - export FIREFOX=$PWD/firefox/firefox
 script:
   - ./test.sh
 sudo: required

--- a/install-dev-dependencies.sh
+++ b/install-dev-dependencies.sh
@@ -13,7 +13,7 @@ if type apt-get >/dev/null ; then
     CHROMEDRIVER="chromedriver"
   fi
   sudo apt-get install libxml2-dev libxml2-utils libxslt1-dev python-dev \
-    $BROWSERS zip sqlite3 python-pip libcurl4-openssl-dev \
+    $BROWSERS zip sqlite3 python-pip libcurl4-openssl-dev xvfb \
     libssl-dev $CHROMEDRIVER
 elif type brew >/dev/null ; then
   brew list python &>/dev/null || brew install python

--- a/test/chromium.sh
+++ b/test/chromium.sh
@@ -34,5 +34,5 @@ else
 	./makecrx.sh
 	echo "running tests"
 	CRX_NAME="`ls -tr pkg/*.crx | tail -1`"
-	python2.7 test/chromium/script.py $CRX_NAME
+	xvfb-run python2.7 test/chromium/script.py $CRX_NAME
 fi

--- a/test/chromium.sh
+++ b/test/chromium.sh
@@ -11,6 +11,10 @@ else
     git rev-parse && cd "$(git rev-parse --show-toplevel)"
 fi
 
+# Make sure we have xvfb-run and it's not already set.
+if [ -z "$XVFB_RUN" -a -n "$(which xvfb-run)" ]; then
+  XVFB_RUN=xvfb-run
+fi
 
 # If you just want to run Chromium with the latest code:
 if [ "$1" == "--justrun" ]; then
@@ -34,5 +38,5 @@ else
 	./makecrx.sh
 	echo "running tests"
 	CRX_NAME="`ls -tr pkg/*.crx | tail -1`"
-	xvfb-run python2.7 test/chromium/script.py $CRX_NAME
+	$XVFB_RUN python2.7 test/chromium/script.py $CRX_NAME
 fi

--- a/test/firefox.sh
+++ b/test/firefox.sh
@@ -46,6 +46,11 @@ if [ ! -d "$HTTPSE_INSTALL_DIRECTORY" ]; then
   die "Firefox profile does not have HTTPS Everywhere installed"
 fi
 
+# Make sure we have xvfb-run and it's not already set.
+if [ -z "$XVFB_RUN" -a -n "$(which xvfb-run)" ]; then
+  XVFB_RUN=xvfb-run
+fi
+
 # Activate the Firefox Addon SDK.
 pushd addon-sdk
 source bin/activate
@@ -68,7 +73,7 @@ if [ "$1" == "--justrun" ]; then
   fi
 else
   echo "running tests"
-  xvfb-run cfx test --profiledir="$PROFILE_DIRECTORY" --verbose
+  $XVFB_RUN cfx test --profiledir="$PROFILE_DIRECTORY" --verbose
 fi
 
 popd

--- a/test/firefox.sh
+++ b/test/firefox.sh
@@ -68,7 +68,7 @@ if [ "$1" == "--justrun" ]; then
   fi
 else
   echo "running tests"
-  cfx test --profiledir="$PROFILE_DIRECTORY" --verbose
+  xvfb-run cfx test --profiledir="$PROFILE_DIRECTORY" --verbose
 fi
 
 popd


### PR DESCRIPTION
I'm not sure if this is categorically useful.  There may be instances where you actually want to have the ability to interact with the webdriver browser.  We could also add this as an option, like `--headless` if desired.