### PR TITLE
[Mozilla.xml] releases.mozilla.org now supports HTTPS

### DIFF
--- a/src/chrome/content/rules/Mozilla.xml
+++ b/src/chrome/content/rules/Mozilla.xml
@@ -78,7 +78,9 @@
 		- labs ¹
 		- talkback-public ⁴
 
-	¹ Refused
+	¹ https://labs.mozilla.org refuses connections.
+	  http://labs.mozilla redirects to http://mozillalabs.com, and
+	  https://mozillalabs.com uses a mismatched certificate.
 	* Mismatched, CN: status.io.watchmouse.com
 	⁴ Prompts for LDAP login; mismatched, CN: static-san.mozilla.org
 	⁵ Works; mismatched, CN: affiliates.mozilla.org
@@ -102,6 +104,7 @@
 
 		- affiliates
 		- affiliates-cdn	(→ affiliates.mozilla.org)
+		- archive
 		- air
 		- aus3
 		- aus4
@@ -247,6 +250,7 @@
 		<test url="http://advocacy.mozilla.org/" />
 		<test url="http://affiliates.mozilla.org/" />
 		<test url="http://air.mozilla.org/" />
+		<test url="http://archive.mozilla.org/" />
 		<test url="http://bonsai.mozilla.org/" />
 		<test url="http://bugzilla.mozilla.org/" />
 		<test url="http://bzr.mozilla.org/" />

--- a/src/chrome/content/rules/Mozilla.xml
+++ b/src/chrome/content/rules/Mozilla.xml
@@ -60,7 +60,6 @@
 			- graphs ³
 			- krakenbenchmark ³
 			- mig ³
-			- releases ³
 			- sfx-images ³		(banners)
 			- alerts.telemetry *
 			- website-archive ³
@@ -166,6 +165,7 @@
 		- planet
 		- pulse
 		- quality
+		- releases
 		- reps
 		- securitywiki
 		- sendto
@@ -228,7 +228,7 @@
 
 				https://mail1.eff.org/pipermail/https-everywhere-rules/2013-June/001635.html
 													-->
-		<exclusion pattern="^http://(?:europe|bonsai|browserquest|trychooser\.pub\.build|(?!image)\w+\.e|graphs|krakenbenchmark|mig|releases|sfx-images|alerts\.telemetry|w(?:ebsite|ww)-archive)\.mozilla\.org/" />
+		<exclusion pattern="^http://(?:europe|bonsai|browserquest|trychooser\.pub\.build|(?!image)\w+\.e|graphs|krakenbenchmark|mig|sfx-images|alerts\.telemetry|w(?:ebsite|ww)-archive)\.mozilla\.org/" />
 
 			<test url="http://bonsai.mozilla.org/" />
 			<test url="http://browserquest.mozilla.org/" />
@@ -236,8 +236,7 @@
 			<test url="http://click.e.mozilla.org/" />
 			<test url="http://graphs.mozilla.org/" />
 			<test url="http://krakenbenchmark.mozilla.org/" />
-			<test url="http://mig.mozilla.org/" />
-			<test url="http://releases.mozilla.org/" />
+			<test url="http://mig.mozilla.org/" />			
 			<test url="http://sfx-images.mozilla.org/" />
 			<test url="http://alerts.telemetry.mozilla.org/" />
 			<test url="http://website-archive.mozilla.org/" />
@@ -261,6 +260,7 @@
 		<test url="http://lists.mozilla.org/" />
 		<test url="http://planet.mozilla.org/" />
 		<test url="http://pulse.mozilla.org/" />
+		<test url="http://releases.mozilla.org/" />
 		<test url="http://sendto.mozilla.org/page/-/ssou-logos/twitter-bird-white-on-blue.png" />
 		<test url="http://start.mozilla.org/" />
 		<test url="http://status.mozilla.org/" />

--- a/src/chrome/content/rules/Mozilla.xml
+++ b/src/chrome/content/rules/Mozilla.xml
@@ -296,12 +296,6 @@
 
 		<test url="http://image.e.mozilla.org/" />
 
-	<rule from="^http://labs\.mozilla\.org/+"
-		to="https://mozillalabs.com/" />
-
-		<test url="http://labs.mozilla.org/" />
-		<test url="http://labs.mozilla.org//" />
-
 	<!--	Redirects like so over http.
 						-->
 	<rule from="^http://talkback-public\.mozilla\.org/"


### PR DESCRIPTION
https://releases.mozilla.org/ now works.