### PR TITLE
[Golem.de] Disable subdomain video

### DIFF
--- a/src/chrome/content/rules/Golem.de.xml
+++ b/src/chrome/content/rules/Golem.de.xml
@@ -1,3 +1,15 @@
+<!--
+	Problematic domains:
+
+		- ^ ¹
+		- ads ¹
+		- video ³
+		- whitepaperdb ²
+
+	¹: Refused
+	²: Expired
+	³: Breaks video (cf. GH #4770).
+-->
 <ruleset name="Golem.de">
 
 		<!--	Direct rewrites:
@@ -5,10 +17,7 @@
 	<target host="cpxl.golem.de" />
 	<target host="cpx.golem.de" />
 	<target host="account.golem.de" />
-	<target host="suche.golem.de"/>
-	<target host="video.golem.de" />
-	<!-- whitepaperdb.golem.de expired-->
-	<!-- TLS not supported on golem.de and ads.golem.de -->
+	<target host="suche.golem.de" />
 
 	<rule from="^http:" to="https:"/>
 


### PR DESCRIPTION
This fixes https://github.com/EFForg/https-everywhere/issues/4770. It would be nice of course to disable only part of the domain, but I couldn't find an easier way out of this one. In particular, the following attempts did not solve the problem:

* Exclude all js/swf/xml on the domain but leave the rest intact.
* Exclude everything but the "files/" subfolder (which contains
  the relevant videos).