### PR TITLE
[Princeton.edu] Remove subdomain tigernet

### DIFF
--- a/src/chrome/content/rules/Princeton.edu.xml
+++ b/src/chrome/content/rules/Princeton.edu.xml
@@ -8,17 +8,17 @@ Fetch error: http://princeton.edu/ => https://www.princeton.edu/: Redirect for '
     - digilab **
     - findingaids **
     - pudl **
+    - tigernet ***
 
   * Refused
   ** Dropped
+  *** Mismatch
 
   UNIX homedirs are also broken, eg:
 
   http://www.princeton.edu/~achaney/tmve/wiki100k/docs/Conjunctive_normal_form.html
 
   ^ In what way? (not broken anymore?)
-
-  tigernet logout page references http://www.alumniconnections.com for stylesheets, but page still works. tigernet, itself, has locally referenced stylesheets.
 
   Fully covered subdomains:
     - alumni
@@ -36,7 +36,7 @@ Fetch error: http://princeton.edu/ => https://www.princeton.edu/: Redirect for '
 -->
 
 <ruleset name="Princeton.edu (partial)">
-  <securecookie host="^(?:alumnicas|blogs|fed|tigernet)\.princeton\.edu$" name=".+" />
+  <securecookie host="^(?:alumnicas|blogs|fed)\.princeton\.edu$" name=".+" />
   
   <target host="princeton.edu" />
   <target host="www.princeton.edu" />
@@ -47,7 +47,6 @@ Fetch error: http://princeton.edu/ => https://www.princeton.edu/: Redirect for '
   <target host="fed.princeton.edu" />
   <target host="lists.princeton.edu" />
   <target host="paw.princeton.edu" />
-  <target host="tigernet.princeton.edu" />
 
   <rule from="^http:" to="https:" />
 </ruleset>


### PR DESCRIPTION
The domain serves an invalid certificate; this in particular fixes https://github.com/EFForg/https-everywhere/issues/4665