### PR TITLE
Webextensions

### DIFF
--- a/chromium/background.js
+++ b/chromium/background.js
@@ -49,7 +49,7 @@ storage.get({httpNowhere: false}, function(item) {
   setIconColor();
 });
 chrome.storage.onChanged.addListener(function(changes, areaName) {
-  if (areaName === 'sync') {
+  if (areaName === 'sync' || areaName === 'local') {
     for (var key in changes) {
       if (key === 'httpNowhere') {
         httpNowhereOn = changes[key].newValue;

--- a/chromium/background.js
+++ b/chromium/background.js
@@ -44,7 +44,7 @@ chrome.browserAction.setBadgeText({ text: "" });
 // Load prefs about whether http nowhere is on. Structure is:
 //  { httpNowhere: true/false }
 var httpNowhereOn = false;
-chrome.storage.sync.get({httpNowhere: false}, function(item) {
+storage.get({httpNowhere: false}, function(item) {
   httpNowhereOn = item.httpNowhere;
   setIconColor();
 });

--- a/chromium/manifest.json
+++ b/chromium/manifest.json
@@ -39,6 +39,11 @@
         "storage", 
         "<all_urls>"
     ], 
+    "applications": {
+        "gecko": {
+            "id": "https-everywhere-eff@eff.org"
+        }
+    },
     "update_url": "https://www.eff.org/files/https-everywhere-chrome-updates.xml", 
     "version": "2016.5.10"
 }

--- a/chromium/manifest.json
+++ b/chromium/manifest.json
@@ -5,6 +5,7 @@
     "background": {
         "scripts": [
             "rules.js", 
+            "storage.js",
             "util.js", 
             "background.js", 
             "incognito-cache-clearing.js"

--- a/chromium/popup.html
+++ b/chromium/popup.html
@@ -2,6 +2,8 @@
 <head>
     <title i18n="about_ext_name"></title>
 
+    <meta charset="utf-8"/>
+
     <!-- Local copy of chrome://resources/css/chrome_shared.css -->
     <link href="chrome-resources/css/chrome_shared.css" rel="stylesheet" type="text/css"/>
 

--- a/chromium/popup.html
+++ b/chromium/popup.html
@@ -32,7 +32,7 @@
     <section>
         <a href="#" id="add-rule-link" i18n="chrome_add_rule"></a>
         <div id="add-new-rule-div" style="display:none">
-            <h3 i18n="about_add_new_rule"> </h3>
+            <h3 i18n="about_add_new_rule"></h3>
             <p i18n="chrome_always_https_for_host"></p>
             <label for="new-rule-host" i18n="chrome_host"></label> <br><input size="50" id="new-rule-host" type="text" disabled><br>
 

--- a/chromium/popup.js
+++ b/chromium/popup.js
@@ -54,17 +54,19 @@ function createRuleLine(ruleset) {
   };
   label.appendChild(checkbox);
 
-  // favicon (from chrome's cache)
-  var favicon = document.createElement("img");
-  favicon.src = "chrome://favicon/";
-  for (var i=0; i < ruleset.rules.length; i++) {
-    var host = hostReg.exec(ruleset.rules[i].to);
-    if (host) {
-      favicon.src += host[0];
-      break;
+  if (!/Firefox/.test(navigator.userAgent)) {
+    // favicon (from chrome's cache)
+    var favicon = document.createElement("img");
+    favicon.src = "chrome://favicon/";
+    for (var i=0; i < ruleset.rules.length; i++) {
+      var host = hostReg.exec(ruleset.rules[i].to);
+      if (host) {
+        favicon.src += host[0];
+        break;
+      }
     }
+    label.appendChild(favicon);
   }
-  label.appendChild(favicon);
 
   // label text
   var text = document.createElement("span");

--- a/chromium/popup.js
+++ b/chromium/popup.js
@@ -54,19 +54,21 @@ function createRuleLine(ruleset) {
   };
   label.appendChild(checkbox);
 
-  if (!/Firefox/.test(navigator.userAgent)) {
-    // favicon (from chrome's cache)
-    var favicon = document.createElement("img");
-    favicon.src = "chrome://favicon/";
-    for (var i=0; i < ruleset.rules.length; i++) {
-      var host = hostReg.exec(ruleset.rules[i].to);
-      if (host) {
-        favicon.src += host[0];
-        break;
-      }
+  // favicon (from chrome's cache)
+  var favicon = document.createElement("img");
+  favicon.src = "chrome://favicon/";
+  for (var i=0; i < ruleset.rules.length; i++) {
+    var host = hostReg.exec(ruleset.rules[i].to);
+    if (host) {
+      favicon.src += host[0];
+      break;
     }
-    label.appendChild(favicon);
   }
+  var xhr = new XMLHttpRequest();
+  try {
+    xhr.open("GET", favicon.src, true);
+    label.appendChild(favicon);
+  } catch (e) {}
 
   // label text
   var text = document.createElement("span");

--- a/chromium/popup.js
+++ b/chromium/popup.js
@@ -1,8 +1,10 @@
 "use strict";
+
 var backgroundPage = chrome.extension.getBackgroundPage();
 var stableRules = null;
 var unstableRules = null;
 var hostReg = /.*\/\/[^$/]*\//;
+var storage = backgroundPage.storage;
 
 function e(id) {
   return document.getElementById(id);
@@ -232,11 +234,11 @@ function toggleHttpNowhere() {
 function getOption_(opt, defaultOpt, callback) {
   var details = {};
   details[opt] = defaultOpt;
-  return chrome.storage.sync.get(details, callback);
+  return storage.get(details, callback);
 }
 
 function setOption_(opt, value) {
   var details = {};
   details[opt] = value;
-  return chrome.storage.sync.set(details);
+  return storage.set(details);
 }

--- a/chromium/storage.js
+++ b/chromium/storage.js
@@ -1,0 +1,7 @@
+var storage = chrome.storage.local;
+if (chrome.storage.sync) {
+  storage = chrome.storage.sync;
+}
+if (typeof exports != 'undefined') {
+  exports = storage;
+}

--- a/src/chrome/locale/en/https-everywhere.dtd
+++ b/src/chrome/locale/en/https-everywhere.dtd
@@ -5,6 +5,7 @@
 <!ENTITY https-everywhere.about.created_by "Created by">
 <!ENTITY https-everywhere.about.and ", and">
 <!ENTITY https-everywhere.about.librarians "Ruleset Librarians">
+<!ENTITY https-everywhere.about.add_new_rule "Add New Rule">
 <!ENTITY https-everywhere.about.thanks "Thanks to">
 <!ENTITY https-everywhere.about.many_contributors "Many many contributors, including">
 <!ENTITY https-everywhere.about.noscript "Also, portions of HTTPS Everywhere are based on code from NoScript, by Giorgio Maone and others.  We are grateful for their excellent work!">


### PR DESCRIPTION
Some minor code changes required for WebExtensions compatibility for Firefox.

These changes can be safely merged without affecting any functionality in Chrome.

To test the functionality in Firefox, apply the following patch:

```
diff --git a/makecrx.sh b/makecrx.sh
index 6cc852d..2758a28 100755
--- a/makecrx.sh
+++ b/makecrx.sh
@@ -76,11 +76,20 @@ sed -i -e "s/VERSION/$VERSION/g" pkg/crx/manifest.json
 
 if [ -n "$BRANCH" ] ; then
   crx="pkg/https-everywhere-$VERSION.crx"
+  xpi="pkg/https-everywhere-$VERSION.xpi"
   key=../dummy-chromium.pem
 else
   crx="pkg/https-everywhere-$VERSION~pre.crx"
+  xpi="pkg/https-everywhere-$VERSION~pre.xpi"
   key=dummy-chromium.pem
 fi
+
+# Package the Firefox WebExtensions XPI format
+cd pkg/crx
+zip -r httpse.zip .
+cd ../..
+mv pkg/crx/httpse.zip $xpi
+
 if ! [ -f "$key" ] ; then
   echo "Making a dummy signing key for local build purposes"
   openssl genrsa 2048 > "$key"
```

Then run `./makecrx.sh`.  Then drag the file ` pkg/https-everywhere-2016.5.10~pre.xpi` into the `about:addons` tab of a new profile of Firefox Developer Edition.

Ready for review @cooperq (we can go over it on Friday)