### PR TITLE
Fix failing ruleset tests.

### DIFF
--- a/src/chrome/content/rules/yell.com.xml
+++ b/src/chrome/content/rules/yell.com.xml
@@ -77,17 +77,13 @@
 
 	<!--	Redirects to http first:
 					-->
-	<rule from="^http://marketing\.yell\.com/+$"
+	<rule from="^http://marketing\.yell\.com/$"
 		to="https://business.yell.com/" />
 
 		<!--	There be faulty regex somewhere
 			in the coverage checker...
 							-->
-		<test url="http://marketing.yell.com//" />
-		<!--test url="http://marketing.yell.com///" /-->
-		<!--test url="http://marketing.yell.com////" /-->
-		<!--test url="http://marketing.yell.com/////" /-->
-		<!--test url="http://marketing.yell.com//////" /-->
+		<test url="http://marketing.yell.com/" />
 
 	<rule from="^http:"
 		to="https:" />


### PR DESCRIPTION
@loveithateit: The ruleset check was not broken, but was finding a real problem
with the ruleset: URLs like "http://marketing.yell.com///" don't get rewritten
by the rule you were adding tests to, because they get caught by the exclusion.
I've fixed the rule to only apply to the root URL, but please double check that
this matches your intention.

cc @cooperq for code review.