### PR TITLE
simplified and fixed Viacom.xml

### DIFF
--- a/src/chrome/content/rules/Viacom.xml
+++ b/src/chrome/content/rules/Viacom.xml
@@ -5,21 +5,13 @@
 		- gameservices.mtvn.com		(Akamai; 503)
 		- www.viacom.com		(Akamai; 401)
 
+		- api.mtvnn.com			(breaks videos on MTV)
 -->
 <ruleset name="Viacom">
-
 	<target host="secure.iphone.mtvn.com" />
-	<target host="*.mtvnn.com" />
+	<target host="specials.mtvnn.com" />
+	<target host="videos.mtvnn.com" />
 	<target host="btg.mtvnservices.com" />
 
-
-	<rule from="^http://secure\.iphone\.mtvn\.com/"
-		to="https://secure.iphone.mtvn.com/" />
-
-	<rule from="^http://(api|specials|videos)\.mtvnn\.com/"
-		to="https://$1.mtvnn.com/" />
-
-	<rule from="^http://btg\.mtvnservices\.com/"
-		to="https://btg.mtvnservices.com/" />
-
+	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Viacom.xml
+++ b/src/chrome/content/rules/Viacom.xml
@@ -27,4 +27,5 @@
 
 	<rule from="^http:" to="https:" />
 	<exclusion pattern="http://api.mtvnn.com/v2/mrss" /> <!-- needed for videos to load on http://www.mtv.de/charts/5-hitlist-germany-top-100 -->
+	<test url="http://api.mtvnn.com/v2/mrss" />
 </ruleset>

--- a/src/chrome/content/rules/Viacom.xml
+++ b/src/chrome/content/rules/Viacom.xml
@@ -1,17 +1,30 @@
 <!--
-	Nonfunctional domains:
+	Problematic subdomains (mismatch):
+		- intl.esperanto.mtvi.com
+		- bcgames.mtvnn.com
+		- games.mtvnn.com
+		- hold.mtvnn.com
+		- images.mtvnn.com
+		- ops.mtvnn.com
+		- pm7.mtvnn.com
+		- web1.mtvnn.com
+		- www.viacom.com
 
-		- intl.esperanto.mtvi.com	(Akamai; different data)
-		- gameservices.mtvn.com		(Akamai; 503)
-		- www.viacom.com		(Akamai; 401)
-
-		- api.mtvnn.com			(breaks videos on MTV)
+	Problematic subdomains (not working):
+		- gameservices.mtvn.com
+		- jerseyshore.mtvnn.com
+		- watasu.mtvnn.com
+		- mtvplay.tv
+		- www.mtvplay.tv
 -->
 <ruleset name="Viacom">
 	<target host="secure.iphone.mtvn.com" />
+	<target host="api.mtvnn.com" />
 	<target host="specials.mtvnn.com" />
+	<target host="utt.mtvnn.com" />
 	<target host="videos.mtvnn.com" />
 	<target host="btg.mtvnservices.com" />
 
 	<rule from="^http:" to="https:" />
+	<exclusion pattern="http://api.mtvnn.com/v2/mrss" /> <!-- needed for videos to load on http://www.mtv.de/charts/5-hitlist-germany-top-100 -->
 </ruleset>


### PR DESCRIPTION
api.mtvnn.com prevented videos from loading here:
http://www.mtv.de/charts/5-hitlist-germany-top-100

This site might be geoblocked in other countries, just like the US version is geoblocked for me, so I can't check this. Apart from that I simplified the rewrites.