### PR TITLE
Google - Default redirection to HTTPS

### DIFF
--- a/src/chrome/content/rules/Google.xml
+++ b/src/chrome/content/rules/Google.xml
@@ -431,4 +431,9 @@
 		<test url="http://www.google.ca/firefox/" />
 		<test url="http://www.google.com/firefox/" />
 		<test url="http://www.google.com.au/firefox/" />
+
+	<!-- Default redirection to HTTPS -->
+	<rule from="^http:"
+		to="https:" />
+		<test url="http://www.google.com/humans.txt" />
 </ruleset>


### PR DESCRIPTION
A default redirection rule is missing in Google.xml.
You can see the effect when opening
http://www.google.com/humans.txt