### PR TITLE
Exception for streamfarm.net-rules on erf.de

### DIFF
--- a/src/chrome/content/rules/Streamfarm.net.xml
+++ b/src/chrome/content/rules/Streamfarm.net.xml
@@ -6,6 +6,11 @@
 -->
 
   <exclusion pattern="^http://c22033\-ls\.i\.core\.cdn\.streamfarm\.net/" />
+
+<!-- 
+	breaks erf.de
+-->
+  <exclusion pattern="^http(s)?://(www\.)?erf\.de" />
   
   <test url="http://c1000305-o.p.core.cdn.streamfarm.net/" />
   <test url="http://c13009-l.l.core.cdn.streamfarm.net/" />


### PR DESCRIPTION
Without this exception videos cannot be playend on erf.de (see example links in commit message)
