### PR TITLE
[Craigslist.org] Downgrade geo.craigslist.org

### DIFF
--- a/src/chrome/content/rules/Craigslist.org.xml
+++ b/src/chrome/content/rules/Craigslist.org.xml
@@ -36,6 +36,7 @@
 		<test url="http://losangeles.craigslist.org/" />
 		<test url="http://sfbay.craigslist.org/" />
 		<test url="http://amsterdam.craigslist.org/" />
+		<test url="http://moscow.craigslist.org/" />
 
 	<securecookie host=".+" name=".+" />
 

--- a/src/chrome/content/rules/Craigslist.org.xml
+++ b/src/chrome/content/rules/Craigslist.org.xml
@@ -35,6 +35,7 @@
 
 		<test url="http://losangeles.craigslist.org/" />
 		<test url="http://sfbay.craigslist.org/" />
+		<test url="http://amsterdam.craigslist.org/" />
 
 	<securecookie host=".+" name=".+" />
 

--- a/src/chrome/content/rules/Craigslist.org.xml
+++ b/src/chrome/content/rules/Craigslist.org.xml
@@ -15,42 +15,40 @@
 
 -->
 <ruleset name="Craigslist.org (partial)">
-  <target host="craigslist.org" />
-  <target host="*.craigslist.org" />
+	<target host="craigslist.org" />
+	<target host="*.craigslist.org" />
 
-		<exclusion pattern="^http://blog\.craigslist\.org/" />
+	<exclusion pattern="^http://blog\.craigslist\.org/" />
 
-			<test url="http://blog.craigslist.org/" />
+		<test url="http://blog.craigslist.org/" />
 
-		<!--	Redirect to http:
-						-->
-		<exclusion pattern="^http://www\.craigslist\.org/$" />
+	<!--	Redirect to http:
+					-->
+	<exclusion pattern="^http://www\.craigslist\.org/$" />
 
-			<test url="http://www.craigslist.org/" />
+		<test url="http://www.craigslist.org/" />
 
-		<exclusion pattern="^http://geo\.craigslist\.org/" />
+	<exclusion pattern="^http://geo\.craigslist\.org/" />
 
-			<test url="http://geo.craigslist.org/" />
-			<test url="https://geo.craigslist.org/" />
+		<test url="http://geo.craigslist.org/" />
+		<test url="https://geo.craigslist.org/" />
 
-		<test url="http://losangeles.craigslist.org/" />
-		<test url="http://sfbay.craigslist.org/" />
-		<test url="http://amsterdam.craigslist.org/" />
-		<test url="http://moscow.craigslist.org/" />
+	<test url="http://losangeles.craigslist.org/" />
+	<test url="http://sfbay.craigslist.org/" />
+	<test url="http://amsterdam.craigslist.org/" />
+	<test url="http://moscow.craigslist.org/" />
 
 	<securecookie host=".+" name=".+" />
 
-  <rule from="^http://craigslist\.org/" to="https://www.craigslist.org/" />
+	<rule from="^http://craigslist\.org/" to="https://www.craigslist.org/" />
 
-  <!--
-  	(May 2016) Craigslist only supports https on its .org, .ca, and .co.uk domains.
-  	geo.craigslist.org redirects to regional sites by sending protocol-relative
-  	redirects such as "//toronto.craigslist.ca". Unfortunately, it does this even when
-  	the destination doesn't support https, such as helsinki.craigslist.fi, making a
-  	downgrade and exclusion necessary.
-  				-->
-  <rule from="^https://geo\.craigslist\.org/" to="http://geo.craigslist.org/" downgrade="1" />
+	<!-- (May 2016) Craigslist only supports https on its .org, .ca, and .co.uk
+	domains. geo.craigslist.org redirects to regional sites by sending protocol-
+	relative redirects such as "//toronto.craigslist.ca". Unfortunately, it does this
+	even when the destination doesn't support https, such as helsinki.craigslist.fi,
+	making a downgrade and exclusion necessary. -->
+	<rule from="^https://geo\.craigslist\.org/" to="http://geo.craigslist.org/" downgrade="1" />
 
