### PR TITLE
Heise.de:

### DIFF
--- a/src/chrome/content/rules/Heise.de.xml
+++ b/src/chrome/content/rules/Heise.de.xml
@@ -25,6 +25,8 @@
 
 		- www.abo.heise.de
 
+	no securable content on ^, short-urls redirect to www on their own (can't be secured either)
+
 -->
 <ruleset name="Heise.de (partial)">
 
@@ -39,74 +41,60 @@
 
 	<!--	Complications:
 				-->
-	<target host="heise.de" />
 	<target host="www.shop.heise.de" />
 
-			<!--	+ve:
-					-->
-			<test url="http://m.heise.de/impressum.html" />
-			<test url="http://m.heise.de/newsticker/" />
-			<test url="http://m.heise.de/security/" />
-			<test url="http://m.heise.de/security/foren/" />
-
-			<!--	-ve:
-					-->
-			<test url="http://m.heise.de/icons/mobi/menu_button.png" />
-			<test url="http://m.heise.de/security/icons/security_logo_smartphone_hdpi_color.png" />
-			<test url="http://m.heise.de/js/mobi/mobi.min.js" />
-			<test url="http://m.heise.de/icons/mobi/favicon.ico" />
 			<test url="http://m.heise.de/avw-bin/ivw/CP/export-api/" />
-			<test url="http://m.heise.de/ivw-bin/ivw/CP/" />
-			<test url="http://m.heise.de/stil/mobi/mobi2013.css" />
 			<test url="http://m.heise.de/fonts/open-sans/OpenSans-CondBold-webfont.woff" />
-
-		<exclusion pattern="^http://(?:www\.)?heise\.de/(?![ai]vw-bin/|favicon\.ico|foto/icons/|icons/|ix/images/|imgs/|js/|security/icons/|software/screenshots/|stil/|security/dienste/portscan/test/go\.shtml|support/lib/)" />
-		<exclusion pattern="^http://www\.heise\.de/js/foto/galerie/angularjs/partials/ngDialog.inc" />
-		<exclusion pattern="^http://www\.heise\.de/js/foto/galerie/angularjs/partials/photo/diashow.html" />
-		<exclusion pattern="^http://www\.heise\.de/js/ho/jwplayer-6.10/skin/" />
+			<test url="http://m.heise.de/icons/mobi/favicon.ico" />
+			<test url="http://m.heise.de/icons/mobi/menu_button.png" />
+			<test url="http://m.heise.de/ivw-bin/ivw/CP/" />
+			<test url="http://m.heise.de/js/mobi/mobi.min.js" />
+			<test url="http://m.heise.de/security/icons/security_logo_smartphone_hdpi_color.png" />
+			<test url="http://m.heise.de/stil/mobi/mobi2013.css" />
 
 			<!--	+ve:
 					-->
-			<test url="http://www.heise.de/download/"/>
-			<test url="http://www.heise.de/foto/"/>
 			<test url="http://www.heise.de/js/foto/galerie/angularjs/partials/ngDialog.inc"/>
 			<test url="http://www.heise.de/js/foto/galerie/angularjs/partials/photo/diashow.html"/>
 			<test url="http://www.heise.de/js/ho/jwplayer-6.10/skin/bekle.xml" />
-			<test url="http://www.heise.de/mediadaten/online/" />
-			<test url="http://www.heise.de/news-extern/news.html" />
-			<test url="http://www.heise.de/newsletter/manage/heisec-summary" />
-			<test url="http://www.heise.de/newsticker/" />
-			<test url="http://www.heise.de/security/artikel/" />
-			<test url="http://www.heise.de/security/hilfe/" />
-			<test url="http://www.heise.de/security/news/" />
-			<test url="http://www.heise.de/security/news/archiv/" />
-			<test url="http://www.heise.de/security/news/news-atom.xml" />
-			<test url="http://www.heise.de/security/tools/" />
 
 			<!--	-ve:
 					-->
-			<test url="http://heise.de/avw-bin/ivw/CP/barfoo/ho/2793053/0.gif" />
+			<test url="http://www.heise.de/avw-bin/ivw/CP/barfoo/ho/2793053/0.gif" />
+			<test url="http://www.heise.de/ivw-bin/ivw/CP/download" />
 			<test url="http://www.heise.de/favicon.ico" />
 			<test url="http://www.heise.de/foto/icons/galerie/avatar_48.png" />
 			<test url="http://www.heise.de/icons/ho/heise_online_logo_top.gif" />
 			<test url="http://www.heise.de/imgs/02/1/2/5/5/4/2/0/newsletter_briefumschlag_ho_klein2-4b495d4dbd4ddf57.png" />
 			<test url="http://www.heise.de/ix/images/navigation_arrow.png" />
+			<test url="http://www.heise.de/scale/geometry/250/q50/imgs/18/1/7/6/3/3/3/9/heise-tls-0d8d7711ff4ce298.png" />
 			<test url="http://www.heise.de/js/heise.min.js" />
 			<test url="http://www.heise.de/js/ho/login.min.js" />
-			<test url="http://www.heise.de/security/dienste/portscan/test/go.shtml" />
-			<test url="http://www.heise.de/security/icons/bg_blue.gif" />
+			<test url="http://www.heise.de/security" />
+			<test url="http://www.heise.de/security/" />
 			<test url="http://www.heise.de/stil/heise-ui.css" />
 			<test url="http://www.heise.de/support/lib/teaser_linking.js" />
+			<test url="http://www.heise.de/software/screenshots/" />
+			<test url="http://www.heise.de/video/imgs/78/1/8/6/1/0/2/8/dtek50-484c0a9567afe57b.jpeg" />
+			<test url="http://www.heise.de/video/latest_vids.xml" />
+
 
 	<rule from="^http://m\.heise\.de/(js/|icons/|[ai]vw-bin/|security/icons/|stil/|fonts/)" to="https://m.heise.de/$1"/>
+		<exclusion pattern="^http://m\.heise\.de/$" />
 
-	<rule from="^http://heise\.de/"
-		to="https://www.heise.de/"/>
+	<rule from="^http://(abo|piwik\.shop|prophet|shop)\.heise\.de/" to="https://$1.heise.de/"/>
 
 	<rule from="^http://www\.shop\.heise\.de/"
 		to="https://shop.heise.de/" />
 
-	<rule from="^http:"
-		to="https:" />
+	<rule from="^http://www\.heise\.de/security"
+		to="https://www.heise.de/security/" />
+
+	<rule from="^http://www\.heise\.de/([ai]vw-bin/|favicon\.ico|foto/icons/|icons/|ix/images/|imgs/|js/|scale/|security/|software/screenshots/|stil/|support/lib/|video/)" to="https://www.heise.de/$1"/>
+		<exclusion pattern="^http://www\.heise\.de/$" />
+		<!-- fix for #2308 -->
+		<exclusion pattern="^http://www\.heise\.de/js/foto/galerie/angularjs/partials/ngDialog\.inc" />
+		<exclusion pattern="^http://www\.heise\.de/js/foto/galerie/angularjs/partials/photo/diashow\.html" />
+		<exclusion pattern="^http://www\.heise\.de/js/ho/jwplayer-6.10/skin/" />
 
 </ruleset>


### PR DESCRIPTION
- everything below /security/ is no longer redirected to plain for testing reasons
- secure more images on the main domain
- simplify exclusion pattern
- more testurls