### PR TITLE
Fix: custom rules should be disableable

### DIFF
--- a/src/chrome/content/code/ApplicableList.js
+++ b/src/chrome/content/code/ApplicableList.js
@@ -213,9 +213,13 @@ ApplicableList.prototype = {
   },
 
   add_command: function(rule) {
+      // basic validation for data to be added to xul
+      if(!String(rule.id).match(/^[a-zA-Z_0-9]+$/))
+        return;
+
       var command = this.document.getElementById("https-everywhere-menuitem-rule-toggle-template").cloneNode();
-      command.setAttribute('id', JSON.stringify(rule.id)+'-command');
-      command.setAttribute('data-id', JSON.stringify(rule.id));
+      command.setAttribute('id', rule.id+'-command');
+      command.setAttribute('data-id', rule.id);
       command.setAttribute('label', rule.name);
       this.commandset.appendChild(command);
   },

--- a/src/chrome/content/code/ApplicableList.js
+++ b/src/chrome/content/code/ApplicableList.js
@@ -214,12 +214,14 @@ ApplicableList.prototype = {
 
   add_command: function(rule) {
       // basic validation for data to be added to xul
-      if(!String(rule.id).match(/^[a-zA-Z_0-9]+$/))
+      var ruleId = String(rule.id);
+      if (!ruleId.match(/^[a-zA-Z_0-9]+$/)) {
         return;
+      }
 
       var command = this.document.getElementById("https-everywhere-menuitem-rule-toggle-template").cloneNode();
-      command.setAttribute('id', rule.id+'-command');
-      command.setAttribute('data-id', rule.id);
+      command.setAttribute('id', ruleId+'-command');
+      command.setAttribute('data-id', ruleId);
       command.setAttribute('label', rule.name);
       this.commandset.appendChild(command);
   },


### PR DESCRIPTION
JSON.stringify was transforming custom rule ids:

From: custom_0
To: "custom_0"

(quotes included in the string)

This was breaking the ability to disable custom rules.  This fixes it by making sure rules fit a certain regex for validation, but removing the JSON.stringify.