### PR TITLE
[Thecthulhu.com] Add akp and time, remove annefrank and hp

### DIFF
--- a/chromium/popup.html
+++ b/chromium/popup.html
@@ -25,7 +25,7 @@
 </section>
 <section id="HttpNowhere" class="options">
     <input id="http-nowhere-checkbox" type="checkbox" value="httpNowhere"/>
-    <label i18n="menu_blockHttpRequests" for="http-nowhere-checkbox"></label>
+    <label i18n="menu_blockUnencryptedRequests" for="http-nowhere-checkbox"></label>
 </section>
 
 <div id="RuleManagement">

--- a/src/chrome/content/rules/Thecthulhu.com.xml
+++ b/src/chrome/content/rules/Thecthulhu.com.xml
@@ -10,6 +10,7 @@
 
 	<target host="thecthulhu.com" />
 	<target host="000webhost.thecthulhu.com" />
+	<target host="akp.thecthulhu.com" />
 	<target host="am.thecthulhu.com" />
 	<target host="atlas.thecthulhu.com" />
 	<target host="citizenfour.thecthulhu.com" />

--- a/src/chrome/content/rules/Thecthulhu.com.xml
+++ b/src/chrome/content/rules/Thecthulhu.com.xml
@@ -33,6 +33,7 @@
 	<target host="sin.thecthulhu.com" />
 	<target host="staminus.thecthulhu.com" />
 	<target host="tails.thecthulhu.com" />
+	<target host="time.thecthulhu.com" />
 	<target host="tor.thecthulhu.com" />
 	<target host="turkey.thecthulhu.com" />
 	<target host="whonix.thecthulhu.com" />


### PR DESCRIPTION
* Add `akp.thecthulhu.com` and `time.thecthulhu.com`
* Remove `annefrank.thecthulhu.com` and `hp.thecthulhu.com`; they no longer resolve