### PR TITLE
[Minecraft] Add subdomains

### DIFF
--- a/src/chrome/content/rules/Minecraft-falsemixed.xml
+++ b/src/chrome/content/rules/Minecraft-falsemixed.xml
@@ -1,0 +1,11 @@
+<!--
+	See also Minecraft.xml
+-->
+<ruleset name="Minecraft (mixed content)" platform="mixedcontent">
+
+	<target host="pi.minecraft.net" />
+
+	<rule from="^http:"
+		to="https:" />
+
+</ruleset>

--- a/src/chrome/content/rules/Minecraft.xml
+++ b/src/chrome/content/rules/Minecraft.xml
@@ -1,18 +1,27 @@
 <!--
+	See also Minecraft-falsemixed.xml.
+
 	Problematic subdomains:
 
 		- education ¹
+		- hopper ²
+		- pocketbeta ³
+		- redstone ¹
 
 	¹: Mismatched
+	²: Refused
+	³: curl: Unknown SSL protocol error
 -->
 <ruleset name="Minecraft">
 
 	<target host="minecraft.net" />
 	<target host="www.minecraft.net" />
 
+	<target host="atlas.minecraft.net" />
+	<target host="beta.minecraft.net" />
+	<target host="feedback.minecraft.net" />
 
 	<securecookie host="^www\.minecraft\.net$" name=".*" />
-
 
 	<rule from="^http:"
 		to="https:" />


### PR DESCRIPTION
As a follow-up on https://github.com/EFForg/https-everywhere/pull/4706#issuecomment-217903213, this adds several subdomains as targets, adds comments on broken ones, and adds a separate ruleset for a subdomain subject to false mixed content blocking.