### PR TITLE
[Lisonfan.com] Add ruleset

### DIFF
--- a/src/chrome/content/rules/Lisonfan.com.xml
+++ b/src/chrome/content/rules/Lisonfan.com.xml
@@ -1,0 +1,6 @@
+<ruleset name="Lisonfan.com">
+	<target host="lisonfan.com" />
+	<target host="www.lisonfan.com" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>


### PR DESCRIPTION
The site ships with a 301 redirect to HTTPS as well as the preload token but is not yet on any of the vendor preload lists. This closes https://github.com/EFForg/https-everywhere/issues/4804.