### PR TITLE
Rename webchat.oftc.net to OFTC.net and add new hosts

### DIFF
--- a/src/chrome/content/rules/OFTC.net.xml
+++ b/src/chrome/content/rules/OFTC.net.xml
@@ -1,9 +1,11 @@
 <!--
 	Problematic hosts:
 
-		- oftc.net *
+		- oftc.net ¹
+		- git.oftc.net ²
 
-	* Mismatched, CN: www.oftc.net
+	¹ Mismatched, CN: www.oftc.net
+	² Mismatched, CN: webchat.oftc.net; shows webchat.oftc.net
 -->
 <ruleset name="OFTC.net">
 

--- a/src/chrome/content/rules/OFTC.net.xml
+++ b/src/chrome/content/rules/OFTC.net.xml
@@ -1,0 +1,20 @@
+<!--
+	Problematic hosts:
+
+		- oftc.net *
+
+	* Mismatched, CN: www.oftc.net
+-->
+<ruleset name="OFTC.net">
+
+	<target host="oftc.net" />
+	<target host="webchat.oftc.net" />
+	<target host="www.oftc.net" />
+
+	<rule from="^http://oftc\.net/"
+		to="https://www.oftc.net/" />
+
+	<rule from="^http:"
+		to="https:" />
+
+</ruleset>

--- a/src/chrome/content/rules/webchat.oftc.net.xml
+++ b/src/chrome/content/rules/webchat.oftc.net.xml
@@ -1,5 +1,0 @@
-<ruleset name="OFTC Webchat">
-  <target host="webchat.oftc.net" />
-
-  <rule from="^http://webchat\.oftc\.net/" to="https://webchat.oftc.net/"/>
-</ruleset>


### PR DESCRIPTION
* Rename **webchat.oftc.net** ruleset to **OFTC.net**.
* Add `oftc.net` and `www.oftc.net`.
* `https://oftc.net/` has a mismatched certificate for `www.oftc.net`, but serves an HTTP redirect to `www.oftc.net` anyway.