### PR TITLE
Update Webtrh.cz.xml

### DIFF
--- a/src/chrome/content/rules/Webtrh.cz.xml
+++ b/src/chrome/content/rules/Webtrh.cz.xml
@@ -4,8 +4,6 @@
 
     <test url="http://www.webtrh.cz/" />
 
-    <rule from="^http://www\.webtrh\.cz/"
-            to="https://webtrh.cz/" />
     <rule from="^http:"
             to="https:" />
 </ruleset>


### PR DESCRIPTION
http(s)://www.webtrh.cz/ and http(s)://webtrh.cz/ are different websites, and rewriting one domain to another breaks links.

For example, http://www.webtrh.cz/rychlost is a valid URL that gets redirected to also valid https://www.webtrh.cz/rychlost by the website itself, but HTTPS Everywhere breaks it by rewriting to https://webtrh.cz/rychlost instead, which is invalid.