### PR TITLE
[VEVO] Rewrite https URLs used in protocol-relative links; update style

### DIFF
--- a/src/chrome/content/rules/VEVO.xml
+++ b/src/chrome/content/rules/VEVO.xml
@@ -13,6 +13,12 @@
 	<target host="scache.vevo.com" />
 	<target host="www.vevo.com" />
 
+	<test url="https://cache.vevo.com/" />
+	<test url="https://img.cache.vevo.com/" />
+	<test url="http://img.cache.vevo.com/Content/VevoImages/artist/62AE5CCE473B998AFD2DB55B659E23E32013167114452900.jpg?width=98&amp;height=98&amp;resize=round" />
+	<test url="https://img.cache.vevo.com/Content/VevoImages/artist/62AE5CCE473B998AFD2DB55B659E23E32013167114452900.jpg?width=98&amp;height=98&amp;resize=round" />
+	<test url="http://scache.vevo.com/Content/VevoImages/artist/62AE5CCE473B998AFD2DB55B659E23E32013167114452900.jpg?width=98&amp;height=98&amp;resize=round" />
+
 	<rule from="^https?://(img\.)?cache\.vevo\.com/"
 		to="https://scache.vevo.com/" />
 

--- a/src/chrome/content/rules/VEVO.xml
+++ b/src/chrome/content/rules/VEVO.xml
@@ -13,7 +13,7 @@
 	<target host="scache.vevo.com" />
 	<target host="www.vevo.com" />
 
-	<rule from="^http://(img\.)?cache\.vevo\.com/"
+	<rule from="^https?://(img\.)?cache\.vevo\.com/"
 		to="https://scache.vevo.com/" />
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/VEVO.xml
+++ b/src/chrome/content/rules/VEVO.xml
@@ -25,13 +25,15 @@
 	<target host="workitout.vevo.com" />
 	<target host="www.vevo.com" />
 
-	<test url="https://cache.vevo.com/" />
 	<test url="https://img.cache.vevo.com/" />
 	<test url="http://img.cache.vevo.com/Content/VevoImages/artist/62AE5CCE473B998AFD2DB55B659E23E32013167114452900.jpg?width=98&amp;height=98&amp;resize=round" />
 	<test url="https://img.cache.vevo.com/Content/VevoImages/artist/62AE5CCE473B998AFD2DB55B659E23E32013167114452900.jpg?width=98&amp;height=98&amp;resize=round" />
 	<test url="http://scache.vevo.com/Content/VevoImages/artist/62AE5CCE473B998AFD2DB55B659E23E32013167114452900.jpg?width=98&amp;height=98&amp;resize=round" />
 
-	<rule from="^https?://(img\.)?cache\.vevo\.com/"
+	<rule from="^http://cache\.vevo\.com/"
+		to="https://scache.vevo.com/" />
+
+	<rule from="^https?://img\.cache\.vevo\.com/"
 		to="https://scache.vevo.com/" />
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/VEVO.xml
+++ b/src/chrome/content/rules/VEVO.xml
@@ -1,16 +1,21 @@
+<!--
+	Problematic subdomains:
+
+		- cache *
+		- img.cache *
+
+	* Mismatch (a248.e.akamai.net)
+-->
 <ruleset name="VEVO">
-
 	<target host="vevo.com" />
-	<target host="*.vevo.com" />
+	<target host="cache.vevo.com" />
 	<target host="img.cache.vevo.com" />
+	<target host="scache.vevo.com" />
+	<target host="www.vevo.com" />
 
-
-	<rule from="^http://(?:www\.)?vevo\.com/"
-		to="https://www.vevo.com/" />
-
-	<!--	cache, img.cache: Akamai
-					-->
-	<rule from="^http://(?:img\.|s)?cache\.vevo\.com/"
+	<rule from="^http://(img\.)?cache\.vevo\.com/"
 		to="https://scache.vevo.com/" />
 
+	<rule from="^http:"
+		to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/VEVO.xml
+++ b/src/chrome/content/rules/VEVO.xml
@@ -1,16 +1,28 @@
 <!--
+	Nonfunctional subdomains:
+
+		- comingsoon *
+
+	* Refused
+
 	Problematic subdomains:
 
-		- cache *
-		- img.cache *
+		- cache ¹
+		- go ²
+		- img.cache ¹
 
-	* Mismatch (a248.e.akamai.net)
+	¹ Mismatched, CN: a248.e.akamai.net
+	² Mismatched, CN: *.awe.sm
 -->
 <ruleset name="VEVO">
 	<target host="vevo.com" />
+	<target host="blog.vevo.com" />
 	<target host="cache.vevo.com" />
 	<target host="img.cache.vevo.com" />
+	<target host="m.vevo.com" />
+	<target host="o.vevo.com" />
 	<target host="scache.vevo.com" />
+	<target host="workitout.vevo.com" />
 	<target host="www.vevo.com" />
 
 	<test url="https://cache.vevo.com/" />


### PR DESCRIPTION
https://img.cache.vevo.com/ has a mismatched certificate (a248.e.akamai.net).
Therefore, http://img.cache.vevo.com/ is rewritten to https://scache.vevo.com/.

However, https://www.vevo.com/ uses a lot of "//img.cache.vevo.com/" protocol-relative images, which wind up going to https://img.cache.vevo.com/ and failing.

So, let's rewrite https://img.cache.vevo.com/ to https://scache.vevo.com/ too.

This change also rewrites https://cache.vevo.com/. I don't know if it's necessary -- i haven't looked hard -- but i decided it was simpler not to add a second rule.

* Remove special rule for vevo.com; it's not problematic. (It has a valid cert and redirects to www.vevo.com.)
* Modernize the style.

The ruleset could probably use other changes -- new subdomains, for example -- but this fixes the status quo.

1. 8d722b0222ea61b81ed1b1d0d7005980a168de6c handles vevo.com and the style.
2. 82ff557adb7b6cdb5da78bdb1ddfb6b9ca034190 is the main (two-byte) change.
3. 76867d9d7cbe5872c6c58d80ceb6266b4f47c2fb adds more tests.

Edit: I did `push --force` twice to fix a mistake, less than ten minutes after filing this.