### PR TITLE
[News Limited] Remove wildcard rule

### DIFF
--- a/src/chrome/content/rules/News_Limited.xml
+++ b/src/chrome/content/rules/News_Limited.xml
@@ -31,10 +31,10 @@
 
 	Problematic subdomains:
 
-		- ^ ¹
+		- ^, www ¹
 		- connect ²
 
-	¹ Works, akamai
+	¹ Works, mismatched, akamai
 	² Works; mismatched, CN: *.pureprofile.com
 
 
@@ -45,8 +45,6 @@
 
 -->
 <ruleset name="News Limited (partial)">
-
-	<target host="*.news.com.au" />
 
 	<target host="controlpanel.blogs.news.com.au" />
 	<target host="myaccount.news.com.au" />


### PR DESCRIPTION
The previous change introduced a broken catch-all rule on accident. Removing it fixes #4561.