### PR TITLE
Reinstall pycurl, making sure it uses OpenSSL instead of GnuTLS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ virtualenv:
 install:
   - pip install -r test/rules/requirements.txt
   - pip install -r test/chromium/requirements.txt
+  - PYCURL_SSL_LIBRARY=openssl pip install --upgrade --force-reinstall --compile pycurl
 env:
   - FIREFOX_VERSION=firefox-latest
   - FIREFOX_VERSION=firefox-esr-latest
@@ -32,6 +33,6 @@ before_script:
   - export FIREFOX=$PWD/firefox/firefox
 script:
   - ./test.sh
-  - # test/travis-ruleset-fetch.sh
+  - test/travis-ruleset-fetch.sh
 sudo: required
 dist: trusty


### PR DESCRIPTION
(from https://github.com/EFForg/https-everywhere/issues/4645#issuecomment-214907617)

The problem seems to be not that we're using an outdated version of `curl` and `libcurl`, but that the version of `pycurl` that is installed by default in the travis build system uses `gnutls`, which apparently as @mnordhoff states does not support ECDSA keys.

I found that running the fetch test on https://github.com/EFForg/https-everywhere/blob/master/src/chrome/content/rules/Archive.is.xml on my local instance of Ubuntu 14.04 did not result in an error.  Thinking it curious, I noticed that the errors that we encounter are referencing `gnutls`, but that my own pycurl uses `openssl`.  I had both libraries installed, but it seems that pycurl prefers `openssl` when it is available, unless explicitly told not to.  When travis hits the `pip install -r test/rules/requirements.txt` step, it skips over pycurl because the build environment already has it installed:

```shell
$ pip install -r test/rules/requirements.txt

Requirement already satisfied (use --upgrade to upgrade): pycurl in /usr/lib/python2.7/dist-packages (from -r test/rules/requirements.txt (line 1))
```

This system pycurl in `/usr/lib/python2.7/dist-packages` must have had `gnutls` explicitly preferred.  We can fix this by following up the `pip install -r` commands with a `PYCURL_SSL_LIBRARY=openssl pip install --upgrade --force-reinstall --compile pycurl` command.  This seems to work, using `openssl` instead: https://travis-ci.org/Hainish/https-everywhere/jobs/125960621

I've opened a PR with the fix https://github.com/EFForg/https-everywhere/pull/4683

Fortunately, this is much quicker than building `curl` and `libcurl` on travis - in another branch I saw it adding ~2.5 mins to our test time.