### PR TITLE
Cleanup the gluster.org rules

### DIFF
--- a/src/chrome/content/rules/Gluster.org.xml
+++ b/src/chrome/content/rules/Gluster.org.xml
@@ -4,24 +4,26 @@
 
 	Fully covered hosts in *gluster.org:
 
-		- (www.)?
-		- forge
+		- (www.)
+        - lists
+        - download
 
+    There is still issue with dev.gluster.org (waiting on migration
+    to a new host) and issue with the cookie for jenkins (again, waiting
+    on cleaning the config on the jenkins side).
+
+    A proper certificate should also be deployed for gluster.org to www
+    redirection
 -->
 <ruleset name="Gluster.org">
 
 	<!--	Direct rewrites:
 				-->
-	<target host="gluster.org" />
-	<target host="forge.gluster.org" />
 	<target host="www.gluster.org" />
-
-
-	<!--	Not secured by server:
-					-->
-	<!--securecookie host="^\.forge\.gluster\.org$" name="^_gitorious_sess$" /-->
-
-	<securecookie host="^\.forge\.gluster\.org$" name=".+" />
+	<target host="build.gluster.org" />
+	<target host="download.gluster.org" />
+	<target host="lists.gluster.org" />
+	<target host="blog.gluster.org" />
 
 
 	<rule from="^http:"


### PR DESCRIPTION
forge.gluster.org no longer exist (cf https://www.mail-archive.com/gluster-infra@gluster.org/msg01062.html)
a few more hosts have been added and secured with letsencrypt and/or digicert:
- build (jenkins)
- lists (a alias for mailman to be added)
- download, to download tarballs
- blog, for wordpress

Some others are to be added later (gerrit instance on dev.gluster.org),
and several historical alias may need to be added and/or deprecated.

And a audit of secure cookies must be done to add the proper rules.
