### PR TITLE
[UserScape] Redirect ^ to www

### DIFF
--- a/src/chrome/content/rules/UserScape.xml
+++ b/src/chrome/content/rules/UserScape.xml
@@ -1,19 +1,22 @@
 <!--
 	Problematic subdomains:
 
-		- ^ serves 404s on all requests
+		- ^ ¹
+		- blog ¹
+		- drop ²
 
+	¹: Serves 404s on all requests
+	²: Mismatch
 -->
 <ruleset name="UserScape">
 
 	<target host="userscape.com" />
 	<target host="www.userscape.com" />
-
+	<target host="drop.userscape.com" />
 
 	<securecookie host="^\.userscape\.com$" name=".+" />
 
-
-	<rule from="^http://(www\.)?userscape\.com/"
+	<rule from="^http://(www\.|drop\.)?userscape\.com/"
 		to="https://www.userscape.com/" />
 
 </ruleset>

--- a/src/chrome/content/rules/UserScape.xml
+++ b/src/chrome/content/rules/UserScape.xml
@@ -1,3 +1,9 @@
+<!--
+	Problematic subdomains:
+
+		- ^ serves 404s on all requests
+
+-->
 <ruleset name="UserScape">
 
 	<target host="userscape.com" />
@@ -7,6 +13,7 @@
 	<securecookie host="^\.userscape\.com$" name=".+" />
 
 
-	<rule from="^http:" to="https:" />
+	<rule from="^http://(www\.)?userscape\.com/"
+		to="https://www.userscape.com/" />
 
 </ruleset>


### PR DESCRIPTION
Currently, userscape.com serves 404s on all HTTPS requests. This takes care of the issue by redirecting all traffic to www.