### PR TITLE
Delete old ruleset databases in 'make' and 'make clean'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ pkg:
 clean:
 	rm -rf pkg/xpi-amo/ pkg/xpi-eff/
 	rm -f pkg/*.xpi
+	rm -f pkg/rulesets.unvalidated.sqlite
 	rm -f src/chrome/content/rules/default.rulesets
+	rm -f src/defaults/rulesets.sqlite
 
 .PHONY: clean prerelease

--- a/makecrx.sh
+++ b/makecrx.sh
@@ -20,7 +20,7 @@
 # releases signed by EFF :/.  We should find a more elegant arrangement.
 
 cd $(dirname $0)
-RULESETS_JSON="$PWD/pkg/rulesets.json"
+RULESETS_JSON=pkg/rulesets.json
 
 if [ -n "$1" ]; then
   BRANCH=`git branch | head -n 1 | cut -d \  -f 2-`
@@ -39,7 +39,7 @@ echo "Building chrome version" $VERSION
 [ -e pkg/crx ] && rm -rf pkg/crx
 
 # Clean up obsolete ruleset databases, just in case they still exist.
-rm -f "$PWD/src/chrome/content/rules/default.rulesets" "$PWD/src/defaults/rulesets.sqlite"
+rm -f src/chrome/content/rules/default.rulesets src/defaults/rulesets.sqlite
 
 # Only generate the ruleset database if any rulesets have changed. Tried
 # implementing this with make, but make is very slow with 15k+ input files.

--- a/makecrx.sh
+++ b/makecrx.sh
@@ -38,7 +38,10 @@ echo "Building chrome version" $VERSION
 [ -d pkg ] || mkdir -p pkg
 [ -e pkg/crx ] && rm -rf pkg/crx
 
-# Only generate the sqlite database if any rulesets have changed. Tried
+# Clean up obsolete ruleset databases, just in case they still exist.
+rm -f "$PWD/src/chrome/content/rules/default.rulesets" "$PWD/src/defaults/rulesets.sqlite"
+
+# Only generate the ruleset database if any rulesets have changed. Tried
 # implementing this with make, but make is very slow with 15k+ input files.
 needs_update() {
   find src/chrome/content/rules/ -newer $RULESETS_JSON |\

--- a/makexpi.sh
+++ b/makexpi.sh
@@ -16,7 +16,7 @@ APP_NAME=https-everywhere
 #  ./makexpi.sh 0.2.3.development.2
 
 cd "`dirname $0`"
-RULESETS_JSON="$PWD/pkg/rulesets.json"
+RULESETS_JSON=pkg/rulesets.json
 ANDROID_APP_ID=org.mozilla.firefox
 VERSION=`echo $1 | cut -d "-" -f 2`
 
@@ -55,7 +55,7 @@ if [ -n "$1" ] && [ "$2" != "--no-recurse" ] ; then
 fi
 
 # Clean up obsolete ruleset databases, just in case they still exist.
-rm -f "$PWD/src/chrome/content/rules/default.rulesets" "$PWD/src/defaults/rulesets.sqlite"
+rm -f src/chrome/content/rules/default.rulesets src/defaults/rulesets.sqlite
 
 # Only generate the ruleset database if any rulesets have changed. Tried
 # implementing this with make, but make is very slow with 15k+ input files.

--- a/makexpi.sh
+++ b/makexpi.sh
@@ -54,6 +54,9 @@ if [ -n "$1" ] && [ "$2" != "--no-recurse" ] ; then
   exit 0
 fi
 
+# Clean up obsolete ruleset databases, just in case they still exist.
+rm -f "$PWD/src/chrome/content/rules/default.rulesets" "$PWD/src/defaults/rulesets.sqlite"
+
 # Only generate the ruleset database if any rulesets have changed. Tried
 # implementing this with make, but make is very slow with 15k+ input files.
 needs_update() {


### PR DESCRIPTION
* `make clean` now deletes the old `rulesets.unvalidated.sqlite` and `rulesets.sqlite` files
* `makecrx.sh` and `makexpi.sh` now delete the old `rulesets.sqlite` file and super-old `default.rulesets` file. (I'm pedantic.)
* (A `makecrx.sh` comment that referred to SQLite has been updated.)

I think it's important for `make clean` to continue to remove the old files, for people who forget to clean before pulling or switching between branches. (Ahem.)

I also think it's useful for `makecrx.sh` and `makexpi.sh` to do it, but that might be more controversial. (And maybe should have been a separate pull request.)

I don't know about you folks, but i build HTTPS Everywhere from a dirty directory, and i was unwittingly building double-size XPIs with `default.rulesets` for *months* after the switch to SQLite. And i just caught myself doing the same thing with an old `rulesets.sqlite` file after last month's move to JSON.