### PR TITLE
Fixes for Firefox Developer Edition (resolves #4195)

### DIFF
--- a/src/chrome/content/toolbar_button.js
+++ b/src/chrome/content/toolbar_button.js
@@ -396,6 +396,10 @@ function open_in_tab(url) {
   recentWindow.delayedOpenTab(url, null, null, null, null);
 }
 
+function httpse_chrome_opener(url, prefs) {
+  HTTPSEverywhere.chrome_opener(url, prefs);
+}
+
 // hook event for showing hint
 HTTPSEverywhere.log(DBUG, 'Adding listener for toolbarButton init.');
 window.addEventListener("load", httpsEverywhere.toolbarButton.init, false);

--- a/src/chrome/content/toolbar_button.xul
+++ b/src/chrome/content/toolbar_button.xul
@@ -68,9 +68,9 @@
     <command id="https-everywhere-menuitem-viewAllRules"
       oncommand="open_in_tab('https://www.eff.org/https-everywhere/atlas/');" />
     <command id="https-everywhere-menuitem-about"
-      oncommand="HTTPSEverywhere.chrome_opener('chrome://https-everywhere/content/about.xul');" />
+      oncommand="httpse_chrome_opener('chrome://https-everywhere/content/about.xul');" />
     <command id="https-everywhere-menuitem-observatory"
-      oncommand="HTTPSEverywhere.chrome_opener('chrome://https-everywhere/content/observatory-preferences.xul', 'chrome,centerscreen,resizable=yes');" />
+      oncommand="httpse_chrome_opener('chrome://https-everywhere/content/observatory-preferences.xul', 'chrome,centerscreen,resizable=yes');" />
     <command id="https-everywhere-menuitem-donate-eff"
       oncommand="open_in_tab('https://www.eff.org/donate');" />
     <command id="https-everywhere-menuitem-donate-tor"

--- a/src/components/ssl-observatory.js
+++ b/src/components/ssl-observatory.js
@@ -313,7 +313,12 @@ SSLObservatory.prototype = {
     function toHexString(charCode) {
       return ("0" + charCode.toString(16)).slice(-2);
     }
-    return [toHexString(h.charCodeAt(i)) for (i in h)].join("").toUpperCase();
+
+    var hexArr = [];
+    for (i in h){
+      hexArr.push(toHexString(h.charCodeAt(i)));
+    }
+    return hexArr.join("").toUpperCase();
   },
 
   ourFingerprint: function(cert) {


### PR DESCRIPTION
1. Refactor js one-liner to allow ssl observatory component to load
2. HTTPSEverywhere object can no longer be refernced directly from
   toolbar xul