### PR TITLE
[WhatPulse.org] Add ruleset

### DIFF
--- a/src/chrome/content/rules/WhatPulse.org.xml
+++ b/src/chrome/content/rules/WhatPulse.org.xml
@@ -1,0 +1,19 @@
+<!--
+	Mismatch:
+		- amcdn.whatpulse.org
+		- direct.whatpulse.org
+		- help.whatpulse.org
+		- www.whatpulse.org
+
+	Missing intermediate certificate:
+		- developer.whatpulse.org (https://github.com/EFForg/https-everywhere/pull/4882)
+
+-->
+<ruleset name="WhatPulse.org">
+	<target host="whatpulse.org" />
+	<target host="api.whatpulse.org" />
+
+	<securecookie host="^\.?whatpulse\.org$" name=".+" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>


### PR DESCRIPTION
Adds support for [whatpulse.org](https://whatpulse.org).

**Edit:** I'm not sure why the build failed, [developer.whatpulse.org](https://developer.whatpulse.org) appears to work just fine on my end.

**Edit 2:** Added `www` subdomain, added notes for `amcdn` and `direct` mismatched subdomains, secured cookies.