### PR TITLE
Added Sankaku Complex image boards

### DIFF
--- a/src/chrome/content/rules/sankakucomplex.com.xml
+++ b/src/chrome/content/rules/sankakucomplex.com.xml
@@ -1,3 +1,10 @@
+<!--
+
+	Nonfunctional domains:
+
+		- charts	(blank page)
+
+-->
 <ruleset name="Sankaku Complex.com">
 
 	<target host="sankakucomplex.com" />
@@ -9,8 +16,6 @@
 	<target host="www.sankakucomplex.com" />
 	<target host="chan.sankakucomplex.com" />
 	<target host="idol.sankakucomplex.com" />
-	
-	<!-- <exclusion pattern="^http://charts.sankakucomplex.com/" /> -->
 
 
 	<securecookie host="^\w" name="." />

--- a/src/chrome/content/rules/sankakucomplex.com.xml
+++ b/src/chrome/content/rules/sankakucomplex.com.xml
@@ -7,6 +7,10 @@
 	<target host="i.sankakucomplex.com" />
 	<target host="images.sankakucomplex.com" />
 	<target host="www.sankakucomplex.com" />
+	<target host="chan.sankakucomplex.com" />
+	<target host="idol.sankakucomplex.com" />
+	
+	<!-- <exclusion pattern="^http://charts.sankakucomplex.com/" /> -->
 
 
 	<securecookie host="^\w" name="." />


### PR DESCRIPTION
Also added a outcommented exclusion rule for charts.sankakucomplex.com to point out that not all subdomains have https.
charts.sankakucomplex.com/niconico can be reached from the Videos menu in the navbar at the main page.