### PR TITLE
add rule for Volksverschlüsselung

### DIFF
--- a/src/chrome/content/rules/Volksverschluesselung.xml
+++ b/src/chrome/content/rules/Volksverschluesselung.xml
@@ -1,0 +1,10 @@
+<ruleset name="Volksverschlüsselung" >
+
+	<target host="volksverschluesselung.sit.fraunhofer.de" />
+	<target host="volksverschluesselung.de" />
+	<target host="www.volksverschluesselung.de" />
+
+	<rule from="^http:"
+		to="https:" />
+
+</ruleset>


### PR DESCRIPTION
HSTS header is set for the domain , so preloading it might also be worth a shot.
