### PR TITLE
[Apple] Add exclusion

### DIFF
--- a/src/chrome/content/rules/Apple.xml
+++ b/src/chrome/content/rules/Apple.xml
@@ -524,7 +524,7 @@
 
 		<!--	Redirects to http:
 						-->
-		<exclusion pattern="http://www\.apple\.com/(?:\w\w/)?shop(?:$|[?/])" />
+		<exclusion pattern="^http://www\.apple\.com/(?:\w\w/)?shop(?:$|[?/])" />
 
 			<!--	+ve:
 					-->
@@ -534,6 +534,10 @@
 			<test url="http://www.apple.com/shop/payment_plan" />
 			<test url="http://www.apple.com/uk/shop/buy-mac/macbook/space-grey-512gb" />
 
+		<exclusion pattern="^http://www\.apple\.com/apple\-events/" />
+
+			<test url="http://www.apple.com/apple-events/" />
+			<test url="http://www.apple.com/apple-events/march-2016/" />
 
 	<!--	Not secured by server:
 					-->

--- a/src/chrome/content/rules/Apple.xml
+++ b/src/chrome/content/rules/Apple.xml
@@ -534,7 +534,8 @@
 			<test url="http://www.apple.com/shop/payment_plan" />
 			<test url="http://www.apple.com/uk/shop/buy-mac/macbook/space-grey-512gb" />
 
-		<exclusion pattern="^http://www\.apple\.com/apple\-events/" />
+		<!-- Performs a JS redirect to HTTP -->
+		<exclusion pattern="^http://www\.apple\.com/apple-events/" />
 
 			<test url="http://www.apple.com/apple-events/" />
 			<test url="http://www.apple.com/apple-events/march-2016/" />


### PR DESCRIPTION
Creates an exclusion for /apple-events/ which is currently broken
(constant reload loop).

Partially resolves https://github.com/EFForg/https-everywhere/issues/4432

This is technically already too late for the Apple event which was today.