### PR TITLE
Add ruleset for growerscup.coffee

### DIFF
--- a/src/chrome/content/rules/growerscup.coffee.xml
+++ b/src/chrome/content/rules/growerscup.coffee.xml
@@ -1,0 +1,7 @@
+<ruleset name="growerscup.coffee">
+	<target host="www.growerscup.coffee" />
+	<target host="growerscup.coffee" />
+	
+	<rule from="^http:"
+		to="https:" />
+</ruleset>


### PR DESCRIPTION
The site _does_ have HSTS enabled, but it isn't preloaded and there's no HTTP -> HTTPS redirect, so one still has to explicitly type https:// to get to the site securely the first time.