### PR TITLE
Corrected hostname jondos.de (wrong: jondos.com)

### DIFF
--- a/src/chrome/content/rules/JonDos.xml
+++ b/src/chrome/content/rules/JonDos.xml
@@ -13,8 +13,8 @@ Fetch error: http://www.jondos.org/ => https://www.jondos.org/: (7, 'Failed to c
 	<target host="*.anonymous-proxy-servers.net"/>
 	<target host="anonym-surfen.de"/>
 	<target host="*.anonym-surfen.de"/>
-	<target host="jondos.org"/>
-	<target host="www.jondos.org"/>
+	<target host="jondos.de"/>
+	<target host="www.jondos.de"/>
 
 	<securecookie host="^(?:.*\.)?anonym(?:ous-proxy-servers\.net|-surfen\.de)$" name=".*"/>
 


### PR DESCRIPTION
Our host name was wrongly specified; it's [www.]jondos.de, not jondos.com.
I fixed it
-- zudljk (Sysadmin JonDos GmbH, Nuremberg, Germany)
