### PR TITLE
[PostNord] Turn off ruleset by default

### DIFF
--- a/src/chrome/content/rules/PostNord.se.xml
+++ b/src/chrome/content/rules/PostNord.se.xml
@@ -1,5 +1,8 @@
 <!--
-	^postnord.se: Mismatched
+	Problematic subdomains:
+
+		^postnord.se: Mismatched
+		www.postnord.se: Causes redirect loop
 
 
 	Insecure cookies are set for these hosts:
@@ -14,16 +17,12 @@
 	* Secured by us
 
 -->
-<ruleset name="PostNord.se">
-
-	<!--	Direct rewrites:
-				-->
-	<target host="www.postnord.se" />
+<ruleset name="PostNord.se" default_off="Causes redirect loop">
 
 	<!--	Complications:
 				-->
 	<target host="postnord.se" />
-
+	<target host="www.postnord.se" />
 
 	<!--	Not secured by server:
 					-->


### PR DESCRIPTION
The GitHub issue https://github.com/EFForg/https-everywhere/issues/5353 points out that the current ruleset causes a redirect loop; this fixes the issue by simply disabling the ruleset.