### PR TITLE
[Wikimedia] Fix missing <target> for wikimedia.cz

### DIFF
--- a/src/chrome/content/rules/Wikimedia.xml
+++ b/src/chrome/content/rules/Wikimedia.xml
@@ -58,6 +58,7 @@
 		<test url="http://upload-www.wikimedia.ch/" />
 
 	<!-- wikimedia.cz uses an invalid certificate, redirecting to www -->
+	<target host="wikimedia.cz" />
 	<target host="www.wikimedia.cz" />
 	<target host="lists.wikimedia.cz" />
 	<target host="tracker.wikimedia.cz" />
@@ -146,7 +147,6 @@
 
 	<rule from="^http://wikimedia\.cz/"
 		to="https://www.wikimedia.cz/" />
-		<test url="http://wikimedia.cz/" />
 
 	<rule from="^http://links\.email\.donate\.wikimedia\.org/"
 		to="https://www.links.mkt41.net/" />


### PR DESCRIPTION
It has a `<rule>` for `wikimedia.cz`, but no `<target>`.

I assume it was inadvertently omitted.

I also removed a redundant `<test>` that will be taken care of automatically.