### PR TITLE
Recreate Deepin related ruleset.

### DIFF
--- a/src/chrome/content/rules/Deepin.xml
+++ b/src/chrome/content/rules/Deepin.xml
@@ -1,6 +1,8 @@
 <ruleset name="Deepin (partial)">
     <!-- Deepin.com -->
     <target host="www.deepin.com" />
+    <!-- Redirects to www subdomain -->
+    <target host="deepin.com" />
     <!-- Redirects to *.linuxdeepin.com: -->
     <target host="packages.deepin.com" />
     <target host="cdimage.deepin.com" />
@@ -11,25 +13,29 @@
     <target host="blog.deepin.org" />
     <target host="api.deepin.org" />
     <target host="account.deepin.org" />
+    <!-- Redirects to www subdomain -->
+    <target host="deepin.org" />
     <!-- Redirects to *.linuxdeepin.com: -->
     <target host="packages.deepin.org" />
     
     <!-- Linuxdeepin.com -->
     <target host="img1.linuxdeepin.com" />
     <target host="img2.linuxdeepin.com" />
+    <target host="img3.linuxdeepin.com" />
     <target host="packages.linuxdeepin.com" />
     <target host="cdimage.linuxdeepin.com" />
     
     <!-- Redirects to *.linuxdeepin.com -->
     <rule from="^http://(packages|cdimage)\.deepin\.com/" to="https://$1.linuxdeepin.com/" />
     <rule from="^http://(packages)\.deepin\.org/" to="https://$1.linuxdeepin.com/" />
+    <!-- Redirects to www subdomain -->
+    <rule from="^http://deepin\.(org|com)/" to="https://www.deepin.$1/" />
     <!-- Redirects directly to HTTPS -->
     <rule from="^http:" to="https:" />
     
     <!--
     Mismatch:
     wiki.deepin.org
-    blog.deepin.org
     feedback.deepin.org
 
     old.linuxdeepin.com

--- a/src/chrome/content/rules/Deepin.xml
+++ b/src/chrome/content/rules/Deepin.xml
@@ -1,0 +1,49 @@
+<ruleset name="Deepin (partial)">
+    <!-- Deepin.com -->
+    <target host="www.deepin.com" />
+    <!-- Redirects to *.linuxdeepin.com: -->
+    <target host="packages.deepin.com" />
+    <target host="cdimage.deepin.com" />
+    
+    <!-- Deepin.org -->
+    <target host="www.deepin.org" />
+    <target host="bbs.deepin.org" />
+    <target host="blog.deepin.org" />
+    <target host="api.deepin.org" />
+    <target host="account.deepin.org" />
+    <!-- Redirects to *.linuxdeepin.com: -->
+    <target host="packages.deepin.org" />
+    
+    <!-- Linuxdeepin.com -->
+    <target host="img1.linuxdeepin.com" />
+    <target host="img2.linuxdeepin.com" />
+    <target host="packages.linuxdeepin.com" />
+    <target host="cdimage.linuxdeepin.com" />
+    
+    <!-- Redirects to *.linuxdeepin.com -->
+    <rule from="^http://(packages|cdimage)\.deepin\.com" to="https://$1.linuxdeepin.com" />
+    <rule from="^http://(packages)\.deepin\.org" to="https://$1.linuxdeepin.com" />
+    <!-- Redirects directly to HTTPS -->
+    <rule from="^http:" to="https:" />
+    
+    <!--
+    Mismatch:
+    wiki.deepin.org
+    blog.deepin.org
+    feedback.deepin.org
+
+    old.linuxdeepin.com
+    (www.)linuxdeepin.com
+    mantis.linuxdeepin.com
+    wiki.linuxdeepin.com
+    start.linuxdeepin.com
+    u.linuxdeepin.com
+    beta.linuxdeepin.com
+    mail.linuxdeepin.com
+
+    Timeout:
+    rsync.linuxdeepin.com
+    
+    Many thanks to J0WI.
+    -->
+</ruleset>

--- a/src/chrome/content/rules/Deepin.xml
+++ b/src/chrome/content/rules/Deepin.xml
@@ -21,8 +21,8 @@
     <target host="cdimage.linuxdeepin.com" />
     
     <!-- Redirects to *.linuxdeepin.com -->
-    <rule from="^http://(packages|cdimage)\.deepin\.com" to="https://$1.linuxdeepin.com" />
-    <rule from="^http://(packages)\.deepin\.org" to="https://$1.linuxdeepin.com" />
+    <rule from="^http://(packages|cdimage)\.deepin\.com/" to="https://$1.linuxdeepin.com/" />
+    <rule from="^http://(packages)\.deepin\.org/" to="https://$1.linuxdeepin.com/" />
     <!-- Redirects directly to HTTPS -->
     <rule from="^http:" to="https:" />
     


### PR DESCRIPTION
Including "*.deepin.com", "*.deepin.org" and "*.linuxdeepin.com" domains.