### PR TITLE
Netflix update

### DIFF
--- a/src/chrome/content/rules/Netflix.com-problematic.xml
+++ b/src/chrome/content/rules/Netflix.com-problematic.xml
@@ -1,21 +1,14 @@
 <!--
 	For rules that are on by default, see Netflix.xml.
-
-
-	Known matches:
-
-		- api-global
-		- jsapi
-
 -->
 <ruleset name="Netflix.com (buggy)" default_off="various things break">
 
-	<target host="*.netflix.com" />
-		<!--
-			Redirect to http:
-						-->
-		<!--exclusion pattern="^http://ca\.netflix\.com/($|\?)" /-->
-		<exclusion pattern="^http://(?:blog|ca|developer|ir|techblog|ukirelandblog)\.netflix\.com/" />
+	<target host="ca.netflix.com" />
+	<target host="blog.netflix.com" />
+	<!--<target host="developer.netflix.com"/> , handled by Mashery-Clients -->
+	<target host="ir.netflix.com" />
+	<target host="techblog.netflix.com" />
+	<target host="ukirelandblog.netflix.com" />
 
 	<rule from="^http:"
 		to="https:" />

--- a/src/chrome/content/rules/Netflix.xml
+++ b/src/chrome/content/rules/Netflix.xml
@@ -28,14 +28,6 @@
 	² Mashery
 	³ Shareholder
 
-
-	Problematic hosts in *netflix.com:
-
-		- jsapi *
-
-	* Works, akamai
-
-
 	Insecure cookies are set for these domains and hosts:
 
 		- .netflix.com
@@ -53,13 +45,16 @@
 	* Secured by us
 
 -->
-<ruleset name="Netflix.com (partial)" default_off="Breaks site">
+<ruleset name="Netflix.com (partial)" >
 
 	<target host="netflix.com" />
 	<target host="account.netflix.com" />
+	<target host="api-global.netflix.com" />
 	<target host="contactus.netflix.com" />
+	<target host="customerevents.netflix.com" />
 	<target host="help.netflix.com" />
 	<target host="jobs.netflix.com" />
+	<!--<target host="jsapi.netflix.com" /> cert only valid for akamai -->
 	<target host="ncds.netflix.com" />
 	<target host="openconnect.netflix.com" />
 	<target host="secure.netflix.com" />
@@ -68,6 +63,17 @@
 	<target host="www1.netflix.com" />
 	<target host="www2.netflix.com" />
 	<target host="www3.netflix.com" />
+	<target host="pr.netflix.com" />
+	<target host="media.netflix.com" />
+
+	<target host="assets.nflxext.com" />
+	<target host="so-s.nflximg.net" />
+	<target host="tp-s.nflximg.net" />
+	<target host="www2-ext-s.nflximg.net" />
+	<target host="scdn.nflximg.net" />
+
+	<target host="*.isp.nflxvideo.net" />
+	<target host="*.ix.nflxvideo.net" />
 
 		<!--	Redirect to http:
 						-->
@@ -83,8 +89,7 @@
 	<!--securecookie host="^help\.netflix\.com$" name="^JSESSIONID$" /-->
 	<!--securecookie host="^openconnect\.netflix\.com$" name="^X-Mapping-\w+$" /-->
 
-	<securecookie host="^\w" name="." />
-
+	<securecookie host="." name="." />
 
 	<rule from="^http:"
 		to="https:" />


### PR DESCRIPTION
Netflix has enabled TLS on most of their websites so i think it is time to re-enable the ruleset.
Sites without valid cert & timeouts still are off by default.