### PR TITLE
[https-everywhere-rewriter] Rename URIjs to urijs

### DIFF
--- a/rewriter/package.json
+++ b/rewriter/package.json
@@ -1,10 +1,10 @@
 {
-  "name" : "https-everywhere-rewriter",
-  "version" : "1.0.0",
-  "dependencies" : {
-    "xmldom" : "0.1.17",
-    "URIjs" : "1.11.2",
-    "readdirp" : "0.3.2",
-    "event-stream" : "3.0.20"
+  "name": "https-everywhere-rewriter",
+  "version": "1.0.0",
+  "dependencies": {
+    "event-stream": "3.0.20",
+    "readdirp": "0.3.2",
+    "urijs": "^1.18.1",
+    "xmldom": "0.1.17"
   }
 }

--- a/rewriter/rewriter.js
+++ b/rewriter/rewriter.js
@@ -22,7 +22,7 @@ var path = require("path"),
 
     rules = require("../chromium/rules"),
 
-    URI = require("URIjs");
+    URI = require("urijs");
 
 var ruleSets = null;
 


### PR DESCRIPTION
From `npm`:

    npm WARN deprecated URIjs@1.11.2: package renamed to "urijs" (lower-case), please update accordingly