### PR TITLE
[OpenBSD.org] Enable, add ^ lists www, remove https.

### DIFF
--- a/src/chrome/content/rules/OpenBSD.org.xml
+++ b/src/chrome/content/rules/OpenBSD.org.xml
@@ -1,17 +1,24 @@
 <!--
-	Nonfunctional hosts in *openbsd.org:
+	Problematic subdomains:
 
-		- (www.) *
-		- cvsweb *
-		- https *
+		- ^ ¹
+		- cvsweb ²
+		- firmware ¹
+		- ftp, ftp.eu, ftp2.eu, &c ¹²
+		- man ²
+		- portroach ¹
 
-	* Refused
-
+	¹ Mismatched
+	² Refused
 -->
-<ruleset name="OpenBSD.org (partial)" default_off="connection refusd">
+<ruleset name="OpenBSD.org (partial)">
 
-	<target host="https.openbsd.org" />
+	<target host="openbsd.org" />
+	<target host="lists.openbsd.org" />
+	<target host="www.openbsd.org" />
 
+	<rule from="^http://openbsd\.org/"
+		to="https://www.openbsd.org/" />
 
 	<rule from="^http:"
 		to="https:" />


### PR DESCRIPTION
* Enable
* Add `^`, `lists` & `www`
* Remove `https` (no longer resolves)

Reported by someone on IRC.

They also mentioned that `cvsweb` may or may not be coming soon, but in any case it isn't here yet.