### PR TITLE
[OPM.gov.xml] remove a redundant rule

### DIFF
--- a/src/chrome/content/rules/OPM.gov.xml
+++ b/src/chrome/content/rules/OPM.gov.xml
@@ -113,10 +113,10 @@
 	<target host="www.servicesonline.opm.gov" />
 	<target host=        "timesheets.opm.gov" />
 	<target host=               "www.opm.gov" />
+	<target host=    "www.leadership.opm.gov" />
 
 	<!--	Complications:
 				-->
-	<target host=    "www.leadership.opm.gov" />
 	<target host=    "servicesonline.opm.gov" />
 
 
@@ -126,10 +126,6 @@
 	<!-- could not resolve host -->
 	<rule from="^http://servicesonline\.opm\.gov/"
 		to="https://www.servicesonline.opm.gov/" />
-
-	<!-- hostname mismatch -->
-	<rule from="^http://www\.leadership\.opm\.gov/"
-		to="https://leadership.opm.gov/" />
 
 	<rule from="^http:"
 		to="https:" />


### PR DESCRIPTION
https://www.leadership.opm.gov/ no longer uses mismatched certificate, and it can successfully redirect to https://leadership.opm.gov/ by the server.

[1] https://www.ssllabs.com/ssltest/analyze.html?d=www.leadership.opm.gov&hideResults=on