### PR TITLE
[Dota2lounge.com] Avoid false mixed content blocking

### DIFF
--- a/src/chrome/content/rules/Dota2lounge.com.xml
+++ b/src/chrome/content/rules/Dota2lounge.com.xml
@@ -2,14 +2,14 @@
 	Doesn't exist:
 	www.dota2lounge.com
 -->
-<ruleset name="Dota2lounge.com">
+<ruleset name="Dota2lounge.com" platform="mixedcontent">
 	<target host="dota2lounge.com" />
 	<target host="cdn.dota2lounge.com" />
 
 	<test url="http://cdn.dota2lounge.com/" />
 	
 	<rule from="^http://cdn\.dota2lounge\.com/"
-	to="https://dota2lounge.com/" />
+		to="https://dota2lounge.com/" />
 	
 	<rule from="^http:" to="https:" />
 </ruleset>


### PR DESCRIPTION
This sets `platform="mixedcontent"` for the ruleset which otherwise has its style sheets blocked. This follows up on https://github.com/EFForg/https-everywhere/pull/5131 and partially reverts https://github.com/EFForg/https-everywhere/pull/4835