### PR TITLE
[localphone.com] Add sites owned by Localphone Ltd.

### DIFF
--- a/src/chrome/content/rules/localphone.com.xml
+++ b/src/chrome/content/rules/localphone.com.xml
@@ -6,13 +6,28 @@
 	* Shows another domain
 
 -->
-<ruleset name="Localphone.com (partial)">
+<ruleset name="Localphone.com (partial) and related sites">
 
 	<!--	Direct rewrites:
 				-->
 	<target host="localphone.com" />
+	<target host="m.localphone.com" />
 	<target host="static.localphone.com" />
 	<target host="www.localphone.com" />
+
+
+	<!--  Sites owned by Localphone Ltd.:
+				-->
+	<target host="0800buster.co.uk" />
+	<target host="www.0800buster.co.uk" />
+	<target host="freecallscanada.co.uk" />
+	<target host="www.freecallscanada.co.uk" />
+	<target host="freecallstosingapore.co.uk" />
+	<target host="www.freecallstosingapore.co.uk" />
+	<target host="freecallstousa.co.uk" />
+	<target host="www.freecallstousa.co.uk" />
+
+	<securecookie host="^(www\.)?freecalls(canada|to(singapore|usa))\.co\.uk$" name=".+" />
 
 
 	<rule from="^http:"


### PR DESCRIPTION
Add rule for missing sub-domain:
- https://m.localphone.com/

Add rules for other Localphone-owned sites:
- https://www.0800buster.co.uk/
- https://www.freecallscanada.co.uk/
- https://www.freecallstosingapore.co.uk/
- https://www.freecallstousa.co.uk/