### PR TITLE
[CJS-CDKeys.com] Splits ruleset due to false MCB; fixes #4498

### DIFF
--- a/src/chrome/content/rules/CJS-CDKeys.com-mixed.xml
+++ b/src/chrome/content/rules/CJS-CDKeys.com-mixed.xml
@@ -1,0 +1,12 @@
+<ruleset name="CJS-CDKeys.com (mixed content)" platform="mixedcontent">
+
+	<target host="cjs-cdkeys.com" />
+	<target host="www.cjs-cdkeys.com" />
+
+
+	<securecookie host="^\.cjs-cdkeys\.com$" name=".+" />
+
+
+	<rule from="^http:" to="https:" />
+
+</ruleset>

--- a/src/chrome/content/rules/CJS-CDKeys.com.xml
+++ b/src/chrome/content/rules/CJS-CDKeys.com.xml
@@ -1,11 +1,30 @@
-<ruleset name="CJS-CDKeys.com">
+<!--
+	Rule to secure static content. See CJS-CDKeys.com-mixed.xml for
+	a more general ruleset, including a rule that cause breakage in
+	mixed content blocking browsers.
+-->
+<ruleset name="CJS-CDKeys.com (partial)">
 
 	<target host="cjs-cdkeys.com" />
 	<target host="www.cjs-cdkeys.com" />
 
+	<!-- Exclude everything but stuff that is static enough. -->
+	<exclusion pattern="^(?![\w:/.-]+\.(css|gif|ico|jpg|js|png)$)" />
+		<!-- Matching exclusion -->
+		<test url="http://cjs-cdkeys.com/" />
+		<test url="http://www.cjs-cdkeys.com/" />
+		<test url="http://www.cjs-cdkeys.com/account.php" />
+		<test url="http://www.cjs-cdkeys.com/cart.php" />
+		<test url="http://www.cjs-cdkeys.com/wishlist.php" />
+		<test url="http://www.cjs-cdkeys.com/orderstatus.php" />
 
-	<securecookie host="^\.cjs-cdkeys\.com$" name=".+" />
-
+		<!-- Not matching exclusion -->
+		<test url="http://cjs-cdkeys.com/templates/Infinity/Styles/red.css" />
+		<test url="http://www.cjs-cdkeys.com/templates/Infinity/images/red/Search.gif" />
+		<test url="http://cjs-cdkeys.com/favicon.ico" />
+		<test url="http://cjs-cdkeys.com/product_images/uploaded_images/just-cause-3-cd-key.jpg" />
+		<test url="http://www.cjs-cdkeys.com/slider/themes/1/js-image-slider.js" />
+		<test url="http://www.cjs-cdkeys.com/trustpilot.png" />
 
 	<rule from="^http:" to="https:" />
 


### PR DESCRIPTION
This modifies <code>trivial-validate.py</code> to no longer include the test for unescaped dots in the exclusion patterns; this test was introduced by @jsha in fb2d2bfd8ad0ca9ae169d3de283b58d0a3a1838e, which makes me think that it is probably there for a reason, though (no reason is given in the commit message specifically, but the same commit fixes up two patterns where wildcards were used (erroneously in one case)).

In this case, I ended up scratching my head for a good while because of it, as I used wildcards in an exclusion in order to fix #4498.

Edit: This no longer changes the test but only fixes the ruleset; see below.