### PR TITLE
Remove special travis notifications section.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,13 +34,3 @@ script:
   - ./test.sh
 sudo: required
 dist: trusty
-notifications:
-  email:
-    recipients:
-      - jsha@eff.org
-  notifications:
-    irc:
-      channels:
-        - "irc.oftc.net#https-everywhere"
-      on_success: change
-      on_failure: change


### PR DESCRIPTION
Too spammy: With the old config I'd get notifications of others' build failures.