### PR TITLE
Remove Bothar.xml

### DIFF
--- a/src/chrome/content/rules/Bothar.xml
+++ b/src/chrome/content/rules/Bothar.xml
@@ -1,6 +1,0 @@
-<ruleset name="Bothar">
-  <target host="www.bothar.ie" />
-  <target host="bothar.ie" />
-
-  <rule from="^http:" to="https:"/>
-</ruleset>

--- a/src/chrome/content/rules/Bothar.xml
+++ b/src/chrome/content/rules/Bothar.xml
@@ -2,5 +2,5 @@
   <target host="www.bothar.ie" />
   <target host="bothar.ie" />
 
-  <rule from="^http://(?:www\.)?bothar\.ie/" to="https://$1bothar.ie/"/>
+  <rule from="^http://(www\.)?bothar\.ie/" to="https://$1bothar.ie/"/>
 </ruleset>

--- a/src/chrome/content/rules/Bothar.xml
+++ b/src/chrome/content/rules/Bothar.xml
@@ -2,5 +2,5 @@
   <target host="www.bothar.ie" />
   <target host="bothar.ie" />
 
-  <rule from="^http://(www\.)?bothar\.ie/" to="https://$1bothar.ie/"/>
+  <rule from="^http:" to="https:"/>
 </ruleset>


### PR DESCRIPTION
Using lookahead with substitution causes `$1` to appear in the end URL:

```javascript
> 'http://bothar.ie/'.replace(new RegExp('^http://(?:www\.)?bothar\.ie/'), "https://$1bothar.ie/")
"https://$1bothar.ie/"
```

Same problem as older #2980.