### PR TITLE
Fixes and documentation for development on Vagrant with Windows 10 host/Fedora 24 Cloud guest

### DIFF
--- a/install-dev-dependencies.sh
+++ b/install-dev-dependencies.sh
@@ -22,7 +22,8 @@ elif type brew >/dev/null ; then
     echo '/usr/local/bin not found in $PATH, please add it.'
   fi
 elif type dnf >/dev/null ; then
-  sudo dnf install libxml2-devel python-devel libxslt-devel
+  sudo dnf install firefox gcc git libcurl-devel libxml2-devel libxslt-devel \
+    python-devel redhat-rpm-config xorg-x11-server-Xvfb
 fi
 
 # Get the addon SDK submodule and rule checker

--- a/test/chromium/README.md
+++ b/test/chromium/README.md
@@ -5,4 +5,4 @@
       - Install Selenium as a python package using ```pip install selenium```, or run install-dev-dependencies.sh and it will do the job
 - ChromeDriver
       - Run ```apt-get install chromium-chromedriver```, or run install-dev-dependencies.sh
-      - Or, manually download ChromeDriver from https://sites.google.com/a/chromium.org/chromedriver/downloads. Extract the executable to /usr/lib/chromium-browser/, so that the pasted executable's full path becomes /usr/lib/chromium-browser/chromedriver
+      - Or, manually download ChromeDriver from https://sites.google.com/a/chromium.org/chromedriver/downloads. Extract the executable to /usr/lib/chromium-browser/ (Ubuntu), /usr/lib/chromium/ (Debian), or /usr/bin/ (other) , so that the pasted executable's full path becomes /usr/lib/chromium-browser/chromedriver (for Ubuntu, otherwise substitute the directory as needed).

--- a/test/chromium/script.py
+++ b/test/chromium/script.py
@@ -45,7 +45,7 @@ except WebDriverException as e:
     error = e.__str__()
 
     if "executable needs to be in PATH" in e.__str__():
-        print "ChromeDriver isn't installed. Check test/chrome/README.md " \
+        print "ChromeDriver isn't installed. Check test/chromium/README.md " \
               "for instructions on how to install ChromeDriver"
 
         sys.exit(2)


### PR DESCRIPTION
I've been working on a development environment for HTTPS-Everywhere running with Vagrant. I'm on a Windows 10 host and setting up a [Fedora 24 Cloud](https://atlas.hashicorp.com/fedora/boxes/24-cloud-base) guest. Why not Ubuntu 16.04? Because the ubuntu/xenial64 box [has problems](https://bugs.launchpad.net/cloud-images/+bug/1565985). Why not Ubuntu 14.04? Because I need SMB support and that seems to require a [more recent kernel](https://github.com/mitchellh/vagrant/issues/6188#issuecomment-171396607).

My working environment is Git (Bash) for Windows 2.9.0.

This pull request fixes some documentation and adds missing dnf dependencies.

Here are various other issues I encountered that should be documented somewhere. I can write the documentation if you can tell me where to put it.

The current default folder sync method for this box is `rsync`, but Git Bash doesn't include rsync so that doesn't work. The usual `virtualbox` method doesn't work either because HTTPS-Everywhere uses symlinks and symlinks don't work correctly on Windows with the `virtualbox` method. `smb` (samba) is needed. This requires some preconfiguration, see [this Vagrant issue](https://github.com/mitchellh/vagrant/issues/7532) I submitted. Due to [this other Vagrant issue](https://github.com/mitchellh/vagrant/issues/7534), I started the box in admin PowerShell and then accessed it in Git Bash by directly sshing into it (`ssh -p 2222 vagrant@127.0.0.1`) instead of using `vagrant ssh`.

The default RAM allocated by the Fedora box is 1024MB. This is not enough to even compile lxml during the `install-dev-dependencies.sh` step, but 2048MB is enough for that. Later I kept getting `git push` timeouts due to the extensive pre-push testing even with 8192MB allocated. I ended up just unlinking the pre-push tests so I could successfully push at all.

The `pycurl` that pip installs doesn't work. You get this error in a Python interpreter:

```
>>> import pycurl
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: pycurl: libcurl link-time ssl backend (nss) is different from compile-time ssl backend (none/other)
>>>
```

The fix is to first remove pycurl with `pip uninstall pycurl`, and then either

```bash
$ sudo dnf install python-pycurl
```

or

```bash
$ export PYCURL_SSL_LIBRARY=nss
$ pip install --user --no-allow-insecure --no-allow-external --compile pycurl
```

Chromium isn't available for Fedora so I installed Google Chrome by downloading the rpm from Google's site. I downloaded `chromedriver` from https://sites.google.com/a/chromium.org/chromedriver/downloads as described in [test/chromium/README.md](https://github.com/jeremyn/https-everywhere/blob/8712bf84858fd4d31b04011dc889767723ba85e8/test/chromium/README.md)

At this point `bash test.sh` and the pre-push hook should work. Running the tests in other ways might not work. In particular I ran into trouble trying to run `test/chromium/script.py` headless without 
[xvfb](https://github.com/EFForg/https-everywhere/blob/master/test/chromium.sh#L42). Instead I tried using `pyvirtualdisplay` as described [here](https://github.com/EFForg/https-everywhere/blob/master/test/chromium/script.py#L11) but eventually got hangs/failures that I couldn't get past. In case it helps you, for reference, I tried pip installing `pyvirtualdisplay` and dnf installing `python-xvfbwrapper` and `dbus-x11`. The dnf stuff might have been useless. The `pyvirtualdisplay` reference in `test/chromium/script.py` should probably either be improved or deleted entirely.