### PR TITLE
Add 1fichier.com and mirrors

### DIFF
--- a/src/chrome/content/rules/1fichier.xml
+++ b/src/chrome/content/rules/1fichier.xml
@@ -12,6 +12,10 @@
 	<target host="tenvoi.com" />
 	<target host="dl4free.com" />
 
+	<!-- not working:
+		dfichiers.com
+	-->
+
 	<rule from="^http:"
 		to="https:" />
 

--- a/src/chrome/content/rules/1fichier.xml
+++ b/src/chrome/content/rules/1fichier.xml
@@ -1,0 +1,18 @@
+<ruleset name="1fichier">
+
+	<target host="1fichier.com" />
+	<target host="*.1fichier.com" />
+	<target host="alterupload.com" />
+	<target host="cjoint.net" />
+	<target host="desfichiers.com" />
+	<target host="megadl.fr" />
+	<target host="mesfichiers.org" />
+	<target host="piecejointe.net" />
+	<target host="pjointe.com" />
+	<target host="tenvoi.com" />
+	<target host="dl4free.com" />
+
+	<rule from="^http:"
+		to="https:" />
+
+</ruleset>

--- a/src/chrome/content/rules/1fichier.xml
+++ b/src/chrome/content/rules/1fichier.xml
@@ -1,3 +1,8 @@
+<!--
+	Mismatch:
+	- dfichiers.com
+-->
+
 <ruleset name="1fichier">
 
 	<target host="1fichier.com" />
@@ -11,10 +16,6 @@
 	<target host="pjointe.com" />
 	<target host="tenvoi.com" />
 	<target host="dl4free.com" />
-
-	<!-- not working:
-		dfichiers.com
-	-->
 
 	<rule from="^http:"
 		to="https:" />

--- a/src/chrome/content/rules/1fichier.xml
+++ b/src/chrome/content/rules/1fichier.xml
@@ -19,9 +19,9 @@
 	<target host="tenvoi.com" />
 	<target host="dl4free.com" />
 
-    <test url="https://img.1fichier.com/favicon.ico" />
-    <test url="https://a-25.1fichier.com/12345" />
-    <test url="https://up2.1fichier.com/end.pl?xid=12345" />
+    	<test url="https://img.1fichier.com/favicon.ico" />
+    	<test url="https://a-25.1fichier.com/12345" />
+    	<test url="https://up2.1fichier.com/end.pl?xid=12345" />
 
 	<rule from="^http:"
 		to="https:" />

--- a/src/chrome/content/rules/1fichier.xml
+++ b/src/chrome/content/rules/1fichier.xml
@@ -19,9 +19,9 @@
 	<target host="tenvoi.com" />
 	<target host="dl4free.com" />
 
-    	<test url="https://img.1fichier.com/favicon.ico" />
-    	<test url="https://a-25.1fichier.com/12345" />
-    	<test url="https://up2.1fichier.com/end.pl?xid=12345" />
+    	<test url="http://www.1fichier.com/" />
+    	<test url="http://img.1fichier.com/" />
+    	<test url="http://st-1.1fichier.com/" />
 
 	<rule from="^http:"
 		to="https:" />

--- a/src/chrome/content/rules/1fichier.xml
+++ b/src/chrome/content/rules/1fichier.xml
@@ -1,4 +1,6 @@
 <!--
+	All non-1fichier.com URLs are mirrors of https://1fichier.com/ .
+	
 	Mismatch:
 	- dfichiers.com
 -->
@@ -16,6 +18,10 @@
 	<target host="pjointe.com" />
 	<target host="tenvoi.com" />
 	<target host="dl4free.com" />
+
+    <test url="https://img.1fichier.com/favicon.ico" />
+    <test url="https://a-25.1fichier.com/12345" />
+    <test url="https://up2.1fichier.com/end.pl?xid=12345" />
 
 	<rule from="^http:"
 		to="https:" />


### PR DESCRIPTION
Example link: `https://alterupload.com/?dkqfao9flj`
One of their domains (dfichiers.com) wasn't configured correctly (SSL_ERROR_BAD_CERT_DOMAIN) so I left it out.