### PR TITLE
Add rulesets for Acessa and Xchan

### DIFF
--- a/Acessa.xml
+++ b/Acessa.xml
@@ -2,6 +2,11 @@
         <target host="acessa.com" />
         <target host="www.acessa.com" />
 
+        <exclusion pattern="usuarios.acessa.com" />
+        <exclusion pattern="webmail.acessa.com" />
+        <exclusion pattern="aol.acessa.com" />
+        <exclusion pattern="estevao.acessa.com" />
+
         <rule from="^http:"
                 to="https:" />
 </ruleset>

--- a/Acessa.xml
+++ b/Acessa.xml
@@ -1,0 +1,7 @@
+<ruleset name="Acessa">
+        <target host="acessa.com" />
+        <target host="www.acessa.com" />
+
+        <rule from="^http:"
+                to="https:" />
+</ruleset>

--- a/Acessa.xml
+++ b/Acessa.xml
@@ -1,11 +1,17 @@
 <ruleset name="Acessa">
+<!--
+        Can't work with HTTPS:
+                usuarios.acessa.com
+                webmail.acessa.com
+                aol.acessa.com
+                estevao.acessa.com
+                crcmg.acessa.com
+        
+        Does not works as HTTP nor HTTPS:
+                discovirtual.acessa.com
+-->
         <target host="acessa.com" />
         <target host="www.acessa.com" />
-
-        <exclusion pattern="usuarios.acessa.com" />
-        <exclusion pattern="webmail.acessa.com" />
-        <exclusion pattern="aol.acessa.com" />
-        <exclusion pattern="estevao.acessa.com" />
 
         <rule from="^http:"
                 to="https:" />

--- a/Acessa.xml
+++ b/Acessa.xml
@@ -1,4 +1,3 @@
-<ruleset name="Acessa">
 <!--
         Can't work with HTTPS:
                 usuarios.acessa.com
@@ -10,6 +9,7 @@
         Does not works as HTTP nor HTTPS:
                 discovirtual.acessa.com
 -->
+<ruleset name="Acessa">
         <target host="acessa.com" />
         <target host="www.acessa.com" />
 

--- a/BRChan.xml
+++ b/BRChan.xml
@@ -1,0 +1,7 @@
+<ruleset name="BRChan">
+        <target host="brchan.org" />
+		<target host="www.brchan.org" />
+
+        <rule from="^http:"
+                to="https:" />
+</ruleset>

--- a/Desustorage.xml
+++ b/Desustorage.xml
@@ -3,7 +3,7 @@
 		status.desustorage.org
 -->
 
-<ruleset name="Priberam">
+<ruleset name="Desustorage">
         <target host="desustorage.org" />
 		<target host="data.desustorage.org" />
 

--- a/Desustorage.xml
+++ b/Desustorage.xml
@@ -1,0 +1,12 @@
+<!--
+	Does not works with HTTPS:
+		status.desustorage.org
+-->
+
+<ruleset name="Priberam">
+        <target host="desustorage.org" />
+		<target host="data.desustorage.org" />
+
+        <rule from="^http:"
+                to="https:" />
+</ruleset>

--- a/Lshare.xml
+++ b/Lshare.xml
@@ -1,0 +1,7 @@
+<ruleset name="L Share">
+        <target host="lsh.re" />
+		<target host="www.lsh.re" />
+
+        <rule from="^http:"
+                to="https:" />
+</ruleset>

--- a/Mojang.xml
+++ b/Mojang.xml
@@ -1,0 +1,17 @@
+<!--
+	blockbyblock.mojang.com does not works on HTTPS
+	
+	Already works only on HTTPS:
+		help.mojang.com
+		account.mojang.com
+		accounts.mojang.com
+		bugs.mojang.com
+		sessionserver.mojang.com
+-->
+
+<ruleset name="Mojang">
+        <target host="mojang.com" />
+
+        <rule from="^http:"
+                to="https:" />
+</ruleset>

--- a/Passa-Palavra.xml
+++ b/Passa-Palavra.xml
@@ -1,0 +1,7 @@
+<ruleset name="Passa-Palavra">
+        <target host="passapalavra.info" />
+		<target host="www.passapalavra.info" />
+
+        <rule from="^http:"
+                to="https:" />
+</ruleset>

--- a/Priberam.xml
+++ b/Priberam.xml
@@ -1,0 +1,15 @@
+<!--
+	Does not works with HTTPS:
+		dicionario.priberam.pt
+		labs.priberam.pt
+		blogue.priberam.pt
+		legix.priberam.pt
+-->
+
+<ruleset name="Priberam">
+        <target host="priberam.pt" />
+		<target host="www.priberam.pt" />
+
+        <rule from="^http:"
+                to="https:" />
+</ruleset>

--- a/Social9.xml
+++ b/Social9.xml
@@ -1,0 +1,9 @@
+<ruleset name="Social9">
+        <target host="social9.com" />
+		<target host="www.social9.com" />
+        <target host="share.social9.com" />
+		<target host="gauge.social9.com" />
+
+        <rule from="^http:"
+                to="https:" />
+</ruleset>

--- a/Telegram Wiki.xml
+++ b/Telegram Wiki.xml
@@ -1,0 +1,13 @@
+<!--
+	Does not works on HTTPS:
+		ip.telegram.wiki
+		data.telegram.wiki
+-->
+
+<ruleset name="Telegram Wiki">
+        <target host="telegram.wiki" />
+		<target host="" />
+
+        <rule from="^http:"
+                to="https:" />
+</ruleset>

--- a/WithoutHotAir.xml
+++ b/WithoutHotAir.xml
@@ -1,0 +1,7 @@
+<ruleset name="WithoutHotAir">
+        <target host="withouthotair.com" />
+		<target host="www.withouthotair.com" />
+
+        <rule from="^http:"
+                to="https:" />
+</ruleset>

--- a/Xchan.xml
+++ b/Xchan.xml
@@ -1,0 +1,6 @@
+<ruleset name="Xchan">
+        <target host="xchan.pw" />
+
+        <rule from="^http:"
+                to="https:" />
+</ruleset>


### PR DESCRIPTION
These two sites support HTTPS, but don't make redirection by default. They need rulesets.