### PR TITLE
Remove csc-stage.cisco.com from Cisco rules.

### DIFF
--- a/src/chrome/content/rules/Cisco.xml
+++ b/src/chrome/content/rules/Cisco.xml
@@ -18,6 +18,7 @@
 	Nonfunctional hosts in *cisco.com:
 
 		- bam-prd1
+		- csc-stage ᵈ
 		- gblogs ⁴
 		- homecommunity
 		- investor ʳ
@@ -109,7 +110,6 @@
 	<target host="cloudsso2.cisco.com" />
 	<target host="cms-smbmarketplace.cisco.com" />
 	<target host="communities.cisco.com" />
-	<target host="csc-stage.cisco.com" />
 	<target host="csc-test1.cisco.com" />
 	<target host="developer.cisco.com" />
 	<target host="eir.cisco.com" />


### PR DESCRIPTION
This subdomain seems to have been removed and can no longer be resolved in DNS.

* http://csc-stage.cisco.com/
* https://csc-stage.cisco.com/