### PR TITLE
[Nyaa] Update rulesets

### DIFF
--- a/src/chrome/content/rules/Nyaa.eu.xml
+++ b/src/chrome/content/rules/Nyaa.eu.xml
@@ -1,23 +1,17 @@
 <!--
-Enable HTTPS on the nyaa.eu domain
+	nyaa.eu redirects to nyaa.se (See Nyaa.se.xml)
 
+	Self-signed, mismatch:
+		- cthuko.nyaa.eu
 -->
 <ruleset name="Nyaa.eu">
+	<target host="nyaa.eu" />
+	<target host="www.nyaa.eu" />
+	<target host="files.nyaa.eu" />
+	<target host="sukebei.nyaa.eu" />
 
-	<!--	Direct rewrites:
-				-->
-  <target host="nyaa.eu" />
-  <target host="www.nyaa.eu" />
-  <target host="sukebei.nyaa.eu" />
+	<!-- CloudFlare cookies: -->
+	<securecookie host="^\.nyaa\.eu$" name="^(?:__cfduid|cf_clearance)$" />
 
-	<!--	CloudFlare cookies:	
-	-->
-				
-   <securecookie host="^\.nyaa\.eu$" name="^(?:__cfduid|cf_clearance)$" />
-
-
-   <rule from="^http:"
-    to="https:" />
-
-
+	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Nyaa.se.xml
+++ b/src/chrome/content/rules/Nyaa.se.xml
@@ -1,7 +1,7 @@
-<ruleset name="Nyaa.se (partial)">
-
-	<!--	Direct rewrites:
-				-->
+<!--
+	nyaa.eu redirects to nyaa.se (See Nyaa.eu.xml)
+-->
+<ruleset name="Nyaa.se">
 	<target host="nyaa.se" />
 	<target host="*.nyaa.se" />
 
@@ -10,15 +10,14 @@
 	<test url="http://sukebei.nyaa.se/" />
 	<test url="http://files.nyaa.se/favicon.png" />
 
+	<securecookie host="^(sukebei|www)?\.nyaa\.se$" name=".+" />
 
-	<!--	CloudFlare cookies:
-					-->
-	<!--securecookie host="^\.nyaa\.se$" name="^(?:__cfduid|cf_clearance)$" /-->
+	<!-- 
+		Error 500 at https://nyaa.se
+		Temporarily fixes a previously working server-side redirect
+		https://github.com/EFForg/https-everywhere/pull/4845
+	-->
+	<rule from="^http://nyaa\.se/" to="https://www.nyaa.se/" />
 
-	<securecookie host="^\.nyaa\.se$" name="^(?:__cfduid|cf_clearance)$" />
-
-
-	<rule from="^http:"
-		to="https:" />
-
+	<rule from="^http:" to="https:" />
 </ruleset>


### PR DESCRIPTION
- [nyaa.se](https://www.nyaa.se) now supports https on all its subdomains
- nyaa.eu now redirects to nyaa.se

**Edit:** Added main domain, secured all cookies.