### PR TITLE
yandex.ru and rutube.ru crossdomain.xml

### DIFF
--- a/src/chrome/content/rules/AdRiver.xml
+++ b/src/chrome/content/rules/AdRiver.xml
@@ -51,6 +51,11 @@
 			<test url="http://content.adriver.ru/?" />
 			<test url="http://content.adriver.ru//" />
 			<test url="http://content.adriver.ru//?" />
+		
+	<!-- Flash-based players fails load ads if detect redirects. It can issue lower video quality on videohostings like on rutube.ru -->
+	<exclusion pattern="^http://ad\.adriver\.ru/crossdomain.xml" />
+	
+		<test url="http://ad.adriver.ru/crossdomain.xml" />
 
 
 	<!--	Not secured by server:

--- a/src/chrome/content/rules/Mail.ru.xml
+++ b/src/chrome/content/rules/Mail.ru.xml
@@ -326,6 +326,11 @@
 			<!--	-ve:
 					-->
 			<test url="http://go.mail.ru/static/web/img/opera_bookmark/sd_search_img.png" />
+			
+		<!-- Flash-based players fails load ads if detect redirects. It can issue lower video quality on videohostings like on rutube.ru -->
+		<exclusion pattern="^http://ad\.mail\.ru/crossdomain.xml" />
+	
+		<test url="http://ad.mail.ru/crossdomain.xml" />
 
 		<test url="http://avt-1.foto.mail.ru/" />
 		<test url="http://avt-10.foto.mail.ru/" />

--- a/src/chrome/content/rules/Yandex.net.xml
+++ b/src/chrome/content/rules/Yandex.net.xml
@@ -21,7 +21,6 @@
 		- img.encyc *
 		- vec0[1-4].maps ⁴
 		- static.video ⁵
-		- st.kp 6
 
 	¹ 404
 	² Mismatched
@@ -30,7 +29,6 @@
 	* Mismatched, CN: yastatic.net
 	⁴ Unspecified effect[?]
 	⁵ Apparently breaks video
-	6 Breaks charts on kinopoisk
 
 
 	Fully covered subdomains:
@@ -84,6 +82,7 @@
 			- img
 			- img[1-7]-fotki
 			- imgl
+			- st.kp
 			- audio.lingvo
 			- webattach.mail
 			- mailstatic
@@ -182,9 +181,11 @@
 		<!--
 			Needed for kinopoisk charts to work:
 								-->
-		<exclusion pattern="^http://st\.kp\.yandex\.net/" />
+		<exclusion pattern="^http://st\.kp\.yandex\.net/crossdomain\.xml" />
+		<exclusion pattern="^http://st\.kp\.yandex\.net/shab/chart_settings/" />
 
-			<test url="http://st.kp.yandex.net/" />
+			<test url="http://st.kp.yandex.net/crossdomain.xml" />
+			<test url="http://st.kp.yandex.net/shab/chart_settings/votes_graph_settings.xml" />
 
 		<!--
 			Miscellaneous:
@@ -232,6 +233,7 @@
 		<test url="http://img.yandex.net/" />
 		<test url="http://img1-fotki.yandex.net/" />
 		<test url="http://imgl.yandex.net/" />
+		<test url="http://st.kp.yandex.net/" />
 		<test url="http://audio.lingvo.yandex.net/" />
 		<test url="http://webattach.mail.yandex.net/" />
 		<test url="http://mailstatic.yandex.net/" />


### PR DESCRIPTION
I reverted "Fix kp charts" commit e000988a399cc00fe39ef61fd955c8d7f7fad865 in favour of more specific kinopoisk charts fix that does not unencrypt whole `st.kp.yandex.net` domain. Revert commit also include similar fix for rutube.ru.