### PR TITLE
Updates to LinuxFoundation subdomains

### DIFF
--- a/src/chrome/content/rules/Datapipe.com.xml
+++ b/src/chrome/content/rules/Datapipe.com.xml
@@ -1,4 +1,6 @@
 <!--
+	go.datapipe.com is handled in Pardot_vanity_domains.xml.
+
 	Other Datapipe rulesets:
 
 		- Datapipe.co.uk.xml
@@ -31,7 +33,6 @@
 
 		- Ads/bugs, on:
 
-			- (www.)?datapipe.com from go.datapipe.com ¹
 			- (www.)?datapipe.com from web-cntr-07.com ²
 
 	¹ Secured by us
@@ -49,21 +50,6 @@
 	<target host="sso.datapipe.com" />
 	<target host="www.datapipe.com" />
 
-	<!--	Complications:
-				-->
-	<target host="go.datapipe.com" />
-
-		<exclusion pattern="^http://go\.datapipe\.com/(?!l/)" />
-
-			<!--	+ve:
-					-->
-			<test url="http://go.datapipe.com/quote_request" />
-
-			<!--	-ve:
-					-->
-			<test url="http://go.datapipe.com/l/47762/2014-08-06/2p7c" />
-
-
 
 	<!--	Not secured by server:
 					-->
@@ -74,9 +60,6 @@
 
 	<securecookie host="^(?:.+\.)?datapipe\.com$" name=".+" />
 
-
-	<rule from="^http://go\.datapipe\.com/"
-		to="https://pi.pardot.com/" />
 
 	<rule from="^http:"
 		to="https:" />

--- a/src/chrome/content/rules/ILX_Group.com.xml
+++ b/src/chrome/content/rules/ILX_Group.com.xml
@@ -1,4 +1,6 @@
 <!--
+	www2.ilxgroup.com is handled in Pardot_vanity_domains.xml.
+
 	Nonfunctional hosts in *ilxgroup.com:
 
 		- shop ⁴
@@ -6,13 +8,6 @@
 
 	⁴ 404
 	ᵃ Shows shop.ilxgroup.com
-
-
-	Problematic hosts in *ilxgroup.com:
-
-		- www2 ᵐ
-
-	ᵐ Pardot / mismatched
 
 
 	Insecure cookies are set for these hosts:
@@ -27,43 +22,13 @@
 	<target host="ilxgroup.com" />
 	<target host="www.ilxgroup.com" />
 
-	<!--	Complications:
-				-->
-	<target host="www2.ilxgroup.com" />
-
-		<exclusion pattern="^http://www2\.ilxgroup\.com/(?!/*(?:e/|$|\?))" />
-
-			<!--	See below respective rules for negative cases.
-
-				+ve:
-					-->
-			<test url="http://www2.ilxgroup.com/default.aspx" />
-			<test url="http://www2.ilxgroup.com/favicon.ico" />
-			<test url="http://www2.ilxgroup.com/index.htm" />
-			<test url="http://www2.ilxgroup.com/index.html" />
-			<test url="http://www2.ilxgroup.com/index.jsp" />
-			<test url="http://www2.ilxgroup.com/index.php" />
-
 
 	<!--	Not secured by server:
 					-->
 	<!--securecookie host="^www\.ilxgroup\.com$" name="^laravel_session$" /-->
 
-	<securecookie host="^(?!www2\.)\w" name="." />
+	<securecookie host=".+" name=".+" />
 
-
-	<rule from="^http://www2\.ilxgroup\.com/(?=/*e/)"
-		to="https://go.pardot.com/" />
-
-		<test url="http://www2.ilxgroup.com/e/52142/112791343529511718875-posts/4j5zhj/152467769" />
-		<test url="http://www2.ilxgroup.com/e/52142/wiki-Windows-1-0/4yqg9x/172139929" />
-
-	<!--	Redirect drops forward slash and args:
-							-->
-	<rule from="^http://www2\.ilxgroup\.com/.*"
-		to="https://www.ilxgroup.com/" />
-
-		<test url="http://www2.ilxgroup.com/?" />
 
 	<rule from="^http:"
 		to="https:" />

