### PR TITLE
Updated Yahoo_Japan.xml

### DIFF
--- a/src/chrome/content/rules/Yahoo_Japan.xml
+++ b/src/chrome/content/rules/Yahoo_Japan.xml
@@ -26,7 +26,6 @@
 			- chiebukuro subdomains:
 
 				- answer *
-				- detail *
 				- list *
 				- my *
 				- note *
@@ -209,6 +208,8 @@
 	<target host="s.sample.yahoo.co.jp" />
 	<target host="custom.search.yahoo.co.jp" />
 	<target host="auctions.yahoo.co.jp" />
+	<target host="chiebukuro.yahoo.co.jp" />
+	<target host="detail.chiebukuro.yahoo.co.jp" />
 	<!--	404
 	target host="odhistory.shopping.yahoo.co.jp" /-->
 	<target host="order.store.yahoo.co.jp" />


### PR DESCRIPTION
- Removed chiebukuro from search subdomains because http://chiebukuro.search.yahoo.co.jp is redirected to http://chiebukuro.yahoo.co.jp
- Added chiebukuro.yahoo.co.jp
- Added detail.chiebukuro.yahoo.co.jp