### PR TITLE
Pixiv.xml: workaround paths requested with CORS

### DIFF
--- a/src/chrome/content/rules/Pixiv.xml
+++ b/src/chrome/content/rules/Pixiv.xml
@@ -38,6 +38,8 @@
 	<target host="sensei.pixiv.net" />
 	<target host="sketch.pixiv.net" />
 	<target host="source.pixiv.net" />
+	<!-- Exclude paths requested with CORS, would fail Access-Control-Allow-Origin check -->
+	<exclusion pattern="^http://source\.pixiv\.net/.*/app/[^/]+\.js" />
 	
 	<target host="d.pixiv.org" />
 	


### PR DESCRIPTION
(At least) Chrome sends `Origin: null` with the rewritten request, which causes `Access-Control-Allow-Origin` to be omitted from the response, failing the CORS check.

Exclude URLs that are requested with CORS from the rules.