### PR TITLE
Create ust.hk

### DIFF
--- a/src/chrome/content/rules/ust.hk.xml
+++ b/src/chrome/content/rules/ust.hk.xml
@@ -1,0 +1,84 @@
+<ruleset name="ust.hk">
+<!-- The Hong Kong University of Science and Technology -->
+    <target host="www.ust.hk" />
+    <target host="cas.ust.hk" />
+    <target host="access.ust.hk" />
+    <target host="canvas.ust.hk" />
+    
+    <target host="login.psft.ust.hk" />
+    <!-- Invalid Certificate 
+        <target host="hrmsxprod.psft.ust.hk" />  -->
+    <target host="sisprod.psft.ust.hk" />
+
+    <!-- Student Affair Office -->
+    <target host="sao.ust.hk" />
+
+    <!-- Information Technology Service Center -->
+    <target host="itsc.ust.hk" />
+    <target host="itscapps.ust.hk" />
+    <target host="lists.ust.hk" />
+
+    <!-- Department of Mathematics -->
+    <target host="www.math.ust.hk" />
+    <target host="webwork.math.ust.hk" />
+    <target host="intranet.math.ust.hk" />
+
+    <!-- Department of Computer Science & Engineering -->
+    <target host="www.cse.ust.hk" />
+    <target host="course.cse.ust.hk" />
+
+    <!-- Department of Industrial Engineering & Logistics Management -->
+    <target host="www.ielm.ust.hk" />
+
+    <!-- Office of Academic Advising and Support, SSCI -->
+    <target host="sdb.science.ust.hk" />
+        <test url="http://sdb.science.ust.hk/mySCI" />
+
+    <!-- Administrative and Business Portal -->
+    <target host="www.ab.ust.hk" />
+    <target host="w3.ab.ust.hk" />
+    <target host="w5.ab.ust.hk" />
+    <target host="w6.ab.ust.hk" />
+    <target host="w7.ab.ust.hk" />
+    <!-- Problematic (connection time-out) 
+        <target host="w9.ab.ust.hk" /> -->
+    
+
+    <!-- University Library -->
+    <target host="illiad.ust.hk" />
+    <target host="ustlib.ust.hk" />
+    <target host="lbapps.ust.hk" />
+    <target host="lbcube.ust.hk" />
+    <target host="lbdb.ust.hk" />
+    <target host="lbezone.ust.hk" />
+    <target host="lbjcrs.ust.hk" />
+    <target host="lbbooking.ust.hk" />
+
+    <!-- Publishing Technology Center -->
+    <target host="video.ust.hk" />
+
+    <!-- Career Center -->
+    <target host="career.ust.hk" />
+
+    <!-- HKUST Alumni -->
+    <target host="alumni.ust.hk" />
+
+    <!-- HKUST Search -->
+    <target host="search.ust.hk" />
+
+    <!-- Teaching Web Server (depreciated) -->
+    <target host="teaching.ust.hk" />
+
+    <!-- HKUST Mail Services -->
+    <target host="sqmail.ust.hk" />
+    <target host="owa.exchange.ust.hk" />
+    <target host="adfs.connect.ust.hk" />
+    <target host="o365.ust.hk" />
+
+    <rule from="^http://o365\.ust\.hk/" to="https://outlook.office365.com/owa/?realm=connect.ust.hk" />
+        <test url="http://o365.ust.hk/" />
+    
+    <rule from="^http:" to="https:" />
+
+    <securecookie host="ust\.hk$" name=".+" />
+</ruleset>


### PR DESCRIPTION
New ruleset for The Hong Kong University of Science and Technology, including the homepage www.ust.hk and some of its subdomain.