### PR TITLE
Exclude leaflet.github.io

### DIFF
--- a/src/chrome/content/rules/Github-Pages.xml
+++ b/src/chrome/content/rules/Github-Pages.xml
@@ -4,6 +4,9 @@
 <ruleset name="GitHub Pages">
 
 	<target host="*.github.io" />
+		<!-- Mixed content issue: https://github.com/Leaflet/Leaflet.markercluster/issues/680 -->
+		<exclusion pattern="^http://leaflet\.github\.io" />
+ 			<test url="https://leaflet.github.io/Leaflet.markercluster/example/marker-clustering-realworld.388.html" />
 
 	<rule from="^http://([^/@:\.]+)\.github\.io/"
 		to="https://$1.github.io/" />


### PR DESCRIPTION
From the developers in Leaflet/Leaflet.markercluster#680, Leaflet's CDN doesn't have certificates configured correctly on HTTPS, so requests should not be redirected for that domain until such time they do.

I'm not 100% sure I've got the syntax correct -- I've copied this from another PR so hopefully this is correct.