### PR TITLE
Solarmovie.is to SolarMovie.ph

### DIFF
--- a/src/chrome/content/rules/SolarMovie.xml
+++ b/src/chrome/content/rules/SolarMovie.xml
@@ -1,6 +1,8 @@
-<ruleset name="Solarmovie.is">
+<ruleset name="SolarMovie">
   <target host="solarmovie.is" />
   <target host="www.solarmovie.is" />
+  <target host="solarmovie.ph" />
+  <target host="www.solarmovie.ph" />
 
   <rule from="^http:" to="https:" />
 </ruleset>


### PR DESCRIPTION
The .is domain still exists and redirects to .ph so I just kept it.