### PR TITLE
[Wikimedia] Remove exclusion of some domains

### DIFF
--- a/src/chrome/content/rules/Wikimedia.xml
+++ b/src/chrome/content/rules/Wikimedia.xml
@@ -24,12 +24,8 @@
 
 	<target host="wikimedia.org" />
 	<target host="*.wikimedia.org" />
-		<exclusion pattern="^http://(?:apt|parsoid-lb\.eqiad|status|ubuntu)\.wikimedia\.org" />
-		<!-- https://mail1.eff.org/pipermail/https-everywhere-rules/2012-June/001189.html -->
-			<test url="http://apt.wikimedia.org" />
-			<test url="http://parsoid-lb.eqiad.wikimedia.org" />
+		<exclusion pattern="^http://status\.wikimedia\.org" />
 			<test url="http://status.wikimedia.org" />
-			<test url="http://ubuntu.wikimedia.org" />
 
 	<!-- Wikimedia Tool Labs -->
 	<target host="tools.wmflabs.org" />


### PR DESCRIPTION
1. https://apt.wikimedia.org, https://ubuntu.wikimedia.org now work.
2. parsoid-lb.eqiad.wikimedia.org doesn't exist in DNS.
3. The [URL](https://mail1.eff.org/pipermail/https-everywhere-rules/2012-June/001189.html) in the comment is irrelevant.