### PR TITLE
New ruleset for GnuCash

### DIFF
--- a/src/chrome/content/rules/GnuCash.xml
+++ b/src/chrome/content/rules/GnuCash.xml
@@ -1,0 +1,15 @@
+<ruleset name="GnuCash">
+
+	<target host="gnucash.org" />
+	<target host="lists.gnucash.org" />
+	<target host="svn.gnucash.org" />
+	<target host="wiki.gnucash.org" />
+	<target host="www.gnucash.org" />
+
+	<securecookie host="(^|\.)(lists|svn|wiki|www)\.gnucash\.org$"
+			name=".+" />
+
+	<rule from="^http:"
+		to="https:" />
+
+</ruleset>


### PR DESCRIPTION
As mixed content goes, the page https://svn.gnucash.org/ has an image that is embedded via the URL http://www.ihtfp.com/Ihtfp.gif From what one understands, the default setting for Firefox is to load images (but not scripts) that are fetched via HTTP but embedded in an HTTPS page. As such, the functionality of the page should not be affected.