### PR TITLE
Tor observatory integration (resolves #2719)

### DIFF
--- a/src/components/ssl-observatory.js
+++ b/src/components/ssl-observatory.js
@@ -176,7 +176,7 @@ SSLObservatory.prototype = {
 
   findSubmissionTarget: function() {
     // Compute the URL that the Observatory will currently submit to
-    var host = this.prefs.getCharPref("extensions.https_everywhere._observatory.server_host");
+    var host = this.myGetCharPref("server_host");
     // Rebuild the regexp iff the host has changed
     if (host != this.submit_host) {
       this.submit_host = host;
@@ -437,9 +437,13 @@ SSLObservatory.prototype = {
     return false;
   },
 
+  // following two methods are syntactic sugar
   myGetBoolPref: function(prefstring) {
-    // syntactic sugar
     return this.prefs.getBoolPref ("extensions.https_everywhere._observatory." + prefstring);
+  },
+
+  myGetCharPref: function(prefstring) {
+    return this.prefs.getCharPref ("extensions.https_everywhere._observatory." + prefstring);
   },
 
   isChainWhitelisted: function(chainhash) {
@@ -828,7 +832,7 @@ SSLObservatory.prototype = {
     // present.  The testingForTor argument is true in the latter case.
     var proxy_settings = ["direct", "", 0];
     this.log(INFO,"in getProxySettings()");
-    var custom_proxy_type = this.prefs.getCharPref("extensions.https_everywhere._observatory.proxy_type");
+    var custom_proxy_type = this.myGetCharPref("proxy_type");
     if (this.torbutton_installed && this.myGetBoolPref("use_tor_proxy")) {
       this.log(INFO,"CASE: use_tor_proxy");
       // extract torbutton proxy settings

--- a/src/components/ssl-observatory.js
+++ b/src/components/ssl-observatory.js
@@ -128,7 +128,9 @@ function SSLObservatory() {
     this.log(WARN, "Failed to initialize NSS component:" + e);
   }
 
-  this.testProxySettings();
+  // It is necessary to testProxySettings after the window is loaded, since the
+  // Tor Browser will not be finished establishing a circuit otherwise
+  OS.addObserver(this, "browser-delayed-startup-finished", false);
 
   this.log(DBUG, "Loaded observatory component!");
 }
@@ -397,6 +399,10 @@ SSLObservatory.prototype = {
           this.submitChain(chainArray, fps, subject.URI.host+":"+subject.URI.port, subject, host_ip, false);
         }
       }
+    }
+
+    if (topic == "browser-delayed-startup-finished") {
+      this.testProxySettings();
     }
   },
 

--- a/src/components/ssl-observatory.js
+++ b/src/components/ssl-observatory.js
@@ -772,6 +772,12 @@ SSLObservatory.prototype = {
      */
     this.proxy_test_successful = null;
 
+    if (this.getProxySettings().tor_safe == false) {
+      this.proxy_test_successful = false;
+      this.log(INFO, "Tor check failed: Not safe to check.");
+      return;
+    }
+
     try {
       var req = Components.classes["@mozilla.org/xmlextras/xmlhttprequest;1"]
                               .createInstance(Components.interfaces.nsIXMLHttpRequest);

--- a/src/components/ssl-observatory.js
+++ b/src/components/ssl-observatory.js
@@ -830,21 +830,27 @@ SSLObservatory.prototype = {
   getProxySettings: function(testingForTor) {
     // This may be called either for an Observatory submission, or during a test to see if Tor is
     // present.  The testingForTor argument is true in the latter case.
-    var proxy_settings = ["direct", "", 0];
+    var proxy_settings = {
+      type: "direct",
+      host: "",
+      port: 0,
+      tor_safe: false
+    };
     this.log(INFO,"in getProxySettings()");
     var custom_proxy_type = this.myGetCharPref("proxy_type");
     if (this.torbutton_installed && this.myGetBoolPref("use_tor_proxy")) {
       this.log(INFO,"CASE: use_tor_proxy");
       // extract torbutton proxy settings
-      proxy_settings[0] = "http";
-      proxy_settings[1] = this.prefs.getCharPref("extensions.torbutton.https_proxy");
-      proxy_settings[2] = this.prefs.getIntPref("extensions.torbutton.https_port");
+      proxy_settings.type = "http";
+      proxy_settings.host = this.prefs.getCharPref("extensions.torbutton.https_proxy");
+      proxy_settings.port = this.prefs.getIntPref("extensions.torbutton.https_port");
 
-      if (proxy_settings[2] == 0) {
-        proxy_settings[0] = "socks";
-        proxy_settings[1] = this.prefs.getCharPref("extensions.torbutton.socks_host");
-        proxy_settings[2] = this.prefs.getIntPref("extensions.torbutton.socks_port");
+      if (proxy_settings.port == 0) {
+        proxy_settings.type = "socks";
+        proxy_settings.host = this.prefs.getCharPref("extensions.torbutton.socks_host");
+        proxy_settings.port = this.prefs.getIntPref("extensions.torbutton.socks_port");
       }
+      proxy_settings.tor_safe = true;
     /* Regarding the test below:
      *
      * custom_proxy_type == "direct" is indicative of the user having selected "submit certs even if
@@ -855,15 +861,17 @@ SSLObservatory.prototype = {
      */
     } else if (this.myGetBoolPref("use_custom_proxy") && !(testingForTor && custom_proxy_type == "direct")) {
       this.log(INFO,"CASE: use_custom_proxy");
-      proxy_settings[0] = custom_proxy_type;
-      proxy_settings[1] = this.prefs.getCharPref("extensions.https_everywhere._observatory.proxy_host");
-      proxy_settings[2] = this.prefs.getIntPref("extensions.https_everywhere._observatory.proxy_port");
+      proxy_settings.type = custom_proxy_type;
+      proxy_settings.host = this.myGetCharPref("proxy_host");
+      proxy_settings.port = this.prefs.getIntPref("extensions.https_everywhere._observatory.proxy_port");
+      proxy_settings.tor_safe = false;
     } else {
       /* Take a guess at default tor proxy settings */
       this.log(INFO,"CASE: try localhost:9050");
-      proxy_settings[0] = "socks";
-      proxy_settings[1] = "localhost";
-      proxy_settings[2] = 9050;
+      proxy_settings.type = "socks";
+      proxy_settings.host = "localhost";
+      proxy_settings.port = 9050;
+      proxy_settings.tor_safe = true;
     }
     this.log(INFO, "Using proxy: " + proxy_settings);
     return proxy_settings;
@@ -896,10 +904,12 @@ SSLObservatory.prototype = {
         // for the torbutton proxy settings.
         try {
           proxy_settings = this.getProxySettings(testingForTor);
-          proxy = this.pps.newProxyInfo(proxy_settings[0], proxy_settings[1],
-                    proxy_settings[2],
-                    Ci.nsIProxyInfo.TRANSPARENT_PROXY_RESOLVES_HOST,
-                    0xFFFFFFFF, null);
+          proxy = this.pps.newProxyInfo(
+            proxy_settings.type,
+            proxy_settings.host,
+            proxy_settings.port,
+            Ci.nsIProxyInfo.TRANSPARENT_PROXY_RESOLVES_HOST,
+            0xFFFFFFFF, null);
         } catch(e) {
           this.log(WARN, "Error specifying proxy for observatory: "+e);
         }


### PR DESCRIPTION
This fixes a few separate but related issues with how we test proxy settings for the SSL observatory.

Commit https://github.com/EFForg/https-everywhere/commit/6de406768a56ad5dabda4b6f614c786d1a0805a1 resolves the edge case in https://github.com/EFForg/https-everywhere/issues/2719#issuecomment-219892166 where a user who has set a custom proxy will be making outbound requests to `check.torproject.org`.

The second issue, discovered while researching the first, is explained here: https://github.com/EFForg/https-everywhere/issues/2719#issuecomment-220182600.  Within the Tor Browser, we attempt to discover if the user can make outbound requests over Tor before the circuit is actually established.  This is technically a race condition, but since it will always take longer for the circuit to be established than to load the observatory code, this check always fails.  https://github.com/EFForg/https-everywhere/commit/c7df15106a049159ee5561cd0ee61c7efb82256b resolves the issue by only checking proxy settings [when the browser window and all its components have been loaded and initialized.](https://developer.mozilla.org/en-US/docs/Observer_Notifications)