### PR TITLE
Init new URLs with default-port of 443, not 80

### DIFF
--- a/src/chrome/content/code/HTTPSRules.js
+++ b/src/chrome/content/code/HTTPSRules.js
@@ -160,7 +160,7 @@ RuleSet.prototype = {
       return null;
     var newuri = Components.classes["@mozilla.org/network/standard-url;1"].
                  createInstance(CI.nsIStandardURL);
-    newuri.init(CI.nsIStandardURL.URLTYPE_STANDARD, 80,
+    newuri.init(CI.nsIStandardURL.URLTYPE_STANDARD, 443,
              newurl, uri.originCharset, null);
     newuri = newuri.QueryInterface(CI.nsIURI);
     return newuri;


### PR DESCRIPTION
This fixes #4220 and https://bugzilla.mozilla.org/show_bug.cgi?id=1250770 (breakage with buttons on embedded http YouTube videos).

We could also do something fancy like testing `newurl` (the string) to see if it starts with "https" vs. "http", and choosing the default port we pass based on that. However, since we are HTTPS Everywhere, we should be pretty sure that the new URI will be HTTPS, so using 443 as our default port seems like a pretty good bet.
