### PR TITLE
Allow requests to hidden services with HTTP Nowhere

### DIFF
--- a/src/chrome/content/code/HTTPS.js
+++ b/src/chrome/content/code/HTTPS.js
@@ -43,8 +43,8 @@ const HTTPS = {
     var isSTS = securityService.isSecureURI(
         CI.nsISiteSecurityService.HEADER_HSTS, channel.URI, 0);
     if (blob === null) {
-      // Abort insecure requests if HTTP Nowhere is on
-      if (httpNowhereEnabled && channel.URI.schemeIs("http") && !isSTS) {
+      // Abort insecure non-onion requests if HTTP Nowhere is on
+      if (httpNowhereEnabled && channel.URI.schemeIs("http") && !isSTS && !/\.onion$/.test(channel.URI.host)) {
         IOUtil.abort(channel);
       }
       return false; // no rewrite

--- a/src/chrome/content/toolbar_button.xul
+++ b/src/chrome/content/toolbar_button.xul
@@ -47,7 +47,7 @@
           command="https-everywhere-menuitem-resetToDefaults" class="hide-on-disable"/>
         <menuitem label="&https-everywhere.menu.viewAllRules;"
           command="https-everywhere-menuitem-viewAllRules" class="hide-on-disable" />
-        <menuitem type="checkbox" id="http-nowhere-item" label="&https-everywhere.menu.blockHttpRequests;" 
+        <menuitem type="checkbox" id="http-nowhere-item" label="&https-everywhere.menu.blockUnencryptedRequests;" 
           oncommand="httpsEverywhere.toolbarButton.toggleHttpNowhere()" class="hide-on-disable"/>
         <menuseparator class="hide-on-disable"/>
         <menuitem type="checkbox" id="https-everywhere-counter-item" label="&https-everywhere.menu.showCounter;" 

--- a/src/chrome/locale/en/https-everywhere.dtd
+++ b/src/chrome/locale/en/https-everywhere.dtd
@@ -19,7 +19,7 @@
 <!ENTITY https-everywhere.menu.observatory "SSL Observatory Preferences">
 <!ENTITY https-everywhere.menu.globalEnable "Enable HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.globalDisable "Disable HTTPS Everywhere">
-<!ENTITY https-everywhere.menu.blockHttpRequests "Block all HTTP requests">
+<!ENTITY https-everywhere.menu.blockHttpRequests "Block all unencrypted requests">
 <!ENTITY https-everywhere.menu.showCounter "Show Counter">
 <!ENTITY https-everywhere.menu.viewAllRules "View All Rules">
 

--- a/src/chrome/locale/en/https-everywhere.dtd
+++ b/src/chrome/locale/en/https-everywhere.dtd
@@ -19,7 +19,7 @@
 <!ENTITY https-everywhere.menu.observatory "SSL Observatory Preferences">
 <!ENTITY https-everywhere.menu.globalEnable "Enable HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.globalDisable "Disable HTTPS Everywhere">
-<!ENTITY https-everywhere.menu.blockHttpRequests "Block all unencrypted requests">
+<!ENTITY https-everywhere.menu.blockUnencryptedRequests "Block all unencrypted requests">
 <!ENTITY https-everywhere.menu.showCounter "Show Counter">
 <!ENTITY https-everywhere.menu.viewAllRules "View All Rules">
 


### PR DESCRIPTION
This excludes .onion hostnames from the main HTTP Nowhere request block. It also updates the HTTP Nowhere label to reflect the change (but perhaps a better wording exists?).

The change is tested in Tor Browser 5.5.3 in which it does what is intended.

This fixes https://github.com/EFForg/https-everywhere/issues/4118

Note: Since this changes the name of a i18n string, a pull of the PR needs to be synced with the translations submodule.