### PR TITLE
[Copenhagenmarathon.dk] New rulesets

### DIFF
--- a/src/chrome/content/rules/Copenhagenmarathon.dk-falsemixed.xml
+++ b/src/chrome/content/rules/Copenhagenmarathon.dk-falsemixed.xml
@@ -1,0 +1,9 @@
+<!--
+	See also Copenhagenmarathon.dk.xml
+-->
+<ruleset name="Copenhagenmarathon.dk" platform="mixedcontent">
+	<target host="copenhagenmarathon.dk" />
+	<target host="www.copenhagenmarathon.dk" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/Copenhagenmarathon.dk.xml
+++ b/src/chrome/content/rules/Copenhagenmarathon.dk.xml
@@ -1,0 +1,21 @@
+<!--
+	Mixed content issues on all pages. See also
+	Copenhagenmarathon.dk-falsemixed.xml
+-->
+<ruleset name="Copenhagenmarathon.dk (mixed content)">
+	<target host="copenhagenmarathon.dk" />
+	<target host="www.copenhagenmarathon.dk" />
+
+	<exclusion pattern="^http://(www\.)?copenhagenmarathon\.dk/(?!files|wp-)" />
+
+		<!-- Does not exclusion-->
+		<test url="http://copenhagenmarathon.dk/files/2015/10/Marathon-Sport-Logo-illustrator-9-Converted-300x121.png" />
+		<test url="http://copenhagenmarathon.dk/wp-content/plugins/simple-share-buttons-adder/buttons/somacro/facebook.png" />
+		<test url="http://copenhagenmarathon.dk/wp-includes/js/wp-embed.min.js?8a953d" />
+
+		<!-- Matches exclusion -->
+		<test url="http://copenhagenmarathon.dk/copenhagen-marathon-2016/" />
+		<test url="http://copenhagenmarathon.dk/expo/" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/Copenhagenmarathon.dk.xml
+++ b/src/chrome/content/rules/Copenhagenmarathon.dk.xml
@@ -1,6 +1,9 @@
 <!--
 	Mixed content issues on all pages. See also
 	Copenhagenmarathon.dk-falsemixed.xml
+
+	Other problematic domains:
+		- map (Bad CN in cert: msf.dk)
 -->
 <ruleset name="Copenhagenmarathon.dk (mixed content)">
 	<target host="copenhagenmarathon.dk" />


### PR DESCRIPTION
Unfortunately, the main Wordpress page provides a fair bit of false mixed content blocking, but this captures a good deal of the securable part of the site.