### PR TITLE
Fix invalid RegExp in portsmouth.gov.uk.xml

### DIFF
--- a/src/chrome/content/rules/portsmouth.gov.uk.xml
+++ b/src/chrome/content/rules/portsmouth.gov.uk.xml
@@ -90,7 +90,7 @@
 	<securecookie host="^\w" name="." />
 
 
-	<rule from="^http://www\.(?:emas|jsna|mediastore)\.portsmouth\.gov\.uk/"
+	<rule from="^http://www\.(emas|jsna|mediastore)\.portsmouth\.gov\.uk/"
 		to="https://$1.portsmouth.gov.uk/" />
 
 	<rule from="^http:"


### PR DESCRIPTION
Same problem as #4302, #4301, #4300,  #4299, #2980.