### PR TITLE
[Minecraft] Update ruleset

### DIFF
--- a/src/chrome/content/rules/Minecraft.xml
+++ b/src/chrome/content/rules/Minecraft.xml
@@ -1,3 +1,10 @@
+<!--
+	Problematic subdomains:
+
+		- education ¹
+
+	¹: Mismatched
+-->
 <ruleset name="Minecraft">
 
 	<target host="minecraft.net" />
@@ -7,9 +14,7 @@
 	<securecookie host="^www\.minecraft\.net$" name=".*" />
 
 
-	<!--	!www doesn't work.
-					-->
-	<rule from="^http://(?:www\.)?minecraft\.net/"
-		to="https://www.minecraft.net/" />
+	<rule from="^http:"
+		to="https:" />
 
 </ruleset>


### PR DESCRIPTION
Both ^ and www now work. This also adds a comment about a broken subdomain.

This closes https://github.com/EFForg/https-everywhere/issues/4703