### PR TITLE
filecrypt.cc: restore click'n'load functionality #5727

### DIFF
--- a/src/chrome/content/rules/filecrypt.cc.xml
+++ b/src/chrome/content/rules/filecrypt.cc.xml
@@ -5,6 +5,8 @@
     
     <securecookie host="^(www\.)?filecrypt\.cc" name=".+"/>
 
+    <test url="http://filecrypt.cc/helper.html"/>
+
     <exclusion pattern="^http://filecrypt\.cc/helper\.html"/>
     <rule from="^http:" to="https:"/>
 

--- a/src/chrome/content/rules/filecrypt.cc.xml
+++ b/src/chrome/content/rules/filecrypt.cc.xml
@@ -5,6 +5,7 @@
     
     <securecookie host="^(www\.)?filecrypt\.cc" name=".+"/>
 
+    <exclusion pattern="^http://filecrypt\.cc/helper\.html"/>
     <rule from="^http:" to="https:"/>
 
 </ruleset>


### PR DESCRIPTION
After the .html there always is a `?` followed by a string of number. Like this: `?1469099854883`
I don't know if the added exclusion pattern covers that, nor am I able to test it.