### PR TITLE
Added a new domain (pcbsd.org) to the list of rules.

### DIFF
--- a/src/chrome/content/rules/Pcbsd.org.xml
+++ b/src/chrome/content/rules/Pcbsd.org.xml
@@ -1,0 +1,7 @@
+<ruleset name="Pcbsd.org">
+	<target host="pcbsd.org" />
+	<target host="www.pcbsd.org" />
+	<target host="web.pcbsd.org" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>


### PR DESCRIPTION
This is a small rule update to add the pcbsd.org domain to HTTPS Everywhere.
