### PR TITLE
Include certain second-level booking.com subdomains

### DIFF
--- a/src/chrome/content/rules/Booking.com.xml
+++ b/src/chrome/content/rules/Booking.com.xml
@@ -23,7 +23,7 @@
 
 		<test url="http://blog.booking.com/" />
 
-	<rule from="^http://([\w\-]+\.)?booking\.com/"
+	<rule from="^http://([\w\-]+\.([\w\-]{1,3}\.)?)?booking\.com/"
 		to="https://$1booking.com/" />
 
 	<test url="http://www.booking.com/" />


### PR DESCRIPTION
Some (but not all) of these subdomains should be moved
to HTTPS such that the <securecookie> rule does not
block them from setting cookies at the first level.