### PR TITLE
[uv.es] Fixed ruleset

### DIFF
--- a/src/chrome/content/rules/Uv.es.xml
+++ b/src/chrome/content/rules/Uv.es.xml
@@ -4,8 +4,6 @@
 
 	Not supporting HTTPS or using an invalid certificate:
 	
-		* uv.es
-	
 		* acceso.uv.es
 		* anglogermanica.uv.es
 		* aposta.uv.es
@@ -70,57 +68,44 @@
 		* uvx.uv.es
 		* webific.ific.uv.es
 -->
-<ruleset name="Universitat de València">
+<ruleset name="Universitat de Val&#232;ncia">
 
-	<target host="anesica.blogs.uv.es" />
-	<target host="anpoto.blogs.uv.es" />
+	<!-- special case for http://uv.es, as https://uv.es does not exist -->
+	<target host="uv.es" />
+	<rule from="^http://uv\.es/" to="https://www.uv.es/" />
+
+	<!-- blogs.uv.es has a wildcard certificate, so every blog will have HTTPS enabled -->
+	<target host="*.blogs.uv.es" />
+	<test url="http://confucio.blogs.uv.es/" />
+	<test url="http://coneixer.blogs.uv.es/" />
+	<test url="http://cperez.blogs.uv.es/" />
+
+	<target host="as.uv.es" />
 	<target host="aulavirtual.uv.es" />
-	<target host="bek.blogs.uv.es" />
 	<target host="blogs.uv.es" />
 	<target host="card.uv.es" />
 	<target host="correoold.uv.es" />
-	<target host="diagon.blogs.uv.es" />
 	<target host="disco.uv.es" />
 	<target host="entreu.uv.es" />
-	<target host="estalmatcv.blogs.uv.es" />
-	<target host="fersalma.blogs.uv.es" />
-	<target host="gentext.blogs.uv.es" />
 	<target host="go.uv.es" />
 	<target host="home.uv.es" />
 	<target host="informatica.uv.es" />
-	<target host="infosogo.blogs.uv.es" />
-	<target host="jgarciar.blogs.uv.es" />
-	<target host="jornea.blogs.uv.es" />
-	<target host="laurapo.blogs.uv.es" />
-	<target host="mafies.blogs.uv.es" />
-	<target host="magarni.blogs.uv.es" />
-	<target host="mamdoca.blogs.uv.es" />
+	<target host="links.uv.es" />
+	<target host="manteniment.uv.es" />
 	<target host="mcuser.uv.es" />
 	<target host="monitor.uv.es" />
 	<target host="moodle.uv.es" />
-	<target host="nauest.blogs.uv.es" />
-	<target host="nauxiquets.blogs.uv.es" />
 	<target host="ojs.uv.es" />
 	<target host="pages.uv.es" />
-	<target host="pauls.blogs.uv.es" />
-	<target host="pausaiz2.blogs.uv.es" />
-	<target host="pausalso.blogs.uv.es" />
-	<target host="peire.blogs.uv.es" />
-	<target host="perezbl.blogs.uv.es" />
-	<target host="period.blogs.uv.es" />
 	<target host="personal.uv.es" />
-	<target host="petosan.blogs.uv.es" />
 	<target host="portal.uv.es" />
-	<target host="rorueso.blogs.uv.es" />
-	<target host="safigue.blogs.uv.es" />
-	<target host="saformo.blogs.uv.es" />
 	<target host="secvirtual.uv.es" />
-	<target host="seramix.blogs.uv.es" />
 	<target host="soft.uv.es" />
 	<target host="software.uv.es" />
+	<target host="sogo.uv.es" />
 	<target host="solitelefons.uv.es" />
-	<target host="stepviv.blogs.uv.es" />
-	<target host="tapeda.blogs.uv.es" />
+	<target host="targeta.uv.es" />
+	<target host="tresor.uv.es" />
 	<target host="uvalred.uv.es" />
 	<target host="webges.uv.es" />
 	<target host="www.uv.es" />


### PR DESCRIPTION
This pull request fixes the rules for www.uv.es, an Spanish university, and most of its subdomains.

Namely:
 - The name of the ruleset has been escaped. For some reason, the grave prevented HTTPS Everywhere from loading the file.
 - Adds a special rule for uv.es, redirecting to https://www.uv.es/
 - The subdomains of blogs.uv.es have been replaced by a single wildcard target. This can be done because the server has a wildcard certificate for *.blogs.uv.es.