### PR TITLE
ComputerBase remove rewrite Restrictions

### DIFF
--- a/src/chrome/content/rules/Computerbase.de.xml
+++ b/src/chrome/content/rules/Computerbase.de.xml
@@ -1,22 +1,11 @@
-<ruleset name="Computerbase.de (partial)">
+<ruleset name="Computerbase.de">
 
+	<!-- mail results in a 403 error -->
+	<target host="ftp.computerbase.de"/>
 	<target host="pics.computerbase.de"/>
 	<target host="www.computerbase.de"/>
 
-	<rule from="^http://www\.computerbase\.de/(abo|api/stats|clientscripts|css|design|img|login|push)/" to="https://www.computerbase.de/$1/"/>
-		<exclusion pattern="^http://www\.computerbase\.de/$" />
-
-	<rule from="^http://pics\.computerbase\.de/"
-		to="https://pics.computerbase.de/" />
-
-	<test url="http://www.computerbase.de/abo/" />
-	<test url="http://www.computerbase.de/api/stats/" />
-	<test url="http://www.computerbase.de/clientscripts/cb-desktop.1424359770.js" />
-	<test url="http://www.computerbase.de/css/" />
-	<test url="http://www.computerbase.de/design/blind.png" />
-	<test url="http://www.computerbase.de/design/fallback/nav.png" />
-	<test url="http://www.computerbase.de/img/logo-opengraph.png" />
-	<test url="http://www.computerbase.de/login/" />
-	<test url="http://www.computerbase.de/push/" />
+	<rule from="^http:"
+		to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Computerbase.de.xml
+++ b/src/chrome/content/rules/Computerbase.de.xml
@@ -1,7 +1,9 @@
 <ruleset name="Computerbase.de">
 
 	<!-- mail results in a 403 error -->
+	<target host="computerbase.de"/>
 	<target host="ftp.computerbase.de"/>
+	<target host="m.computerbase.de"/>
 	<target host="pics.computerbase.de"/>
 	<target host="www.computerbase.de"/>
 


### PR DESCRIPTION
As of today CB has enabled TLS on the whole site for all users, not just those that have a paid subscription.
