### PR TITLE
Bitly vanity domains: direct http to https redirect (resolves #4097)

### DIFF
--- a/src/chrome/content/rules/Bit.ly_vanity_domains.xml
+++ b/src/chrome/content/rules/Bit.ly_vanity_domains.xml
@@ -40,279 +40,60 @@
   -->
 <ruleset name="bit.ly vanity domains" default_off="Breaks many redirectors">
 
-	<target host="1tw.org" />
-	<target host="www.1tw.org" />
-	<target host="4mn.ca" />
 	<target host="7ny.tv" />
-	<target host="www.7ny.tv" />
-	<target host="a21.tv" />
 	<target host="abcn.ws" />
-	<target host="www.abcn.ws" />
-	<target host="alj.am" />
-	<target host="www.alj.am" />
 	<target host="apne.ws" />
 	<target host="atfp.co" />
-	<target host="www.atfp.co" />
 	<target host="bbc.in" />
 	<target host="bitly.is" />
 	<target host="bloom.bg" />
 	<target host="brook.gs" />
-	<target host="www.brook.gs" />
 	<target host="buff.ly" />
-	<target host="www.buff.ly" />
-	<target host="bzfd.it" />
-	<target host="www.bzfd.it" />
 	<target host="cbsn.ws" />
-	<target host="www.cbsn.ws" />
-	<target host="ccwc.me" />
-	<target host="www.ccwc.me" />
 	<target host="on.cfr.org" />
 	<target host="cnb.cx" />
-	<target host="www.cnb.cx" />
 	<target host="cnnmon.ie" />
-	<target host="www.cnnmon.ie" />
 	<target host="cs.is" />
 	<target host="curbed.cc" />
-	<target host="www.curbed.cc" />
 	<target host="thebea.st" />
-	<target host="www.thebea.st" />
-	<target host="dico.im" />
-	<target host="dly.do" />
 	<target host="do.co" />
 	<target host="econ.st" />
-	<target host="www.econ.st" />
 	<target host="fxn.ws" />
-	<target host="www.fxn.ws" />
 	<target host="glo.bo" />
-	<target host="www.glo.bo" />
-	<target host="hub.am" />
-	<target host="www.hub.am" />
 	<target host="huff.to" />
-	<target host="www.huff.to" />
 	<target host="ift.tt" />
-	<target host="www.ift.tt" />
 	<target host="ind.pn" />
-	<target host="www.ind.pn" />
-	<target host="iti.ms" />
-	<target host="www.iti.ms" />
 	<target host="jrnl.ie" />
-	<target host="www.jrnl.ie" />
 	<target host="lat.ms" />
-	<target host="mitsmr.com" />
-	<target host="www.mitsmr.com" />
 	<target host="on.msnbc.com" />
 	<target host="mzl.la" />
-	<target host="www.mzl.la" />
 	<target host="n.pr" />
 	<target host="nbcnews.to" />
-	<target host="www.nbcnews.to" />
 	<target host="nym.ag" />
 	<target host="nyti.ms" />
 	<target host="on.mash.to" />
 	<target host="go.nasa.gov" />
 	<target host="nydn.us" />
-	<target host="www.nydn.us" />
-	<target host="sm.ohchr.org" />
 	<target host="to.pbs.org" />
 	<target host="pewrsr.ch" />
-	<target host="www.pewrsr.ch" />
-	<target host="polho.me" />
-	<target host="www.polho.me" />
 	<target host="politi.co" />
-	<target host="www.politi.co" />
-	<target host="propub.ca" />
-	<target host="www.propub.ca" />
 	<target host="rbl.ms" />
-	<target host="www.rbl.ms" />
 	<target host="reut.rs" />
-	<target host="www.reut.rs" />
 	<target host="seati.ms" />
-	<target host="sched.co" />
 	<target host="slate.me" />
-	<target host="specc.ie" />
-	<target host="www.specc.ie" />
 	<target host="stanford.io" />
-	<target host="www.stanford.io" />
-	<target host="sun-tim.es" />
-	<target host="www.sun-tim.es" />
 	<target host="tcrn.ch" />
-	<target host="www.tcrn.ch" />
 	<target host="tek.io" />
-	<target host="www.tek.io" />
 	<target host="theatln.tc" />
 	<target host="ti.me" />
-	<target host="www.ti.me" />
 	<target host="usat.ly" />
 	<target host="wapo.st" />
 	<target host="on.wsj.com" />
 	<target host="ucla.in" />
-	<target host="ubm.io" />
 	<target host="1.usa.gov" />
-	<target host="vrge.co" />
-	<target host="wcas.nu" />
-	<target host="www.wcas.nu" />
-	<target host="wmk.me" />
-	<target host="www.wmk.me" />
 	<target host="zd.net" />
-	<target host="www.zd.net" />
-		<!--
-			$ redirects to custom domain:
-							-->
-		<exclusion pattern="^http://(?:www\.)?(?:7ny\.tv|abcn\.ws|alj\.am|atfp\.co|bloom\.bg|brook\.gs|bzfd\.it|cbsn\.ws|cnb\.cx|cnnmon\.ie|fxn\.ws|glo\.bo|huff\.to|jrnl\.ie|on\.mash\.to|mitsmr\.com|nydn\.us|nym\.ag|politi\.co|reut\.rs|tcrn\.ch|zd\.net)/+(?:$|\?)" />
-		<!--
-			More custom links :(
 
-			https://github.com/EFForg/https-everywhere/issues/835
-
-			bit.ly keys appear to be [\dA-Za-z]{6,7}.
-			Avoid matches that are legibly cased.
-									-->
-		<exclusion pattern="^http://(?:www\.)?mzl\.la/+(?!$|\?|(?:[\dA-Za-z][A-Z][\da-z][A-Z][\dA-Za-z]{2,3}|[\dA-Za-z]{2}[A-Z][\da-z][A-Z][\dA-Za-z]{1,2}|[\dA-Za-z]{3}[A-Z][\da-z][A-Z][\dA-Za-z]?|[\dA-Za-z]{4}[A-Z][\da-z][A-Z]|[\dA-Za-z][a-z][\dA-Z][a-z][\dA-Za-z]{2,3}|[\dA-Za-z]{2}[a-z][A-Z][a-z][\dA-Za-z]{1,2}|[\dA-Za-z]{3}[a-z][A-Z][a-z][\dA-Za-z]?|[\dA-Za-z]{4}[a-z][A-Z][a-z]|[\dA-Za-z][\d][a-z][A-Z][\dA-Za-z]{2,3}|[\dA-Za-z]{2}[\d][A-Z][\d][\dA-Za-z]{1,2}|[\dA-Za-z]{3}[\d][A-Z][\d][\dA-Za-z]?|[\dA-Za-z]{4}[\d][a-z][\d]|20compat|AndrewO|deployed-mdn|DevProgram|devtools|Flame|globalteachin|Lightbeam_AMA|Manana|MediaRecorderAPI|PAMremix|teamweb)(?:$|\?))" />
-
-
-	<!--	First, emulate custom redirection behavior:
-
-		(such behavior appears to be a setting.)
-							-->
-	<!--rule from="^http://(www\.)?7ny\.tv/($|\?.*)"
-		to="https://7online.com/" /-->
-
-	<!--rule from="^http://(www\.)?abcn\.ws/($|\?.*)"
-		to="https://abcradio.com/" /-->
-
-	<!--rule from="^http://(www\.)?alj\.am/($|\?.*)"
-		to="https://america.aljazeera.com/" /-->
-
-	<!--rule from="^http://(www\.)?atfp\.co/($|\?.*)"
-		to="https://www.foreignpolicy.com/" /-->
-
-	<!--rule from="^http://bloom\.bg/+($|\?.*)"
-		to="https://www.bloomberg.com/" /-->
-
-	<!--rule from="^http://(www\.)?brook\.gs/+($|\?.*)"
-		to="https://www.brookings.edu/" /-->
-
-	<rule from="^http://(?:www\.)?buff\.ly/+(?:$|\?.*)"
-		to="https://bufferapp.com/" />
-
-	<!--rule from="^http://(www\.)?bzfd\.it/+($|\?.*)"
-		to="https://buzzfeed.com/" /-->
-
-	<!--rule from="^http://(www\.)?cnnmon\.ie/($|\?.*)"
-		to="https://www.money.cnn.com/" /-->
-
-	<rule from="^http://(?:www\.)?econ\.st/+(?:$|\?.*)"
-		to="https://www.economist.com/" />
-
-	<!--rule from="^http://(www\.)?fxn\.ws/+($|\?.*)"
-		to="https://www.foxnews.com/" /-->
-
-	<!--rule from="^http://(www\.)?huff\.to/+($|\?.*)"
-		to="https://www.huffingtonpost.com/" /-->
-
-	<rule from="^http://(?:www\.)?ift\.tt/+(?:$|\?.*)"
-		to="https://ifttt.com/" />
-
-	<rule from="^http://(?:www\.)?iti\.ms/+(?:$|\?.*)"
-		to="https://www.irishtimes.com/" />
-
-	<!--rule from="^http://on\.mash\.to/+($|\?.*)"
-		to="https://www.mashable.com/" /-->
-
-	<!--rule from="^http://(www\.)?mitsmr\.com/+($|\?.*)"
-		to="https://sloanreview.mit.edu/" /-->
-
-	<rule from="^http://on\.msnbc\.com/+(?:$|\?.*)"
-		to="https://msnbc.com/" />
-
-	<rule from="^http://(?:www\.)?mzl\.la/+(?:$|\?.*)"
-		to="https://www.mozilla.org/" />
-
-	<rule from="^http://(?:www\.)?mzl\.la/+20compat(?:$|\?.*)"
-		to="https://developer.mozilla.org/en-US/docs/Site_Compatibility_for_Firefox_20" />
-
-	<rule from="^http://(?:www\.)?mzl\.la/+AndrewO(?:$|\?.*)"
-		to="https://twitter.com/overholt" />
-
-	<rule from="^http://(?:www\.)?mzl\.la/+deployed-mdn(?:$|\?.*)"
-		to="https://bit.ly/1krjISM" />
-
-	<rule from="^http://(?:www\.)?mzl\.la/+devtools(?:$|\?.*)"
-		to="https://bit.ly/1krjISM" />
-
-	<rule from="^http://(?:www\.)?mzl\.la/+DevProgram(?:$|\?.*)"
-		to="https://developer.mozilla.org/en-US/docs/Mozilla/Developer_Program" />
-
-	<rule from="^http://(?:www\.)?mzl\.la/+Flame(?:$|\?.*)"
-		to="https://developer.mozilla.org/en-US/Firefox_OS/Developer_phone_guide/Flame" />
-
-	<rule from="^http://(?:www\.)?mzl\.la/+globalteachin(?:$|\?.*)"
-		to="https://blog.webmaker.org/net-neutrality" />
-
-	<rule from="^http://(?:www\.)?mzl\.la/+Lightbeam_AMA(?:$|\?.*)"
-		to="https://www.reddit.com/r/IAmA/comments/1pbjtw/we_are_the_mozilla_team_who_have_been_working_on/" />
-
-	<rule from="^http://(?:www\.)?mzl\.la/+Manana(?:$|\?.*)"
-		to="https://blog.mozilla.org/apps/2014-04-09/why-localization-is-important-the-word-from-mana/" />
-
-	<rule from="^http://(?:www\.)?mzl\.la/+MediaRecorderAPI(?:$|\?.*)"
-		to="https://developer.mozilla.org/en-US/docs/Web/API/MediaRecorder_API" />
-
-	<rule from="^http://(?:www\.)?mzl\.la/+PAMremix(?:$|\?.*)"
-		to="https://welcome.webmaker.org/for/pam/" />
-
-	<!--rule from="^http://(www\.)?mzl\.la/+TCAdapter($|\?.*)"
-		to="https://techcrunch.com/2014/09/11/mozilla-launches-experimental-tool-for-cross-browser-debugging/" /-->
-
-	<rule from="^http://(?:www\.)?mzl\.la/+teamweb(?:$|\?.*)"
-		to="https://gear.mozilla.org/collections/apparel/products/mozilla-team-web-tshirt" />
-
-	<rule from="^http://go\.nasa\.gov/+(?:$|\?.*)"
-		to="https://www.nasa.gov/" />
-
-	<rule from="^http://(?:www\.)?nbcnews\.to/+(?:$|\?.*)"
-		to="https://nbcnews.com/" />
-
-	<!--rule from="^http://(www\.)?nydn\.us/+($|\?.*)"
-		to="https://www.newyorkdailynews.com/" /-->
-
-	<!--rule from="^http://nym\.ag/+($|\?.*)"
-		to="https://nymag.com/" /-->
-
-	<rule from="^http://(?:www\.)?polho\.me/+(?:$|\?.*)"
-		to="https://bit.ly/zsHQjo" />
-
-	<!--rule from="^http://(www\.)?politi\.co/+($|\?.*)"
-		to="https://www.politico.com/" /-->
-
-	<rule from="^http://sched\.co/+(?:$|\?.*)"
-		to="https://sched.org/" />
-
-	<rule from="^http://(?:www\.)?stanford\.io/+(?:$|\?.*)"
-		to="https://www.stanford.edu/" />
-
-	<!--rule from="^http://(www\.)?tcrn\.ch/+($|\?.*)"
-		to="https://www.techcrunch.com/" /-->
-
-	<rule from="^http://(?:www\.)?tek\.io/+(?:$|\?.*)"
-		to="https://techrepublic.com/" />
-
-	<rule from="^http://(?:www\.)?thebea\.st/+(?:$|\?.*)"
-		to="https://www.thedailybeast.com/" />
-
-	<rule from="^http://(?:www\.)?ti\.me/+(?:$|\?.*)"
-		to="https://time.com/" />
-
-	<rule from="^http://vrge\.co/+(?:$|\?.*)"
-		to="https://www.theverge.com/" />
-
-	<!--	Domains for which both !www and www
-		exist and both are bit.ly aliases:
-							-->
-	<rule from="^http://(?:www\.)?(?:1tw\.org|7ny\.tv|alj\.am|abcn\.ws|atfp\.co|brook\.gs|buff\.ly|bzfd\.it|cbsn\.ws|ccwc\.me|cnb\.cx|cnnmon\.ie|curbed\.cc|econ\.st|fxn\.ws|glo\.bo|hub\.am|huff\.to|ind\.pn|iti\.ms|ift\.tt|jrnl\.(?:ie|to)|mzl\.la|nbcnews\.to|nydn\.us|pewrsr\.ch|polho\.me|politi\.co|propub\.ca|rbl\.ms|reut\.rs|specc\.ie|stanford\.io|sun-tim\.es|tcrn\.ch|tek\.io|thebea\.st|ti\.me|wcas\.nu|wmk\.me|zd\.net)/"
-		to="https://bit.ly/" />
-
-	<rule from="^http://(?:4mn\.ca|a21\.tv|apne\.ws|bbc\.in|bitly\.is|bloom\.bg|on\.cfr\.org|cs\.is|dico\.im|do\.co|dly\.do|lat\.ms|on\.mash\.to|on\.msnbc\.com|n\.pr|go\.nasa\.gov|nym\.ag|nyti\.ms|sm\.ohchr\.org|to\.pbs\.org|seati\.msslate\.me|theatln\.tc|ucla\.in|ubm\.io|1\.usa\.gov|usat\.ly|vrge\.co|wapo\.st|on\.wsj\.com)/"
-		to="https://bit.ly/" />
+  <rule from="^http:"
+        to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Bit.ly_vanity_domains.xml
+++ b/src/chrome/content/rules/Bit.ly_vanity_domains.xml
@@ -96,4 +96,61 @@
   <rule from="^http:"
         to="https:" />
 
+
+	<!--
+		The following vanity domains that are returning a certificate only valid
+		for bit.ly, but we may add later as a valid cert becomes available.
+		Ref: https://github.com/EFForg/https-everywhere/pull/4099
+
+		1tw.org
+		www.1tw.org
+		4mn.ca
+		www.7ny.tv
+		a21.tv
+		www.abcn.ws
+		www.atfp.co
+		www.brook.gs
+		www.buff.ly
+		www.bzfd.it
+		www.cbsn.ws
+		www.cnb.cx
+		www.cnnmon.ie
+		www.curbed.cc
+		www.thebea.st
+		dly.do
+		www.econ.st
+		www.fxn.ws
+		hub.am
+		www.hub.am
+		www.huff.to
+		www.ift.tt
+		www.ind.pn
+		iti.ms
+		www.iti.ms
+		mitsmr.com
+		www.mitsmr.com
+		www.mzl.la
+		www.nbcnews.to
+		www.nydn.us
+		sm.ohchr.org
+		www.pewrsr.ch
+		www.rbl.ms
+		www.reut.rs
+		specc.ie
+		www.specc.ie
+		www.stanford.io
+		sun-tim.es
+		www.sun-tim.es
+		www.tcrn.ch
+		www.tek.io
+		www.ti.me
+		ubm.io
+		vrge.co
+		wcas.nu
+		www.wcas.nu
+		wmk.me
+		www.wmk.me
+		www.zd.net
+	-->
+
 </ruleset>


### PR DESCRIPTION
I went through the instructions in #4097 so the target domains all have valid https endpoints. It looks like all the rules are snapping redirects, other than the few very particular mzl.la path redirects. Some of those were simply mimicking server redirects that no longer exist, others were very specific paths that are still redirecting. Either way, https://mzl.la and all paths behind it redirect to https endpoints it looks like, so this should no longer be needed.

I also removed the exclusion patterns, as they seem brittle to me. Why should we only redirect bit.ly patterns that we've observed as valid instead of them all? What if they change this pattern? Better to just redirect them all.

I'm not completely sure if I've done everything right here and would appreciate any feedback you have.