-  <!-- As of 8/2013, 4th level craigslist.org domains do not support SSL. --> 
-  <rule from="^http://([\w-]+)\.craigslist\.org/" to="https://$1.craigslist.org/" />
+	<!-- As of 8/2013, 4th level craigslist.org domains do not support SSL. --> 
+	<rule from="^http://([\w-]+)\.craigslist\.org/" to="https://$1.craigslist.org/" />
 </ruleset>

--- a/src/chrome/content/rules/Craigslist.org.xml
+++ b/src/chrome/content/rules/Craigslist.org.xml
@@ -28,6 +28,11 @@
 
 			<test url="http://www.craigslist.org/" />
 
+		<exclusion pattern="^http://geo\.craigslist\.org/" />
+
+			<test url="http://geo.craigslist.org/" />
+			<test url="https://geo.craigslist.org/" />
+
 		<test url="http://losangeles.craigslist.org/" />
 		<test url="http://sfbay.craigslist.org/" />
 
@@ -38,6 +43,16 @@
 		to="https://geo.craiglist.org/" /-->
 
   <rule from="^http://craigslist\.org/" to="https://www.craigslist.org/" />
+
+  <!--
+  	(May 2016) Craigslist only supports https on its .org, .ca, and .co.uk domains.
+  	geo.craigslist.org redirects to regional sites by sending protocol-relative
+  	redirects such as "//toronto.craigslist.ca". Unfortunately, it does this even when
+  	the destination doesn't support https, such as helsinki.craigslist.fi, making a
+  	downgrade and exclusion necessary.
+  				-->
+  <rule from="^https://geo\.craigslist\.org/" to="http://geo.craigslist.org/" downgrade="1" />
+
   <!-- As of 8/2013, 4th level craigslist.org domains do not support SSL. --> 
   <rule from="^http://([^/:@.]+)\.craigslist\.org/" to="https://$1.craigslist.org/" />
 </ruleset>

--- a/src/chrome/content/rules/Craigslist.org.xml
+++ b/src/chrome/content/rules/Craigslist.org.xml
@@ -38,11 +38,6 @@
 
 	<securecookie host=".+" name=".+" />
 
-	<!--	Is this what the server always does?
-
-	<rule from="^http://(?:www\.)?craiglist\.org/$"
-		to="https://geo.craiglist.org/" /-->
-
   <rule from="^http://craigslist\.org/" to="https://www.craigslist.org/" />
 
   <!--

--- a/src/chrome/content/rules/Craigslist.org.xml
+++ b/src/chrome/content/rules/Craigslist.org.xml
@@ -36,6 +36,7 @@
 		<test url="http://losangeles.craigslist.org/" />
 		<test url="http://sfbay.craigslist.org/" />
 
+	<securecookie host=".+" name=".+" />
 
 	<!--	Is this what the server always does?
 

--- a/src/chrome/content/rules/Craigslist.org.xml
+++ b/src/chrome/content/rules/Craigslist.org.xml
@@ -55,5 +55,5 @@
   <rule from="^https://geo\.craigslist\.org/" to="http://geo.craigslist.org/" downgrade="1" />
 
   <!-- As of 8/2013, 4th level craigslist.org domains do not support SSL. --> 
-  <rule from="^http://([^/:@.]+)\.craigslist\.org/" to="https://$1.craigslist.org/" />
+  <rule from="^http://([\w-]+)\.craigslist\.org/" to="https://$1.craigslist.org/" />
 </ruleset>

--- a/utils/downgrade-whitelist.txt
+++ b/utils/downgrade-whitelist.txt
@@ -3,6 +3,7 @@ Apple.com (partial)
 CERN.ch (partial)
 Cheezburger
 Contextly.com (partial)
+Craigslist.org (partial)
 dafont.com (partial)
 dict.cc
 EvoTronix (partial)


### PR DESCRIPTION
- Fixes #3997 by downgrading and excluding geo.craigslist.org
- Adds securecookie
- Simplifies the subdomain rule pattern, as per the [Ruleset Style Guide](https://github.com/EFForg/https-everywhere/blob/master/ruleset-style.md)