### PR TITLE
[Archive.is] Update ruleset

### DIFF
--- a/src/chrome/content/rules/Archive.is.xml
+++ b/src/chrome/content/rules/Archive.is.xml
@@ -10,11 +10,16 @@
 	<target host="archive.today" />
 	<target host="blog.archive.today" />
 	<target host="www.archive.today" />
+	<target host="archive.fo" />
+	<target host="www.archive.fo" />
 	<target host="archive.is" />
 	<target host="www.archive.is" />
 	<target host="archive.li" />
 	<target host="blog.archive.li" />
 	<target host="www.archive.li" />
+
+	<rule from="^http://(www\.)?archive\.is/"
+		to="https://$1archive.fo/" />
 
 	<rule from="^http:"
 		to="https:" />

--- a/src/chrome/content/rules/Archive.is.xml
+++ b/src/chrome/content/rules/Archive.is.xml
@@ -1,9 +1,10 @@
 <!--
-	Nonfunctional hosts in *archive.is:
+	Problematic domains:
+		- (www.)archive.is ¹
+		- blog.archive.is ²
 
-		- blog *
-
-	* tumblr
+	¹ By webmaster request, we avoid redirecting anything to https://archive.is/ but ensure that the relevant connections are still upgraded by using archive.fo instead.
+	² Mismatch
 -->
 <ruleset name="Archive.is (partial)">
 


### PR DESCRIPTION
After having had a couple of different issues with this ruleset, cf. in particular https://github.com/EFForg/https-everywhere/issues/5805 and https://github.com/EFForg/https-everywhere/issues/4075.

I prompted the webmaster for what would be a proper solution moving forwards. On their request, this avoids redirecting anything to https://archive.is/ but ensures that the relevant connections are still upgrading by using archive.fo instead. Indeed, they considered disabling the option to use secure connections to archive.is but were happy with still providing the option in this slightly round-about fashion.

This closes #5805.