### PR TITLE
[Mbl.is] Add exclusion to fix redirect loop and breakage

### DIFF
--- a/src/chrome/content/rules/Mbl.is.xml
+++ b/src/chrome/content/rules/Mbl.is.xml
@@ -5,10 +5,12 @@
 	Problematic subdomains:
 
 		- (www.) *
-		- m *		(works)
-		- static *	(works)
+		- icelandmonitor *
+		- m *
+		- media *
+		- static *
 
-	* Cert only matches secure
+	* curl: (35) Unknown SSL protocol error
 
 
 	Mixed images from:

--- a/src/chrome/content/rules/Mbl.is.xml
+++ b/src/chrome/content/rules/Mbl.is.xml
@@ -33,6 +33,9 @@
 		<test url="http://www.mbl.is/fasteignir/" />
 		<test url="http://secure.mbl.is/fasteignir/" />
 
+	<test url="http://secure.mbl.is/" />
+	<test url="http://www.mbl.is/" />
+
 	<rule from="^http://(?:secure\.|www\.)?mbl\.is/"
 		to="https://secure.mbl.is/" />
 

--- a/src/chrome/content/rules/Mbl.is.xml
+++ b/src/chrome/content/rules/Mbl.is.xml
@@ -27,6 +27,11 @@
 	<target host="*.mbl.is" />
 	<target host="mbl.teljari.is" />
 
+	<!-- Causes redirect loop and breaks search form. -->
+	<exclusion pattern="^http://(secure\.|www\.)?mbl\.is/fasteignir/" />
+		<test url="http://mbl.is/fasteignir/" />
+		<test url="http://www.mbl.is/fasteignir/" />
+		<test url="http://secure.mbl.is/fasteignir/" />
 
 	<rule from="^http://(?:secure\.|www\.)?mbl\.is/"
 		to="https://secure.mbl.is/" />


### PR DESCRIPTION
The entirety of the "fasteignir" subpage would appear to serve redirects to HTTP, so we exclude that to avoid some loops. In some (but apparently not quite all) cases, this would also break the search form on http://www.mbl.is/fasteignir/.