### PR TITLE
[ScummVM.org] New ruleset

### DIFF
--- a/src/chrome/content/rules/ScummVM.org.xml
+++ b/src/chrome/content/rules/ScummVM.org.xml
@@ -1,0 +1,17 @@
+<!--
+	Subdomains without HTTPS support:
+
+		- bugs
+		- buildbot
+		- doxygen
+		- forums
+		- logs
+		- planet
+		- wiki
+-->
+<ruleset name="ScummVM.org">
+	<target host="scummvm.org" />
+	<target host="www.scummvm.org" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>


### PR DESCRIPTION
[scummvm.org](https://www.scummvm.org/) has recently switched on HTTPS.

It has many subdomains in use, but those don't have HTTPS yet. I will submit updates once those are in place.