### PR TITLE
Add rules for German Le Monde diplomatique

### DIFF
--- a/src/chrome/content/rules/Le-Monde-diplomatique.de.xml
+++ b/src/chrome/content/rules/Le-Monde-diplomatique.de.xml
@@ -1,0 +1,9 @@
+<ruleset name="Le Monde diplomatique (deutsch)">
+	<target host="monde-diplomatique.de" />
+	<target host="www.monde-diplomatique.de" />
+
+	<securecookie host="^monde-diplomatique\.de$" name=".+" />
+
+	<rule from="^http:"
+		to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/Le-Monde-diplomatique.de.xml
+++ b/src/chrome/content/rules/Le-Monde-diplomatique.de.xml
@@ -2,7 +2,7 @@
 	<target host="monde-diplomatique.de" />
 	<target host="www.monde-diplomatique.de" />
 
-	<securecookie host="^monde-diplomatique\.de$" name=".+" />
+	<securecookie host="^\.monde-diplomatique\.de$" name=".+" />
 
 	<rule from="^http:"
 		to="https:" />


### PR DESCRIPTION
I have got one question before this pull request is merged. Regarding `securecookie`, the following is stated in *docs/rulesets.html*:

> A cookie whose domain attribute starts with a "." (the default, if not specified by Javascript) will be matched as if it was sent from a host name made by stripping the leading dot.

Does that mean that cookies like the following will be matched by `<securecookie host="^monde-diplomatique\.de$" name=".+" />`?

![Screenshot of a cookie with domain ".monde-diplomatique.de" in Google Chrome's developer tools.](https://cloud.githubusercontent.com/assets/811907/15899144/0f860c8a-2d9b-11e6-9d27-0edf44c8a7b0.png)
