### PR TITLE
Recreate Automattic.xml

### DIFF
--- a/src/chrome/content/rules/Automattic.xml
+++ b/src/chrome/content/rules/Automattic.xml
@@ -1,0 +1,9 @@
+<ruleset name="Automattic">
+
+	<target host="automattic.com"/>
+	<target host="*.automattic.com"/>
+
+	<rule from="^http://(subversion\.|www\.)?automattic\.com/"
+		to="https://$1automattic.com/"/>
+
+</ruleset>

--- a/src/chrome/content/rules/Automattic.xml
+++ b/src/chrome/content/rules/Automattic.xml
@@ -1,15 +1,28 @@
 <!--
-	Problematic subdomain:
+	Problematic subdomains:
+
+		- bbpress	(shows svn.automattic.com)
 		- lists		(timeout)
 		- status	(hostname mismatch, CN: status.io.watchmouse.com)
 -->
-<ruleset name="Automattic (partial)">
+<ruleset name="Automattic">
 	<target host="automattic.com" />
+	<target host="bbpress.automattic.com" />
 	<target host="fieldguide.automattic.com" />
 	<target host="help.automattic.com" />
+	<target host="lounge.automattic.com" />
+	<target host="museum.automattic.com" />
+	<target host="publisherblog.automattic.com" />
 	<target host="subversion.automattic.com" />
 	<target host="svn.automattic.com" />
+	<target host="win8.svn.automattic.com" />
+	<target host="wpcom-i18n.svn.automattic.com" />
+	<target host="wpcom-themes.svn.automattic.com" />
+	<target host="transparency.automattic.com" />
 	<target host="www.automattic.com" />
+
+	<rule from="^http://bbpress\.automattic\.com/"
+		to="https://bbpress.trac.wordpress.org/" />
 
 	<rule from="^http:"
 		to="https:" />


### PR DESCRIPTION
Recreate `Automattic.xml`.

It was removed in 143128b3f9b647c3a07aa3063239e42f6a3e055f (2012), then independently recreated by @youdly in #3983 (January), then independently recreated again by me in #4585 (today).

This combines the best of all 3, reverting 143128b3f9b647c3a07aa3063239e42f6a3e055f, merging #3983, and rewriting #4585.