### PR TITLE
[Codecademy.com] Add subdomain

### DIFF
--- a/src/chrome/content/rules/Codecademy.com.xml
+++ b/src/chrome/content/rules/Codecademy.com.xml
@@ -1,13 +1,12 @@
 <!--
-    Nonfunctional subdomains:
-	    - discuss       -> times out
-	    - discuss-cdn   -> tims out
+
 -->
 <ruleset name="Codecademy.com">
     <target host="codecademy.com" />
     <target host="www.codecademy.com" />
+    <target host="discuss.codecademy.com" />
 
-    <securecookie host="^(www\.)?codecademy\.com$" name=".+" />
+    <securecookie host="^(www\.|discuss\.)?codecademy\.com$" name=".+" />
 
     <rule from="^http:"
             to="https:" />


### PR DESCRIPTION
As [said in the forum](https://discuss.codecademy.com/t/suggestion-https-on-subdomains/7935/10?u=rugk) the discuss subdomain now also supports HTTPS.
The discuss-cdn subdomain does not seem to be used anymore.