### PR TITLE
Fix invalid RegExp in Waffles.fm.xml

### DIFF
--- a/src/chrome/content/rules/Waffles.fm.xml
+++ b/src/chrome/content/rules/Waffles.fm.xml
@@ -9,5 +9,5 @@
 <ruleset name="Waffles.fm">
 	<target host="waffles.fm" />
 	<target host="www.waffles.fm" />
-	<rule from="^http://www\.waffles\.fm/" to="https://$1waffles.fm/"/>
+	<rule from="^http:" to="https:"/>
 </ruleset>


### PR DESCRIPTION
Same problem as #4299, #4300, #2980.
Also simplifies the rule to trivial one.