### PR TITLE
[Linode] https://status.linode.com/ has a proper certificate now.

### DIFF
--- a/src/chrome/content/rules/Linode.xml
+++ b/src/chrome/content/rules/Linode.xml
@@ -25,12 +25,6 @@
 
 	¹ Refused
 	² Customer load balancers and VPSes. Mismatched, refused or time out.
-
-	Problematic hosts in *linode.com:
-
-		- status *
-
-	* StatusPage.io
 -->
 <ruleset name="Linode.com">
 
@@ -51,6 +45,7 @@
 	<target host="login.linode.com" />
 	<target host="manager.linode.com" />
 	<target host="stats.linode.com" />
+	<target host="status.linode.com" />
 	<target host="atlanta.webconsole.linode.com" />
 	<target host="dallas.webconsole.linode.com" />
 	<target host="frankfurt.webconsole.linode.com" />
@@ -61,20 +56,12 @@
 	<target host="tokyo.webconsole.linode.com" />
 	<target host="www.linode.com" />
 
-	<!--	Complications:
-				-->
-	<target host="status.linode.com" />
-
-
 	<!--	Not secured by server:
 					-->
 	<!--securecookie host="^\.forum\.linode\.com$" name="^phpbb3_\w+_(k|sid|u)$" /-->
 
 	<securecookie host="^(?:.*\.)?linode\.com$" name=".+" />
 
-
-	<rule from="^http://status\.linode\.com/"
-		to="https://linode.statuspage.io/" />
 
 	<rule from="^http:"
 		to="https:" />


### PR DESCRIPTION
(It's still StatusPage.io.)

This is low priority, since the old redirect to https://linode.statuspage.io/ still works (for now, at least). But this is nicer. :smile:

Edit: On Travis, the firefox-latest tests succeeded, and firefox-esr-latest failed. Probably due to cached DNS. I'll rerun it later. I suppose it shouldn't be merged for ~24 hours until old DNS caches have expired anyway.

Edit: Travis is green now.