### PR TITLE
Added trivial rule for speedrun.com domain.

### DIFF
--- a/src/chrome/content/rules/Speedrun.com.xml
+++ b/src/chrome/content/rules/Speedrun.com.xml
@@ -1,0 +1,6 @@
+<ruleset name="Speedrun.com">
+	<target host="speedrun.com" />
+	<target host="www.speedrun.com" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>


### PR DESCRIPTION
Simple trivial rule for a new domain.  This domain has SSL support already and everything appears to work fine.