### PR TITLE
Check scheme before attempting to rewrite.

### DIFF
--- a/src/chrome/content/code/ApplicableList.js
+++ b/src/chrome/content/code/ApplicableList.js
@@ -73,7 +73,11 @@ ApplicableList.prototype = {
   populate_list: function() {
     // The base URI of the dom tends to be loaded from some /other/
     // ApplicableList, so pretend we're loading it from here.
-    HTTPSEverywhere.instance.https_rules.rewrittenURI(this, this.uri);
+    var uri = this.uri;
+    if (!(uri.schemeIs("http") || uri.schemeIs("https"))) {
+      return true;
+    }
+    HTTPSEverywhere.instance.https_rules.rewrittenURI(this, uri);
     this.log(DBUG, "populating using alist #" + this.serial);
   },
 


### PR DESCRIPTION
This avoids "uri.host is explosive" errors in the logs on URIs like
about:startpage. This check already happens in https-everywhere.js before
calling replaceChannel, but this other path into rewrittenURI wasn't checked
previously.