### PR TITLE
Added t411.in and t411.ch to T411 rule.

### DIFF
--- a/src/chrome/content/rules/T411.xml
+++ b/src/chrome/content/rules/T411.xml
@@ -3,20 +3,36 @@
   <target host="*.t411.io" />
   <target host="t411.me" />
   <target host="*.t411.me" />
+  <target host="t411.in" />
+  <target host="*.t411.in" />
+  <target host="t411.ch" />
+  <target host="*.t411.ch" />
   
-  <test url="http://wiki.t411.io/" />
   <test url="http://www.t411.io/" />
   <test url="http://forum.t411.io/" />
   <test url="http://api.t411.io/" />
-  <test url="http://wiki.t411.me/" />
   <test url="http://www.t411.me/" />
   <test url="http://forum.t411.me/" />
   <test url="http://api.t411.me/" />
+  <test url="http://www.t411.in/" />
+  <test url="http://forum.t411.in/" />
+  <test url="http://api.t411.in/" />
+  <test url="http://www.t411.ch/" />
+  <test url="http://forum.t411.ch/" />
+  <test url="http://api.t411.ch/" />
   
-  <exclusion pattern="^http://irc\.t411\.(io|me)/" />
-  <test url="http://irc.t411.me/" />
+  <exclusion pattern="^http://irc\.t411\.(io|me|in|ch)/" />
   <test url="http://irc.t411.io/" />
+  <test url="http://irc.t411.me/" />
+  <test url="http://irc.t411.in/" />
+  <test url="http://irc.t411.ch/" />
+  
+  <exclusion pattern="^http://wiki\.t411\.(io|me|in|ch)/" />
+  <test url="http://wiki.t411.io/" />
+  <test url="http://wiki.t411.me/" />
+  <test url="http://wiki.t411.in/" />
+  <test url="http://wiki.t411.ch/" />
   
   <rule from="^http:" to="https:" />
-  <securecookie host="^.*t411\.(io|me)$" name=".*" />
+  <securecookie host="^.*t411\.(io|me|in|ch)$" name=".*" />
 </ruleset>

--- a/src/chrome/content/rules/T411.xml
+++ b/src/chrome/content/rules/T411.xml
@@ -1,38 +1,17 @@
 <ruleset name="T411">
-  <target host="t411.io" />
-  <target host="*.t411.io" />
-  <target host="t411.me" />
-  <target host="*.t411.me" />
-  <target host="t411.in" />
-  <target host="*.t411.in" />
   <target host="t411.ch" />
   <target host="*.t411.ch" />
   
-  <test url="http://www.t411.io/" />
-  <test url="http://forum.t411.io/" />
-  <test url="http://api.t411.io/" />
-  <test url="http://www.t411.me/" />
-  <test url="http://forum.t411.me/" />
-  <test url="http://api.t411.me/" />
-  <test url="http://www.t411.in/" />
-  <test url="http://forum.t411.in/" />
-  <test url="http://api.t411.in/" />
   <test url="http://www.t411.ch/" />
   <test url="http://forum.t411.ch/" />
   <test url="http://api.t411.ch/" />
   
-  <exclusion pattern="^http://irc\.t411\.(io|me|in|ch)/" />
-  <test url="http://irc.t411.io/" />
-  <test url="http://irc.t411.me/" />
-  <test url="http://irc.t411.in/" />
+  <exclusion pattern="^http://irc\.t411\.ch/" />
   <test url="http://irc.t411.ch/" />
   
-  <exclusion pattern="^http://wiki\.t411\.(io|me|in|ch)/" />
-  <test url="http://wiki.t411.io/" />
-  <test url="http://wiki.t411.me/" />
-  <test url="http://wiki.t411.in/" />
+  <exclusion pattern="^http://wiki\.t411\.ch/" />
   <test url="http://wiki.t411.ch/" />
   
   <rule from="^http:" to="https:" />
-  <securecookie host="^.*t411\.(io|me|in|ch)$" name=".*" />
+  <securecookie host="^.*t411\.ch$" name=".*" />
 </ruleset>


### PR DESCRIPTION
This website changed domain name
It used t411.me t411.io t411.in  and is now using t411.ch.
I excluded wiki.t411.ch because it has a redirection problem as said in #2988.