--- a/src/chrome/content/rules/LinuxFoundation.xml
+++ b/src/chrome/content/rules/LinuxFoundation.xml
@@ -19,17 +19,9 @@
 
 	Partially covered hosts in *linuxfoundation.org:
 
-		- collabprojects ʰ
 		- events ʰ
-		- eventsstg ʰ
-		- www ʰ
 
 	ʰ Some pages redirect to http
-
-
-	Insecure cookies are set for these domains:
-
-		- developerbugs.linuxfoundation.org
 
 -->
 <ruleset name="Linux Foundation.org (partial)">
@@ -44,7 +36,6 @@
 	<target host="collabprojects.linuxfoundation.org" />
 	<target host="developerbugs.linuxfoundation.org" />
 	<target host="events.linuxfoundation.org" />
-	<target host="eventsstg.linuxfoundation.org" />
 	<target host="identity.linuxfoundation.org" />
 	<target host="ldn.linuxfoundation.org" />
 	<target host="lists.linuxfoundation.org" />
@@ -56,69 +47,34 @@
 				-->
 	<target host="go.linuxfoundation.org" />
 
-		<!--	Redirects to http:
-						-->
-		<!--exclusion pattern="^http://collabprojects\.linuxfoundation\.org/$" /-->
-		<!--exclusion pattern="^http://events\.linuxfoundation\.org/(contact-us|events(/|[\w/-]+/*)?)?(\?.*)?$" /-->
-		<!--exclusion pattern="^http://eventstg\.linuxfoundation\.org/$" /-->
-		<!--exclusion pattern="^http://www\.linuxfoundation\.org/$" /-->
-
 		<!--	Exceptions:
 					-->
-		<exclusion pattern="^http://collabprojects\.linuxfoundation\.org/+(?!sites/)" />
+		<exclusion pattern="^http://events\.linuxfoundation\.org/((events/|\?).*)?$" />
 
 			<!--	+ve:
 					-->
-			<test url="http://collabprojects.linuxfoundation.org/" />
-			<test url="http://collabprojects.linuxfoundation.org//" />
-
-			<!--	-ve:
-					-->
-			<test url="http://collabprojects.linuxfoundation.org/sites/all/modules/custom/lf_assets/includes/img/di_blue.png" />
-
-		<exclusion pattern="^http://events(?:stg)?\.linuxfoundation\.org/+(?!sites/)" />
-
-			<!--	+ve:
-					-->
-			<test url="http://events.linuxfoundation.org/contact-us" />
-			<test url="http://events.linuxfoundation.org/events" />
 			<test url="http://events.linuxfoundation.org/events/embedded-linux-conference-europe/attend/register" />
 			<test url="http://events.linuxfoundation.org/events/linuxcon-europe/program/cfp" />
-			<test url="http://events.linuxfoundation.org/events/mesoscon/attend/register" />
+			<test url="http://events.linuxfoundation.org/events/mesoscon/attend/register?utm_source=lf" />
+			<test url="http://events.linuxfoundation.org/?" />
+			<test url="http://events.linuxfoundation.org/?utm_source=lf" />
 
 			<!--	-ve:
 					-->
+			<test url="http://events.linuxfoundation.org/sponsor" />
 			<test url="http://events.linuxfoundation.org/sites/events/files/styles/events_listing_192x192/public/ccc_eu_color.png" />
-			<test url="http://eventsstg.linuxfoundation.org/sites/all/themes/lfevents/css/homepage-pardot_new.css" />
 
