### PR TITLE
[Cloudfront] Attempt to fix rotten tomatoes video playback

### DIFF
--- a/src/chrome/content/rules/Cloudfront.xml
+++ b/src/chrome/content/rules/Cloudfront.xml
@@ -16,8 +16,7 @@
 			<test url="http://d2i3r43q6ffvz8.cloudfront.net/prod/public/js/min/core.11b1b69c86c5.js?bust=3" />
 
 
-	<rule from="^http://([^/:@\.]+)\.cloudfront\.net/" 
-		to="https://$1.cloudfront.net/" />
+	<rule from="^http:" to="https:" />
 
 	<!-- from src/chrome/content/rules/Guild-Wars-2.xml  -->
 	<test url="http://d15glo5zfrmw71.cloudfront.net/" />
@@ -33,14 +32,12 @@
 		<test url="http://d1ej19d7kwigfi.cloudfront.net/crossdomain.xml" />
 
 	<!-- Fix PBS videos, see https://github.com/EFForg/https-everywhere/issues/1508  -->
-	<exclusion pattern="^http:\/\/d3aef1qbbv7i5v\.cloudfront\.net\/" />
 		<test url="http://d3aef1qbbv7i5v.cloudfront.net/lib/jwplayer/jwplayer.js" />
 		<test url="http://d3aef1qbbv7i5v.cloudfront.net/img/viral_player_sprite.png" />
 
 	<!--
 		acinitiates.com fix
 									-->
-	<exclusion pattern="^http:\/\/(?:d3bn78kc7qbjb6|d1nawi9f7y8zrl)\.cloudfront\.net\/" />
 		<test url="http://d3bn78kc7qbjb6.cloudfront.net/rc-0.0.0.392/views/logs/logs.html" />
 		<test url="http://d1nawi9f7y8zrl.cloudfront.net/content/v1/content?ver=1.0.0" /> <!-- http://d1nawi9f7y8zrl.cloudfront.net/content/v1/content?ver=1.0.0&lang=en -->
 
@@ -50,4 +47,8 @@
   <exclusion pattern="&amp;Signature=" />
   	<test url="http://d1h9a8s8eodvjz.cloudfront.net/test.txt?a=b&amp;Signature=1234" />
 
+	<!-- Fix trailers playing on rottentomatoes.com e.g. http://www.rottentomatoes.com/m/the_revenant_2015/ -->
+	<!-- HTTPS seems to work, but it appears to force HTTP -->
+		<test url="http://d3biamo577v4eu.cloudfront.net/static/js/lib/jwplayer-7.2.3/jwplayer.flash.swf" />
+		<test url="http://d3biamo577v4eu.cloudfront.net/static/images/icons/favicon.ico" />
 </ruleset>

--- a/src/chrome/content/rules/Cloudfront.xml
+++ b/src/chrome/content/rules/Cloudfront.xml
@@ -2,53 +2,43 @@
 
 	<target host="*.cloudfront.net" />
 
-		<!--	Attempt to work around "hang" after login for mapmyrun.com
-
-			https://github.com/EFForg/https-everywhere/issues/4159
-
-			report does not give any examples, so try all scripts.
-										-->
-		<exclusion pattern="^http://d2i3r43q6ffvz8\.cloudfront\.net/.+\.js" />
-
-			<!--	+ve:
-					-->
-			<test url="http://d2i3r43q6ffvz8.cloudfront.net/prod/public/js/jquery/jquery-1.8.3.ddb54eca80f2.js?bust=3" />
-			<test url="http://d2i3r43q6ffvz8.cloudfront.net/prod/public/js/min/core.11b1b69c86c5.js?bust=3" />
-
-
 	<rule from="^http:" to="https:" />
-
 	<!-- from src/chrome/content/rules/Guild-Wars-2.xml  -->
 	<test url="http://d15glo5zfrmw71.cloudfront.net/" />
 	<test url="http://d1ej19d7kwigfi.cloudfront.net/" />
 	<test url="http://d1h9a8s8eodvjz.cloudfront.net/" />
 
