### PR TITLE
[OFTC.net] oftc.net cert mismatch is fixed

### DIFF
--- a/src/chrome/content/rules/OFTC.net.xml
+++ b/src/chrome/content/rules/OFTC.net.xml
@@ -1,20 +1,15 @@
 <!--
-	Problematic hosts:
+	Problematic subdomains:
 
-		- oftc.net ¹
-		- git.oftc.net ²
+		- git *
 
-	¹ Mismatched, CN: www.oftc.net
-	² Mismatched, CN: webchat.oftc.net; shows webchat.oftc.net
+	* Mismatched, CN: webchat.oftc.net; shows webchat.oftc.net
 -->
 <ruleset name="OFTC.net">
 
 	<target host="oftc.net" />
 	<target host="webchat.oftc.net" />
 	<target host="www.oftc.net" />
-
-	<rule from="^http://oftc\.net/"
-		to="https://www.oftc.net/" />
 
 	<rule from="^http:"
 		to="https:" />


### PR DESCRIPTION
This change is effectively a no-op, since https://oftc.net/ just redirects to www.oftc.net, which is what we did anyway. Still, this simplifies the ruleset.