### PR TITLE
Remove www.modern.ie and modern.ie

### DIFF
--- a/src/chrome/content/rules/Modern.IE.xml
+++ b/src/chrome/content/rules/Modern.IE.xml
@@ -1,56 +1,16 @@
 <!--
-	For other Microsoft coverage, see Microsoft.xml.
+offers.modern.ie ¹
+uservoice.modern.ie ¹
 
 
-	Problematic subdomains:
-
-		- www. mismatch
-		- virtualization. mismatch
-		- uservoice. mismatch
-
-
-	Insecure cookies are set for these domains:
-
-		- .
-		- .devchannel
-		- remote
-		- .remote
-		- .status
-		- .www
-
-
-	Mixed content:
-
-		- Fonts on devchannel from www.modern.ie *
-
-	* Secured by us
-
+¹ mismatch
 -->
-<ruleset name="modern.IE">
-
-	<!--	Direct rewrites:
-				-->
+<ruleset name="modern.ie">
 	<target host="modern.ie" />
-	<target host="devchannel.modern.ie" />
-	<target host="remote.modern.ie" />
-	<target host="status.modern.ie" />
-	<target host="dev.modern.ie" />
 	<target host="www.modern.ie" />
+	<target host="dev.modern.ie" />
+	<target host="devchannel.modern.ie" />
+	<target host="status.modern.ie" />
 
-
-	<!--	Not secured by server:
-					-->
-	<!--securecookie host="^\.(devchannel\.|status\.|www\.)?modern\.ie$" name="^ARRAffinity$" /-->
-	<!--securecookie host="^remote\.modern\.ie$" name="^connect\.sid$" /-->
-
-	<securecookie host="^(?:\.devchannel|\.?remote|\.status|\.www)?\.modern\.ie$" name=".+" />
-	
-	
-	<rule from="^http://www\.modern\.ie/"
-		to="https://modern.ie/"/>
-
-
-	<rule from="^http:"
-		to="https:" />
-
+	<rule from="^http:" to="https:" />
 </ruleset>


### PR DESCRIPTION
www.modern.ie via ssl.prod-modernie-redirect.azurewebsites.net [168.62.21.207] sends cert for modern.ie