-		<exclusion pattern="^http://www\.linuxfoundation\.org/(?!about/join/individual(?:$|[?/])|cas\?|misc/|sites/|user(?:$|\?))" />
+		<!-- Exclude Pardot paths other than /, /e/*, /l/*, and /?* -->
+		<!-- As of Sept 2016, most Pardot vanity URLs do NOT work on go.pardot.com,
+		     only on the vanity domain (go.linuxfoundation.org) which does not
+		     support SSL. Embedded forms (/l/*) and non-vanity tracker URLs (/e/*)
+		     are the only paths confirmed to work on https://go.pardot.com. -->
+		<!-- http://help.pardot.com/customer/portal/articles/2126757-using-vanity-urls -->
+		<exclusion pattern="^http://go\.linuxfoundation\.org/(?![el]/)[^?]" />
 
 			<!--	+ve:
 					-->
-			<test url="http://www.linuxfoundation.org/about" />
-			<test url="http://www.linuxfoundation.org/about/faq" />
-			<test url="http://www.linuxfoundation.org/about/members" />
-			<test url="http://www.linuxfoundation.org/collaborate" />
-			<test url="http://www.linuxfoundation.org/news-media/blogs" />
-			<test url="http://www.linuxfoundation.org/og" />
-			<test url="http://www.linuxfoundation.org/privacy" />
-			<test url="http://www.linuxfoundation.org/programs" />
-			<test url="http://www.linuxfoundation.org/publications" />
-			<test url="http://www.linuxfoundation.org/search" />
-
-			<!--	-ve:
-					-->
-			<test url="http://www.linuxfoundation.org/about/join/individual" />
-			<test url="http://www.linuxfoundation.org/cas?destination=homepage" />
-			<test url="http://www.linuxfoundation.org/sites/all/modules/custom/lf_assets/includes/img/di_blue.png" />
-			<test url="http://www.linuxfoundation.org/user" />
-
-
-	<!--	Not secured by server:
-					-->
-	<!--securecookie host="^developerbugs\.linuxfoundation\.org$" name="^(BUGLIST|LASTORDER)$" /-->
-
-	<securecookie host="^(?!collabprojects\.|events\.)." name="." />
+			<test url="http://go.linuxfoundation.org/sysadminday2016" />
 
 
 	<rule from="^http://go\.linuxfoundation\.org/+(?:\?.*)?$"
@@ -129,10 +85,11 @@
 		<test url="http://go.linuxfoundation.org//" />
 		<test url="http://go.linuxfoundation.org//?" />
 
-	<rule from="^http://go\.linuxfoundation\.org/"
-		to="https://pi.pardot.com/" />
+	<rule from="^http://go\.linuxfoundation\.org/([el])/"
+		to="https://pi.pardot.com/$1/" />
 
 		<test url="http://go.linuxfoundation.org/e/6342/TheLinuxFoundation/ymc8q/578968329" />
+		<test url="http://go.linuxfoundation.org/l/6342/2016-03-23/33c3kc" />
 
 	<rule from="^http:"
 		to="https:" />

--- a/src/chrome/content/rules/LinuxFoundation.xml
+++ b/src/chrome/content/rules/LinuxFoundation.xml
@@ -21,16 +21,10 @@
 
 	Partially covered hosts in *linuxfoundation.org:
 
-		- events ʰ
-
-	ʰ Some pages redirect to http
+		- events (root domain and /events/* redirect to http)
 
 -->
 <ruleset name="Linux Foundation.org (partial)">
-
-	<!--	Direct rewrites:
-				-->
-	<target host="lists.linux-foundation.org" />
 
 	<target host="linuxfoundation.org" />
 	<target host="www.linuxfoundation.org" />
@@ -39,28 +33,21 @@
 	<target host="collabprojects.linuxfoundation.org" />
 	<target host="developerbugs.linuxfoundation.org" />
 	<target host="events.linuxfoundation.org" />
+		<exclusion pattern="^http://events\.linuxfoundation\.org/((events/|\?).*)?$" />
+		<!-- Secured -->
+		<test url="http://events.linuxfoundation.org/sponsor" />
+		<test url="http://events.linuxfoundation.org/sites/events/files/styles/events_listing_192x192/public/ccc_eu_color.png" />
+		<!-- Excluded -->
+		<test url="http://events.linuxfoundation.org/events/embedded-linux-conference-europe/attend/register" />
+		<test url="http://events.linuxfoundation.org/events/linuxcon-europe/program/cfp" />
+		<test url="http://events.linuxfoundation.org/events/mesoscon/attend/register?utm_source=lf" />
+		<test url="http://events.linuxfoundation.org/" />
+		<test url="http://events.linuxfoundation.org/?utm_source=lf" />
 	<target host="identity.linuxfoundation.org" />
 	<target host="ldn.linuxfoundation.org" />
 	<target host="lists.linuxfoundation.org" />
 	<target host="lsbbugs.linuxfoundation.org" />
 	<target host="training.linuxfoundation.org" />
-
-		<!--	Exceptions:
-					-->
-		<exclusion pattern="^http://events\.linuxfoundation\.org/((events/|\?).*)?$" />
-
-			<!--	+ve:
-					-->
-			<test url="http://events.linuxfoundation.org/events/embedded-linux-conference-europe/attend/register" />
-			<test url="http://events.linuxfoundation.org/events/linuxcon-europe/program/cfp" />
-			<test url="http://events.linuxfoundation.org/events/mesoscon/attend/register?utm_source=lf" />
-			<test url="http://events.linuxfoundation.org/?" />
-			<test url="http://events.linuxfoundation.org/?utm_source=lf" />
-
-			<!--	-ve:
-					-->
-			<test url="http://events.linuxfoundation.org/sponsor" />
-			<test url="http://events.linuxfoundation.org/sites/events/files/styles/events_listing_192x192/public/ccc_eu_color.png" />
 
 	<rule from="^http:"
 		to="https:" />

--- a/src/chrome/content/rules/LinuxFoundation.xml
+++ b/src/chrome/content/rules/LinuxFoundation.xml
@@ -1,4 +1,6 @@
 <!--
+	go.linuxfoundation.org is handled in Pardot_vanity_domains.xml.
+
 	Other Linux Foundation rulesets:
 
 		- AllSeen_Alliance.org.xml
@@ -31,6 +33,7 @@
 	<target host="lists.linux-foundation.org" />
 
 	<target host="linuxfoundation.org" />
+	<target host="www.linuxfoundation.org" />
 	<target host="admin.linuxfoundation.org" />
 	<target host="automotive.linuxfoundation.org" />
 	<target host="collabprojects.linuxfoundation.org" />
@@ -41,11 +44,6 @@
 	<target host="lists.linuxfoundation.org" />
 	<target host="lsbbugs.linuxfoundation.org" />
 	<target host="training.linuxfoundation.org" />
-	<target host="www.linuxfoundation.org" />
-
-	<!--	Complications:
-				-->
-	<target host="go.linuxfoundation.org" />
 
 		<!--	Exceptions:
 					-->
@@ -63,33 +61,6 @@
 					-->
 			<test url="http://events.linuxfoundation.org/sponsor" />
 			<test url="http://events.linuxfoundation.org/sites/events/files/styles/events_listing_192x192/public/ccc_eu_color.png" />
-
-		<!-- Exclude Pardot paths other than /, /e/*, /l/*, and /?* -->
-		<!-- As of Sept 2016, most Pardot vanity URLs do NOT work on go.pardot.com,
-		     only on the vanity domain (go.linuxfoundation.org) which does not
-		     support SSL. Embedded forms (/l/*) and non-vanity tracker URLs (/e/*)
-		     are the only paths confirmed to work on https://go.pardot.com. -->
-		<!-- http://help.pardot.com/customer/portal/articles/2126757-using-vanity-urls -->
-		<exclusion pattern="^http://go\.linuxfoundation\.org/(?![el]/)[^?]" />
-
-			<!--	+ve:
-					-->
-			<test url="http://go.linuxfoundation.org/sysadminday2016" />
-
-
-	<rule from="^http://go\.linuxfoundation\.org/+(?:\?.*)?$"
-		to="https://www.linuxfoundation.org/" />
-
-		<test url="http://go.linuxfoundation.org/?" />
-		<test url="http://go.linuxfoundation.org/?f" />
-		<test url="http://go.linuxfoundation.org//" />
-		<test url="http://go.linuxfoundation.org//?" />
-
-	<rule from="^http://go\.linuxfoundation\.org/([el])/"
-		to="https://pi.pardot.com/$1/" />
-
-		<test url="http://go.linuxfoundation.org/e/6342/TheLinuxFoundation/ymc8q/578968329" />
-		<test url="http://go.linuxfoundation.org/l/6342/2016-03-23/33c3kc" />
 
 	<rule from="^http:"
 		to="https:" />

--- a/src/chrome/content/rules/Pardot_vanity_domains.xml
+++ b/src/chrome/content/rules/Pardot_vanity_domains.xml
@@ -1,0 +1,24 @@
+<!--
+
+For other Pardot coverage, see Pardot.xml.
+
+-->
+<ruleset name="Pardot vanity domains (partial)">
+
+	<!-- Many Pardot tracker URLs that work on a vanity CNAME do *NOT* work on
+	     the SSL-enabled domain "go.pardot.com". Embedded forms (/l/*) and
+	     non-vanity tracker URLs (/e/*) ARE confirmed to work. -->
+	<!-- http://help.pardot.com/customer/portal/articles/2126757-using-vanity-urls -->
+	<!-- http://help.pardot.com/customer/portal/articles/2126640-how-to-ssl-enable-http-secure-pardot-urls -->
+	<rule from="^http://([\w.-]+)/([el])/"
+		to="https://go.pardot.com/$2/" />
+
+	<!-- Exclude top domain to disable implicit test -->
+	<exclusion pattern="^http://([\w.-]+)/$" />
+
+	<target host="go.linuxfoundation.org" />
+		<test url="http://go.linuxfoundation.org/" />
+		<test url="http://go.linuxfoundation.org/e/6342/TheLinuxFoundation/ymc8q/578968329" />
+		<test url="http://go.linuxfoundation.org/l/6342/2016-03-23/33c3kc" />
+
+</ruleset>

--- a/src/chrome/content/rules/Pardot_vanity_domains.xml
+++ b/src/chrome/content/rules/Pardot_vanity_domains.xml
@@ -16,9 +16,29 @@ For other Pardot coverage, see Pardot.xml.
 	<!-- Exclude top domain to disable implicit test -->
 	<exclusion pattern="^http://([\w.-]+)/$" />
 
+	<target host="go.datapipe.com" />
+		<test url="http://go.datapipe.com/l/47762/2014-08-06/2p7c" />
+	<target host="www2.ilxgroup.com" />
+		<test url="http://www2.ilxgroup.com/e/52142/112791343529511718875-posts/4j5zhj/152467769" />
+		<test url="http://www2.ilxgroup.com/e/52142/wiki-Windows-1-0/4yqg9x/172139929" />
+	<target host="www2.fraedom.com" />
+		<test url="http://www2.fraedom.com/l/97782/2015-09-17/5r76f" />
 	<target host="go.linuxfoundation.org" />
-		<test url="http://go.linuxfoundation.org/" />
 		<test url="http://go.linuxfoundation.org/e/6342/TheLinuxFoundation/ymc8q/578968329" />
 		<test url="http://go.linuxfoundation.org/l/6342/2016-03-23/33c3kc" />
+	<target host="go.smashfly.com" />
+		<test url="http://go.smashfly.com/l/63212/2015-01-21/4z31" />
+		<test url="http://go.smashfly.com/l/63212/2015-01-21/4z39" />
+		<test url="http://go.smashfly.com/l/63212/2015-02-10/7r8f?nid=" />
+	<target host="www2.spongecell.com" />
+		<test url="http://www2.spongecell.com/l/105302/2015-11-03/33mpz" />
+	<target host="go.twenga-solutions.com" />
+		<test url="http://go.twenga-solutions.com/l/103922/2015-09-08/gmm/103922/2284/form_responsive.css" />
+	<target host="go.unruly.co" />
+		<test url="http://go.unruly.co/l/50182/2014-11-11/rtxy" />
+		<test url="http://go.unruly.co/l/50182/2015-08-17/3wmwmr/50182/63492/submit_button.png" />
+		<test url="http://go.unruly.co/l/50182/2015-12-09/57f3t2/50182/82583/SB_template_v1.png" />
+		<test url="http://go.unruly.co/l/50182/2015-12-09/57r24x" />
+		<test url="http://go.unruly.co/l/50182/2016-04-28/66l55p" />
 
 </ruleset>

--- a/src/chrome/content/rules/SmashFly.com.xml
+++ b/src/chrome/content/rules/SmashFly.com.xml
@@ -1,4 +1,6 @@
 <!--
+	go.smashfly.com is handled in Pardot_vanity_domains.xml.
+
 	For problematic rules, see SmashFly.com-problematic.xml.
 
 
@@ -18,11 +20,9 @@
 
 		- (www.)? ¹ ²
 		- blog ¹ ²
-		- go ³
 
 	¹ Expired
 	² Self-signed
-	³ Pardot
 
 
 	Fully covered hosts in *.smashfly.com:
@@ -53,39 +53,6 @@
 	<!--	Direct rewrites:
 				-->
 	<target host="recruit.smashfly.com" />
-
-	<!--	Complications:
-				-->
-	<target host="go.smashfly.com" />
-
-		<!--	Redirects to http:
-						-->
-		<exclusion pattern="^http://go.smashfly.com/+(?!$|\?|l/)" />
-
-			<!--	+ve:
-					-->
-			<test url="http://go.smashfly.com/beyondemployees" />
-			<test url="http://go.smashfly.com//beyondemployees" />
-			<test url="http://go.smashfly.com/forresterwebinar" />
-			<test url="http://go.smashfly.com/how-cande-winners-improve-candidate-experience-smashfly" />
-			<test url="http://go.smashfly.com/newcandidateexperiencejourney" />
-			<test url="http://go.smashfly.com//newcandidateexperiencejourney" />
-
-
-	<rule from="^http://go\.smashfly\.com/(?=/*l/)"
-		to="https://go.pardot.com/" />
-
-		<test url="http://go.smashfly.com/l/63212/2015-01-21/4z31" />
-		<test url="http://go.smashfly.com/l/63212/2015-01-21/4z39" />
-		<test url="http://go.smashfly.com/l/63212/2015-02-10/7r8f?nid=" />
-
-	<!--	Redirect drops forward
-		slash and args:
-					-->
-	<rule from="^http://go\.smashfly\.com/.*"
-		to="https://smashfly.com/" />
-
-		<test url="http://go.smashfly.com/?" />
 
 	<rule from="^http:"
 		to="https:" />

--- a/src/chrome/content/rules/Twenga-Solutions.com.xml
+++ b/src/chrome/content/rules/Twenga-Solutions.com.xml
@@ -1,15 +1,10 @@
 <!--
+	go.twenga-solutions.com is handled in Pardot_vanity_domains.xml.
+
 	Other Twenga Solutions rulesets:
 
 		- C4tw.net.xml
 		- Twenga.com.xml
-
-
-	Problematic hosts in *twenga-solutions.com:
-
-		- go ᴾ
-
-	ᴾ Pardot/mismatched
 
 
 	Insecure cookies are set for these hosts:
@@ -24,22 +19,6 @@
 	<target host="twenga-solutions.com" />
 	<target host="www.twenga-solutions.com" />
 
-	<!--	Complications:
-				-->
-	<target host="go.twenga-solutions.com" />
-
-		<exclusion pattern="^http://go\.twenga-solutions\.com/+(?!l/)" />
-
-			<!--	+ve:
-					-->
-			<test url="http://go.twenga-solutions.com/en/contact-us" />
-			<test url="http://go.twenga-solutions.com/ECE15" />
-
-			<!--	-ve:
-					-->
-			<test url="http://go.twenga-solutions.com/l/103922/2015-09-08/gmm/103922/2284/form_responsive.css" />
-
-
 	<!--	Not secured by server:
 					-->
 	<!--securecookie host="^www\.twenga-solutions\.com$" name="^(?:RTS_SID|SERVERID|tws-lang)$" /-->
@@ -47,9 +26,6 @@
 	<securecookie host="^\." name="^_gat?$" />
 	<securecookie host="^\w" name="." />
 
-
-	<rule from="^http://go\.twenga-solutions\.com/"
-		to="https://pi.pardot.com/" />
 
 	<rule from="^http:"
 		to="https:" />

--- a/src/chrome/content/rules/fraedom.com.xml
+++ b/src/chrome/content/rules/fraedom.com.xml
@@ -1,20 +1,10 @@
 <!--
+	www2.fraedom.com is handled in Pardot_vanity_domains.xml.
+
 	Other Fraedom rulesets:
 
 		- fraedom-cdn.com.xml
 		- spendvision.com.xml
-
-
-	Problematic hosts in *fraedom.com:
-
-		- www2 ᵐ
-
-	ᵐ Pardot / mismatched
-
-
-	Partially covered hosts in *fraedom.com:
-
-		- www2 
 
 
 	Insecure cookies are set for these hosts:
@@ -31,11 +21,6 @@
 	<target host="control.fraedom.com" />
 	<target host="www.fraedom.com" />
 
-	<!--	Complications:
-				-->
-	<target host="www2.fraedom.com" />
-
-
 	<!--	Not secured by server:
 					-->
 	<!--securecookie host="^(?:www\.)?fraedom\.com$" name="^NVOYX$" /-->
@@ -43,30 +28,6 @@
 	<securecookie host="^\." name="^_gat?$" />
 	<securecookie host="^\w" name="." />
 
-
-	<!--	Redirect drops forward slash and args:
-							-->
-	<rule from="^http://www2\.fraedom\.com/+(?:\?.*)?$"
-		to="https://www.fraedom.com/" />
-
-	<rule from="^http://www2\.fraedom\.com/"
-		to="https://pi.pardot.com/" />
-
-		<exclusion pattern="^http://www2\.fraedom\.com/+(?!$|\?|l/)" />
-
-			<!--	+ve:
-					-->
-			<test url="http://www2.fraedom.com/default.aspx" />
-			<test url="http://www2.fraedom.com/index.cgi" />
-			<test url="http://www2.fraedom.com/index.htm" />
-			<test url="http://www2.fraedom.com/index.html" />
-			<test url="http://www2.fraedom.com/index.jsp" />
-			<test url="http://www2.fraedom.com/index.php" />
-
-			<!--	-ve:
-					-->
-			<test url="http://www2.fraedom.com/?" />
-			<test url="http://www2.fraedom.com/l/97782/2015-09-17/5r76f" />
 
 	<rule from="^http:"
 		to="https:" />

--- a/src/chrome/content/rules/spongecell.com.xml
+++ b/src/chrome/content/rules/spongecell.com.xml
@@ -1,14 +1,9 @@
 <!--
+	www2.spongecell.com is handled in Pardot_vanity_domains.xml.
+
 	CDN buckets:
 
 		- spongecell-assets.s3.amazonaws.com
-
-
-	Problematic hosts in *spongecell.com:
-
-		- www2 ᵐ
-
-	ᵐ Pardot / mismatched
 
 
 	Insecure cookies are set for these domains and hosts: ᶜ
@@ -58,24 +53,6 @@
 		<!--test url="http://royale.spongecell.com/api/ad_tags/00000000/clickthrough?creative_id=&amp;noflash=&amp;iid=&amp;external_placement_id=&amp;external_site_id=&amp;anticache=&amp;click_tag=" /-->
 		<!--test url="http://royale-ssl.spongecell.com/api/ad_tags/00000000/clickthrough?creative_id=&amp;noflash=&amp;noscript=&amp;external_placement_id=&amp;external_site_id=&amp;anticache=&amp;click_tag=&amp;sig=&amp;urlfix=&amp;adurl=&amp;landingPages1=&amp;c3nid=&amp;c3creative=&amp;c3adid=&amp;c3size=&amp;utm_source=&amp;utm_medium=&amp;utm_campaign=" /-->
 
-	<!--	Complications:
-				-->
-	<target host="www2.spongecell.com" />
-
-		<exclusion pattern="^http://www2\.spongecell\.com/(?!/*(?:$|\?|[el]/))" />
-
-			<!--	See below respective rules for negative cases.
-
-				+ve:
-					-->
-			<test url="http://www2.spongecell.com/COREverview" />
-			<test url="http://www2.spongecell.com/downloads/retargeting_playbook_2015" />
-			<test url="http://www2.spongecell.com/default.aspx" />
-			<test url="http://www2.spongecell.com/index.htm" />
-			<test url="http://www2.spongecell.com/index.html" />
-			<test url="http://www2.spongecell.com/index.php" />
-
-
 	<!--	Not secured by server:
 					-->
 	<!--securecookie host="^(?:royale\.|royale-ssl\.)?spongecell\.com$" name="^XSRF-TOKEN$" /-->
@@ -83,20 +60,7 @@
 	<!--securecookie host="^\.royale(?:-ssl)?\.spongecell\.com$" name="^_spongecell_loves_u$" /-->
 
 	<securecookie host="^\." name="^spongekey$" />
-	<securecookie host="^(?!www2?\.)\w" name="." />
-
-
-	<!--	Redirect drops args and forward slash:
-							-->
-	<rule from="^http://www2\.spongecell\.com/+(?:\?.*)?$"
-		to="https://www.spongecell.com/" />
-
-		<test url="http://www2.spongecell.com/?" />
-
-	<rule from="^http://www2\.spongecell\.com/"
-		to="https://go.pardot.com/" />
-
-		<test url="http://www2.spongecell.com/l/105302/2015-11-03/33mpz" />
+	<securecookie host="^(?!www\.)\w" name="." />
 
 	<rule from="^http:"
 		to="https:" />

--- a/src/chrome/content/rules/unruly.co.xml
+++ b/src/chrome/content/rules/unruly.co.xml
@@ -1,4 +1,6 @@
 <!--
+	go.unruly.co is handled in Pardot_vanity_domains.xml.
+
 	Other Unruly Group rulesets:
 
 		- unrulymedia.com.xml
@@ -6,7 +8,6 @@
 
 	Problematic hosts in *unruly.co:
 
-		- go ᵐ
 		- tech ᵐ
 
 	ᵐ Mismatched
@@ -36,45 +37,11 @@
 	<target host="partnerportal.unruly.co" />
 	<target host="www.unruly.co" />
 
-	<!--	Complications:
-				-->
-	<target host="go.unruly.co" />
-
-		<exclusion pattern="^http://go\.unruly\.co/(?!/*(?:$|\?|[el]/))" />
-
-			<test url="http://go.unruly.co/2016-trends" />
-			<test url="http://go.unruly.co/FacebookVVC" />
-			<test url="http://go.unruly.co/TwitterVideoChart" />
-			<test url="http://go.unruly.co/fovadownload" />
-			<test url="http://go.unruly.co/nc-blog-social" />
-			<test url="http://go.unruly.co/nc-social" />
-			<test url="http://go.unruly.co/pp-about-unrulyx" />
-			<test url="http://go.unruly.co/pp-contact" />
-			<test url="http://go.unruly.co/vertical" />
-			<test url="http://go.unruly.co/webhero10" />
-
-
 	<!--	Not secured by server:
 					-->
 	<!--securecookie host="(?:partnerportal\.|www\.)?unruly\.co$" name="^(?:X-Mapping-|wordpress_google_apps_login)$" /-->
 
-	<securecookie host="^\." name="_ga(?:t?$|t_)" />
-	<securecookie host="^(?!go\.)\w" name="." />
-
-
-	<rule from="^http://go\.unruly\.co/+(?:\?.*)?$"
-		to="https://unruly.co/" />
-
-		<test url="http://go.unruly.co/?" />
-
-	<rule from="^http://go\.unruly\.co/"
-		to="https://go.pardot.com/" />
-
-		<test url="http://go.unruly.co/l/50182/2014-11-11/rtxy" />
-		<test url="http://go.unruly.co/l/50182/2015-08-17/3wmwmr/50182/63492/submit_button.png" />
-		<test url="http://go.unruly.co/l/50182/2015-12-09/57f3t2/50182/82583/SB_template_v1.png" />
-		<test url="http://go.unruly.co/l/50182/2015-12-09/57r24x" />
-		<test url="http://go.unruly.co/l/50182/2016-04-28/66l55p" />
+	<securecookie host=".+" name=".+" />
 
 	<rule from="^http:"
 		to="https:" />


### PR DESCRIPTION
- not all paths on the go.linuxfoundation.org vanity domain work on go.pardot.com
- eventsstg.linuxfoundation.org is a private site behind HTTP auth and is not testable
- LDN has been gone for several years
- events.linuxfoundation.org now only redirects to HTTP for / and /events/*
- collabprojects supports SSL (though is just a redirect to www.linuxfoundation.org now)
- www.linuxfoundation.org is HTTPS only with HSTS; no more mixed-SSL and http:// redirects
- developerbugs.linuxfoundation.org now provides "secure" flag in cookie
