### PR TITLE
Increase ruleset testing timeout limits

### DIFF
--- a/test/rules/coverage.checker.config
+++ b/test/rules/coverage.checker.config
@@ -16,8 +16,8 @@ basedir = test/rules/platform_certs
 user_agent = Mozilla/5.0 (X11; Linux x86_64; rv:36.0) Gecko/20100101 Firefox/36.0
 # Don't bother doing HTTP, we are just checking coverage and want it to be fast.
 enabled = false
-connect_timeout = 10
-read_timeout = 15
+connect_timeout = 20
+read_timeout = 30
 redirect_depth = 10
 threads = 10
 fetch_in_subprocess = false

--- a/test/rules/disable-broken-rulesets.checker.config
+++ b/test/rules/disable-broken-rulesets.checker.config
@@ -13,8 +13,8 @@ basedir = test/rules/platform_certs
 [http]
 user_agent = Mozilla/5.0 (X11; Linux x86_64; rv:36.0) Gecko/20100101 Firefox/36.0
 enabled = true
-connect_timeout = 10
-read_timeout = 15
+connect_timeout = 20
+read_timeout = 30
 redirect_depth = 10
 threads = 20
 fetch_in_subprocess = false

--- a/test/rules/http.checker.config
+++ b/test/rules/http.checker.config
@@ -16,8 +16,8 @@ basedir = test/rules/platform_certs
 [http]
 user_agent = Mozilla/5.0 (X11; Linux x86_64; rv:36.0) Gecko/20100101 Firefox/36.0
 enabled = true
-connect_timeout = 10
-read_timeout = 15
+connect_timeout = 20
+read_timeout = 30
 redirect_depth = 10
 threads = 40
 fetch_in_subprocess = false

--- a/test/rules/manual.checker.config
+++ b/test/rules/manual.checker.config
@@ -14,8 +14,8 @@ basedir = test/rules/platform_certs
 [http]
 user_agent = Mozilla/5.0 (X11; Linux x86_64; rv:36.0) Gecko/20100101 Firefox/36.0
 enabled = true
-connect_timeout = 10
-read_timeout = 15
+connect_timeout = 20
+read_timeout = 30
 redirect_depth = 10
 threads = 40
 fetch_in_subprocess = false


### PR DESCRIPTION
This doubles the length of the timeout restrictions for all current https-everywhere-checker configs in an attempt to fix https://github.com/EFForg/https-everywhere/issues/4810.

Arguably, since Travis is the one causing that particular issue, it could suffice to change only http.checker.config, but increasing all of them is probably safer for database-wide runs anyway.