### PR TITLE
Rename and Re-enable BECU.org Ruleset

### DIFF
--- a/src/chrome/content/rules/Becu.org.xml
+++ b/src/chrome/content/rules/Becu.org.xml
@@ -1,13 +1,15 @@
 <ruleset name="Becu.org">
     <target host="becu.org" />
     <target host="www.becu.org" />
-    <target host="*.becu.org" />
+    <target host="onlinebanking.becu.org" />
+    <target host="onlineappointments.becu.org" />
+    <target host="accessassistant.becu.org" />
 
     <exclusion pattern="^http://news\.becu\.org/" />
 
     <test url="http://www.becu.org/" />
-    <test url="http://www.becu.org/images/becu-logo.jpg" />
     <test url="http://onlinebanking.becu.org/" />
+    <test url="http://news.becu.org/" />
 
     <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Becu.org.xml
+++ b/src/chrome/content/rules/Becu.org.xml
@@ -1,7 +1,13 @@
 <ruleset name="Becu.org">
-	<target host="becu.org" />
-	<target host="www.becu.org" />
-	<target host="*.becu.org" />
+    <target host="becu.org" />
+    <target host="www.becu.org" />
+    <target host="*.becu.org" />
 
-	<rule from="^http:" to="https:" />
+    <exclusion pattern="^http://news\.becu\.org/" />
+
+    <test url="http://www.becu.org/" />
+    <test url="http://www.becu.org/images/becu-logo.jpg" />
+    <test url="http://onlinebanking.becu.org/" />
+
+    <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Becu.org.xml
+++ b/src/chrome/content/rules/Becu.org.xml
@@ -6,6 +6,7 @@
     <target host="accessassistant.becu.org" />
 
     <exclusion pattern="^http://news\.becu\.org/" />
+    <exclusion pattern="^http://locatorsearch\.becu\.org/" />
 
     <test url="http://www.becu.org/" />
     <test url="http://onlinebanking.becu.org/" />

--- a/src/chrome/content/rules/Becu.org.xml
+++ b/src/chrome/content/rules/Becu.org.xml
@@ -11,6 +11,7 @@
     <test url="http://www.becu.org/" />
     <test url="http://onlinebanking.becu.org/" />
     <test url="http://news.becu.org/" />
+    <test url="http://locatorsearch.becu.org/" />
 
     <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Becu.org.xml
+++ b/src/chrome/content/rules/Becu.org.xml
@@ -1,0 +1,7 @@
+<ruleset name="Becu.org">
+	<target host="becu.org" />
+	<target host="www.becu.org" />
+	<target host="*.becu.org" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/Boeing-Employees-Credit-Union.xml
+++ b/src/chrome/content/rules/Boeing-Employees-Credit-Union.xml
@@ -1,37 +1,9 @@
-<!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://becuonlinebanking.org/ => https://www.becuonlinebanking.org/: (7, 'Failed to connect to becuonlinebanking.org port 80: No route to host')
-	becu.122.2o7.net/b/ss/becudev/1/H.17/
+<ruleset name="Boeing Employees Credit Union (BECU)">
+    <target host="becu.org" />
+    <target host="www.becu.org" />
+    <target host="onlinebanking.becu.org" />
+    <target host="*.becu.org" />
 
--->
-<ruleset name="Boeing Employees Credit Union (partial)" default_off='failed ruleset test'>
-
-	<target host="becu.org" />
-	<target host="*.becu.org" />
-	<target host="becuonlinebanking.org" />
-	<target host="*.becuonlinebanking.org" />
-
-
-	<!--	s_ cookies are set by 2o7.net.
-		becuhome is set by the homepage.	-->
-	<securecookie host="^\.becu\.org$" name="^(?:becuhome|s_\w+)$" />
-	<securecookie host="^accessassistant\.becu\.org$" name=".*" />
-	<securecookie host="^.*\.becuonlinebanking\.org$" name=".*" />
-
-
-	<!--	Cert is only valid for www.	-->
-	<rule from="^http://becu\.org/"
-		to="https://www.becu.org/" />
-
-	<!--	Some pages redirect to http.  There may be more that don't.	-->
-	<rule from="^http://www\.becu\.org/($|contact-us\.aspx|css/|Default\.aspx|flash/|images/|js/|mobile-online-banking/|pdfsource/|who-is/becu-is-you\.aspx)"
-		to="https://www.becu.org/$1" />
-
-	<rule from="^http://accessassistant\.becu\.org/"
-		to="https://accessassistant.becu.org/" />
-
-	<!--	Cert is only valid for www.	-->
-	<rule from="^http://(?:www\.)?becuonlinebanking\.org/"
-		to="https://www.becuonlinebanking.org/" />
-
+    <rule from="^http:"
+        to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Boeing-Employees-Credit-Union.xml
+++ b/src/chrome/content/rules/Boeing-Employees-Credit-Union.xml
@@ -1,9 +1,0 @@
-<ruleset name="Boeing Employees Credit Union (BECU)">
-    <target host="becu.org" />
-    <target host="www.becu.org" />
-    <target host="onlinebanking.becu.org" />
-    <target host="*.becu.org" />
-
-    <rule from="^http:"
-        to="https:" />
-</ruleset>


### PR DESCRIPTION
The ruleset for BECU.org was disabled some time ago due to various different
inconsistent usage of HTTPS across the site. This commit not only re-enables the
ruleset, but the rule has been modified to include all BECU.org sub-domains
which appear to all be HTTPS capable or HTTPS-only.

This is the continuation of https://github.com/EFForg/https-everywhere/pull/3976 which was closed in favor of this request.