### PR TITLE
Stub all log types to execute other methods in Node.js

### DIFF
--- a/chromium/rules.js
+++ b/chromium/rules.js
@@ -1,6 +1,10 @@
 "use strict";
 // Stubs so this runs under nodejs. They get overwritten later by util.js
-var DBUG = 1;
+var VERB=1;
+var DBUG=2;
+var INFO=3;
+var NOTE=4;
+var WARN=5;
 function log(){}
 
 // To reduce memory usage for the numerous rules/cookies with trivial rules


### PR DESCRIPTION
I'm running `addUserRule` in Node.js which fails due to `INFO` not being defined, and I noticed that other methods use various log types as well, so decided to fix altogether.