### PR TITLE
add rule for Teltarif.de

### DIFF
--- a/src/chrome/content/rules/Teltarif.xml
+++ b/src/chrome/content/rules/Teltarif.xml
@@ -1,0 +1,14 @@
+<ruleset name="Teltarif">
+
+	<target host="teltarif.de"/>
+	<target host="m.teltarif.de"/>
+	<target host="mobil.teltarif.de"/>
+	<target host="www.mobil.teltarif.de"/>
+	<target host="www.teltarif.de"/>
+
+	<securecookie host="^\.teltarif\.de$" name=".+" />
+
+	<rule from="^http:"
+		to="https:" />
+
+</ruleset>


### PR DESCRIPTION
According to
www.teltarif.de/https-verschluesselung-sicherheit/news/63626.html
did the website introduce TLS for both mobile and desktop version of their site