### PR TITLE
Fix example rule in `ruleset-testing.md`.

### DIFF
--- a/ruleset-testing.md
+++ b/ruleset-testing.md
@@ -37,8 +37,8 @@ target host with a right-side wildcard. But this is not yet implemented.
       <test url="http://www.example.com/" />
       <test url="http://beta.example.com/" />
 
-      <rule from="^http://([\w-]+\.)?dezeen\.com/"
-          to="https://$1dezeen.com/" />
+      <rule from="^http://([\w-]+\.)?example\.com/"
+          to="https://$1example.com/" />
 
     </ruleset>
 
@@ -50,7 +50,7 @@ using explicit &lt;test&gt; tags.
 
 # Testing and Continuous Build
 
-Testing for rulest coverage is now part of the Travis CI continuous build.
+Testing for ruleset coverage is now part of the Travis CI continuous build.
 Currently we only test rulesets that have been modified since February 2 2015.
 Submitting changes to any ruleset that does not meet the coverage requirements
 will break the build. This means that even fixes of existing rules may require


### PR DESCRIPTION
The ruleset target was using `example.com` but the rule was using
`dezeen.com`.