### PR TITLE
Modify url for checker to behave more like uri.href behaves in js

### DIFF
--- a/test/rules/src/https_everywhere_checker/rules.py
+++ b/test/rules/src/https_everywhere_checker/rules.py
@@ -1,4 +1,5 @@
 import regex
+from urlparse import urlparse
 
 class Rule(object):
 	"""Represents one from->to rule element."""
@@ -141,6 +142,12 @@ class Ruleset(object):
 		
 		@param url: string URL
 		"""
+
+		# format url in accordance with with how uri object is serialized in js
+		parsed_url = urlparse(url)
+		if parsed_url.path == '':
+			url = parsed_url._replace(path="/").geturl()
+
 		if self.excludes(url):
 			return url
 		


### PR DESCRIPTION
When running the `https_everywhere_checker` fetch test, I noticed that some rule exceptions were not being matched when they should.  For example, in `rules/Lenovo.xml` there is an exception for `http://social.lenovo.com/`, but this exception is not matched for the test url `http://social.lenovo.com` since it lacks the trailing `/`.  This results in the fetch test attempting to fetch `https://social.lenovo.com`, which is not the intended behavior (this fails).

In javascript, this is not an issue, since when the URL is applied to the `RuleSets`, it is first modified so that the trailing `/` is always present.  Likewise, in our `node.js` scripts creating a `URIjs` `URI` object does the same.

Here are a few examples that should result in the same output, but don't:

https://github.com/Hainish/https-everywhere/blob/fix-checker-example/test.js
https://github.com/Hainish/https-everywhere/blob/fix-checker-example/test/rules/src/https_everywhere_checker/test.py

This PR modifies the URL passed to `apply` in `rules.js` so that the trailing slash is always present.