### PR TITLE
Make trivial rule for particle.io

### DIFF
--- a/src/chrome/content/rules/Particle.io.xml
+++ b/src/chrome/content/rules/Particle.io.xml
@@ -1,0 +1,11 @@
+<ruleset name="Particle.io">
+	<target host="particle.io" />
+	<target host="www.particle.io" />
+
+	<target host="build.particle.io" />
+	<target host="community.particle.io" />
+	<target host="docs.particle.io" />
+	<target host="store.particle.io" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/Particle.io.xml
+++ b/src/chrome/content/rules/Particle.io.xml
@@ -1,3 +1,11 @@
+<!--
+
+	Problematic domains:
+
+		- blog.particle.io	(mismatched)
+		- status.particle.io	(mismatched)
+
+-->
 <ruleset name="Particle.io">
 	<target host="particle.io" />
 	<target host="www.particle.io" />
@@ -5,6 +13,7 @@
 	<target host="build.particle.io" />
 	<target host="community.particle.io" />
 	<target host="docs.particle.io" />
+	<target host="projects.particle.io" />
 	<target host="store.particle.io" />
 
 	<rule from="^http:" to="https:" />


### PR DESCRIPTION
Particle uses quite a few subdomains and most appear to support HTTPS.
`community` in particular, needs a redirect rule as it does not
redirect to HTTPS automatically.