### PR TITLE
Add Egotastic.com

### DIFF
--- a/src/chrome/content/rules/Egotastic.xml
+++ b/src/chrome/content/rules/Egotastic.xml
@@ -1,0 +1,9 @@
+<ruleset name="Egotastic">
+
+	<target host="egotastic.com" />
+	<target host="www.egotastic.com" />
+
+	<rule from="^http:"
+		to="https:" />
+
+</ruleset>


### PR DESCRIPTION
Mixed content warning for some advertising scripts. Is that a problem? Seems to me like security shouldn't be compromised for ads. What's the rule of thumb here?
Edit: Would it be better to add a platform="mixedcontent"?