### PR TITLE
[Booking.com] Exclude broken subdomain

### DIFF
--- a/src/chrome/content/rules/Booking.com.xml
+++ b/src/chrome/content/rules/Booking.com.xml
@@ -1,4 +1,11 @@
 <!--
+
+	Problematic domains:
+
+		- blog.booking.com ¹
+
+	¹: Timeout
+
 	For other Booking.com rulesets, see :
 
 		Villas.com.xml
@@ -12,6 +19,7 @@
 
 	<securecookie host="^(\.[\w\-]+)?\.booking\.com$" name=".+" />
 
+	<exclusion pattern="^http://blog\.booking\.com" />
 
 	<rule from="^http://([\w\-]+\.)?booking\.com/"
 		to="https://$1booking.com/" />

--- a/src/chrome/content/rules/Booking.com.xml
+++ b/src/chrome/content/rules/Booking.com.xml
@@ -21,6 +21,8 @@
 
 	<exclusion pattern="^http://blog\.booking\.com" />
 
+		<test url="http://blog.booking.com/" />
+
 	<rule from="^http://([\w\-]+\.)?booking\.com/"
 		to="https://$1booking.com/" />
 


### PR DESCRIPTION
This explicitly excludes the subdomain blog.booking.com, which currently times out. In particular, this fixes https://github.com/EFForg/https-everywhere/issues/4350.