### PR TITLE
[Hummingbird.me] Add ruleset

### DIFF
--- a/src/chrome/content/rules/Hummingbird.me.xml
+++ b/src/chrome/content/rules/Hummingbird.me.xml
@@ -1,0 +1,11 @@
+<ruleset name="Hummingbird">
+	<target host="hummingbird.me" />
+	<target host="www.hummingbird.me" />
+	<target host="forum-static.hummingbird.me" />
+	<target host="forums.hummingbird.me" />
+	<target host="static.hummingbird.me" />
+
+	<securecookie host="^(\.?forums)?\.?hummingbird\.me$" name=".+" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>


### PR DESCRIPTION
Adds support for [hummingbird.me](https://hummingbird.me).

**Edit:** Added `www` subdomain (redirect) and secured cookies.