### PR TITLE
[GoogleAPIs] Add ct.googleapis.com

### DIFF
--- a/src/chrome/content/rules/GoogleAPIs.xml
+++ b/src/chrome/content/rules/GoogleAPIs.xml
@@ -87,6 +87,7 @@
 		<!-- The implicit test URL at the root of this domain generates a 404.
 				 Add an exclusion so the fetcher is happy. -->
 		<exclusion pattern="^http://chart\.googleapis\.com/$" />
+	<target host="ct.googleapis.com" />
 	<target host="fonts.googleapis.com" />
 	<target host="www.googleapis.com" />
 	<target host="*.commondatastorage.googleapis.com" />
@@ -117,9 +118,10 @@
 	<rule from="^http://(click|ssl|www)\.google-analytics\.com/"
 		to="https://$1.google-analytics.com/" />
 
-	<rule from="^http://(ajax|chart|fonts|www)\.googleapis\.com/"
+	<rule from="^http://(ajax|chart|ct|fonts|www)\.googleapis\.com/"
 		to="https://$1.googleapis.com/" />
 		<test url="http://ajax.googleapis.com/ajax/libs/angular_material/0.8.2/angular-material.min.js" />
+		<test url="http://ct.googleapis.com/aviator/ct/v1/get-entries?start=0&amp;end=1" />
 		<test url="http://chart.googleapis.com/chart?cht=p3&amp;chs=250x100&amp;chd=t:60,40&amp;chl=Hello|World" />
 		<test url="http://fonts.googleapis.com/css?family=Tangerine" />
 


### PR DESCRIPTION
The 404s in the folder roots look a bit different over HTTP and HTTPS, but according to https://tools.ietf.org/html/rfc6962#section-4, all CT logs are to be served over HTTPS, so as far as the actual logs are concerned, this should be alright.