-	<!--
-		and this is a generalised precaution from turntable.fm
-		(rewriting this file seems to break cross origin in flash)
-									-->
+	<!--	Attempt to work around "hang" after login for mapmyrun.com
+		https://github.com/EFForg/https-everywhere/issues/4159
+		report does not give any examples, so try all scripts. -->
+	<exclusion pattern="^http://d2i3r43q6ffvz8\.cloudfront\.net/.+\.js" />
+		<test url="http://d2i3r43q6ffvz8.cloudfront.net/prod/public/js/jquery/jquery-1.8.3.ddb54eca80f2.js?bust=3" />
+		<test url="http://d2i3r43q6ffvz8.cloudfront.net/prod/public/js/min/core.11b1b69c86c5.js?bust=3" />
+
+	<!-- This is a generalised precaution from turntable.fm
+		(rewriting this file seems to break cross origin in flash) -->
 	<exclusion pattern="^http://(\w+)\.cloudfront\.net/crossdomain\.xml" />
 		<test url="http://d1h9a8s8eodvjz.cloudfront.net/crossdomain.xml" />
 		<test url="http://d1ej19d7kwigfi.cloudfront.net/crossdomain.xml" />
 
 	<!-- Fix PBS videos, see https://github.com/EFForg/https-everywhere/issues/1508  -->
+	<exclusion pattern="^http://d3aef1qbbv7i5v\.cloudfront\.net/" />
 		<test url="http://d3aef1qbbv7i5v.cloudfront.net/lib/jwplayer/jwplayer.js" />
 		<test url="http://d3aef1qbbv7i5v.cloudfront.net/img/viral_player_sprite.png" />
 
-	<!--
-		acinitiates.com fix
-									-->
+	<!-- acinitiates.com fix -->
+	<exclusion pattern="^http://(?:d3bn78kc7qbjb6|d1nawi9f7y8zrl)\.cloudfront\.net/" />
 		<test url="http://d3bn78kc7qbjb6.cloudfront.net/rc-0.0.0.392/views/logs/logs.html" />
 		<test url="http://d1nawi9f7y8zrl.cloudfront.net/content/v1/content?ver=1.0.0" /> <!-- http://d1nawi9f7y8zrl.cloudfront.net/content/v1/content?ver=1.0.0&lang=en -->
 
-  <!-- See https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-creating-signed-url-custom-policy.html
-    Policies contain the protocol, so a signature for http will not work for https
-  -->
-  <exclusion pattern="&amp;Signature=" />
-  	<test url="http://d1h9a8s8eodvjz.cloudfront.net/test.txt?a=b&amp;Signature=1234" />
+	<!-- See https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-creating-signed-url-custom-policy.html
+		Policies contain the protocol, so a signature for http will not work for https -->
+	<exclusion pattern="&amp;Signature=" />
+		<test url="http://d1h9a8s8eodvjz.cloudfront.net/test.txt?a=b&amp;Signature=1234" />
 
 	<!-- Fix trailers playing on rottentomatoes.com e.g. http://www.rottentomatoes.com/m/the_revenant_2015/ -->
 	<!-- HTTPS seems to work, but it appears to force HTTP -->
+	<exclusion pattern="^http://d3biamo577v4eu\.cloudfront\.net/" />
 		<test url="http://d3biamo577v4eu.cloudfront.net/static/js/lib/jwplayer-7.2.3/jwplayer.flash.swf" />
 		<test url="http://d3biamo577v4eu.cloudfront.net/static/images/icons/favicon.ico" />
 </ruleset>

--- a/src/chrome/content/rules/Cloudfront.xml
+++ b/src/chrome/content/rules/Cloudfront.xml
@@ -35,6 +35,7 @@
 		Policies contain the protocol, so a signature for http will not work for https -->
 	<exclusion pattern="&amp;Signature=" />
 		<test url="http://d1h9a8s8eodvjz.cloudfront.net/test.txt?a=b&amp;Signature=1234" />
+		<test url="http://d1h9a8s8eodvjz.cloudfront.net/test.txt?a=b&amp;Signature=5678" />
 
 	<!-- Fix trailers playing on rottentomatoes.com e.g. http://www.rottentomatoes.com/m/the_revenant_2015/ -->
 	<!-- HTTPS seems to work, but it appears to force HTTP -->


### PR DESCRIPTION
Broken trailer (video) on http://www.rottentomatoes.com/m/the_revenant_2015/
The source `d3biamo577v4eu.cloudfront.net` seems to support HTTPS just fine but I believe rotten tomatos is trying to force it over HTTP (I couldn't locate the actual source), so I'm excluding this rule in an attempt to resolve it.

Did a search and this was actually reported last year: https://github.com/EFForg/https-everywhere/issues/2742