### PR TITLE
Add HSTS-based rewrites to the Node rewriter.

### DIFF
--- a/rewriter/hsts-transform.js
+++ b/rewriter/hsts-transform.js
@@ -1,0 +1,26 @@
+// A tool to transform transport_security_state_static.json into one big trivial
+// ruleset on stdout.
+// To get transport_security_state_static.json:
+// curl https://chromium.googlesource.com/chromium/src/+/master/net/http/transport_security_state_static.json?format=TEXT \
+//  | base64 -d > transport_security_state_static.json
+var fs = require('fs');
+
+if (process.argv.length != 3) {
+  console.error('Provide path to transport_security_state_static.json as only argument.');
+  return;
+}
+var contents = fs.readFileSync(process.argv[2], 'utf8');
+contents = contents.split('\n').filter(line => !/^\s*\/\//.test(line)).join('\n');
+var secStateStatic = JSON.parse(contents);
+console.log('<ruleset name="hsts">')
+secStateStatic.entries.forEach(function(entry) {
+  if (entry.mode != "force-https") {
+    return;
+  }
+  console.log('  <target host="' + entry.name + '" />');
+  if (entry.include_subdomains) {
+    console.log('  <target host="*.' + entry.name + '" />');
+  }
+});
+console.log('  <rule from="^http:" to="https:" />');
+console.log('</ruleset>');

--- a/rewriter/package.json
+++ b/rewriter/package.json
@@ -1,10 +1,10 @@
 {
-  "name" : "https-everywhere-rewriter",
-  "version" : "1.0.0",
-  "dependencies" : {
-    "xmldom" : "0.1.17",
-    "URIjs" : "1.11.2",
-    "readdirp" : "0.3.2",
-    "event-stream" : "3.0.20"
+  "name": "https-everywhere-rewriter",
+  "version": "1.1.0",
+  "dependencies": {
+    "URIjs": "*",
+    "event-stream": "^3.3.2",
+    "readdirp": "^2.0.0",
+    "xmldom": "^0.1.22"
   }
 }


### PR DESCRIPTION
Also, bring all dependencies up-to-date and remove the hacky workaround for
explosive regex in URIjs (seems to be fixed upstream now).

cc @Hainish @cooperq 
