### PR TITLE
Add hosts-file.net

### DIFF
--- a/src/chrome/content/rules/hosts-file.net.xml
+++ b/src/chrome/content/rules/hosts-file.net.xml
@@ -1,6 +1,7 @@
 <ruleset name="hpHosts">
         <target host="hosts-file.net" />
         <target host="www.hosts-file.net" />
+        <target host="forum.hosts-file.net" />
 
         <rule from="^http:"
                 to="https:" />

--- a/src/chrome/content/rules/hosts-file.net.xml
+++ b/src/chrome/content/rules/hosts-file.net.xml
@@ -1,0 +1,7 @@
+<ruleset name="hpHosts">
+        <target host="hosts-file.net" />
+        <target host="www.hosts-file.net" />
+
+        <rule from="^http:"
+                to="https:" />
+</ruleset>


### PR DESCRIPTION
Recently hpHosts announced they started supporting HTTPS.  However, automatic redirect of the main domain (with and without www) got disabled due to issues with certain third-party applications.
Since redirecting on interactive web browsers should be safe, I am proposing the addition of hosts-file.net and www.hosts-file.net to HTTPS Everywhere.