### PR TITLE
[engadget.com] Re-enable ruleset

### DIFF
--- a/src/chrome/content/rules/Engadget.com.xml
+++ b/src/chrome/content/rules/Engadget.com.xml
@@ -1,29 +1,30 @@
 <!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://profiles.engadget.com/ => https://profiles.engadget.com/: (6, 'Could not resolve host: profiles.engadget.com')
 	For other AOL coverage, see AOL.xml.
 
 
 	CDN buckets:
 
-		- v4.engadget.com.aol.akadns.net
-
-			- alt.engadget.com
-			- hd.engadget.com
-			- mobile.engadget.com
-			- www.engadget.com
+		- s.blogcdn.com
+		- s.blogsmithmedia.com
+		- s.aolcdn.com
+		- cdn.komentary.aol.com
+		- delivery.vidible.tv
+		- cdn-ssl.vidible.tv
 
 
 	Nonfunctional subdomains:
 
-		- ^ ¹
-		- alt ²
-		- hd ²
-		- mobile ²
-		- www ²
+		- ^ 		¹
+		- b-aws		(cert mismatch)
+		- chinese	¹
+		- cn		¹
+		- de		¹
+		- es		¹
+		- gdgt-admin	(failed handshake)
+		- japanese	¹
+		- uk		¹
 
 	¹ Refused
-	² Redirects to http, valid cert
 
 
 	Mixed content:
@@ -33,12 +34,11 @@ Fetch error: http://profiles.engadget.com/ => https://profiles.engadget.com/: (6
 	* Secured by us
 
 -->
-<ruleset name="Engadget.com (partial)" default_off='failed ruleset test'>
+<ruleset name="Engadget.com (partial)">
+	<target host="www.engadget.com" />
 
-	<target host="profiles.engadget.com" />
+  	<securecookie host="^www\.engadget\.com$" name=".*" />
 
-
-	<rule from="^http://profiles\.engadget\.com/"
-		to="https://profiles.engadget.com/" />
-
+	<rule from="^http:"
+		to="https:" />
 </ruleset>


### PR DESCRIPTION
Previously disabled (https://github.com/EFForg/https-everywhere/pull/1036#issuecomment-73798377), then somehow removed.
Removed 404'd subdomains.
https://www.engadget.com/2016/06/10/engadget-moved-to-https-because-we-love-you/
