### PR TITLE
[Transport for London] Exclude subdomain content

### DIFF
--- a/src/chrome/content/rules/Transport_for_London.xml
+++ b/src/chrome/content/rules/Transport_for_London.xml
@@ -16,11 +16,12 @@
 	<target host="tfl.gov.uk" />
 	<target host="*.tfl.gov.uk" />
 
-		<exclusion pattern="^http://(?:art|blog|countdown|cyclestories|info|cisitorshop)\.tfl\.gov\.uk/" />
+		<exclusion pattern="^http://(?:art|blog|content|countdown|cyclestories|info|cisitorshop)\.tfl\.gov\.uk/" />
 
 			<test url="http://art.tfl.gov.uk/" />
 			<test url="http://art.tfl.gov.uk/contact/" />
 			<test url="http://blog.tfl.gov.uk/house-rules/" />
+			<test url="http://content.tfl.gov.uk/" />
 			<test url="http://countdown.tfl.gov.uk/MyStops/" />
 			<test url="http://cyclestories.tfl.gov.uk/cyclists-beth.shtml" />
 			<test url="http://info.tfl.gov.uk/licenses/aboutEcm.jsp" />


### PR DESCRIPTION
This fixes https://github.com/EFForg/https-everywhere/issues/4390