### PR TITLE
twitch.tv html5 video streaming endpoint

### DIFF
--- a/src/chrome/content/rules/Twitch.tv.xml
+++ b/src/chrome/content/rules/Twitch.tv.xml
@@ -45,6 +45,7 @@ science.twitch.tv
   <target host="justin.tv" />
   <target host="www.justin.tv" />
   <target host="secure.justin.tv" />
+  <target host="*.hls.ttvnw.net" />
   
   <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Twitch.tv.xml
+++ b/src/chrome/content/rules/Twitch.tv.xml
@@ -46,6 +46,7 @@ science.twitch.tv
   <target host="www.justin.tv" />
   <target host="secure.justin.tv" />
   <target host="*.hls.ttvnw.net" />
+  <target host="usher.ttvnw.net" />
   
   <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Twitch.tv.xml
+++ b/src/chrome/content/rules/Twitch.tv.xml
@@ -48,5 +48,9 @@ science.twitch.tv
   <target host="*.hls.ttvnw.net" />
   <target host="usher.ttvnw.net" />
   
+  <test url="http://video-edge-914510.jfk03.hls.ttvnw.net/" />
+  <test url="http://video-edge-8fa768.jfk03.hls.ttvnw.net/" />
+  <test url="http://video-edge-498e94.iad02.hls.ttvnw.net/" />
+  
   <rule from="^http:" to="https:" />
 </ruleset>


### PR DESCRIPTION
Twitch.tv uses multiple subdomains as video streaming endpoints. They are all under hls.ttvnw.net and they have valid certificates.

They take the format: video-edge-*.*.hls.ttvnw.net

Here are some examples:
https://video-edge-8fa768.jfk03.hls.ttvnw.net/
https://video-edge-498e94.iad02.hls.ttvnw.net/
