### PR TITLE
[downgrade-whitelist] Remove ruleset that no longer have downgrade.

### DIFF
--- a/utils/downgrade-whitelist.txt
+++ b/utils/downgrade-whitelist.txt
@@ -7,11 +7,8 @@ dafont.com (partial)
 dict.cc
 EvoTronix (partial)
 Fourmilab (partial)
-Gigya (partial)
-GO.com (partial)
 IBTimes.co.uk
 ImageShack (partial)
-Jabber.ru (partial)
 Lenovo (partial)
 Link+ Catalog
 Marktplaats (buggy)
@@ -20,9 +17,7 @@ NewsBlur
 Nextag (self-signed)
 NYTimes.com (needs ruleset tests)
 Oak Ridge National Laboratory (partial)
-Phoronix.com (partial)
 SRG SSR (partial)
 Stack Exchange (partial)
 University of Alaska Anchorage (partial)
 Visa (partial)
-xxxbunker.com (partial)


### PR DESCRIPTION
Downgrade rule has been removed from following rules (with corresponding commit):
Gigya (partial) ea881c383e819900bc8a2499243f540ba65c5443
GO.com (partial) 3f534ac0474c2de417082402d69d71331a166e74
Jabber.ru (partial) c97d1fda0a8329b3648ad998479a226918dbb451
Phoronix.com (partial) 666c4112fb8a723243203fcee9d37ec0bd737694
xxxbunker.com (partial) 96c87f3158c860f6752c67fdcaa83c4abac87b4e