### PR TITLE
[prntscr.com] Disable ruleset

### DIFF
--- a/src/chrome/content/rules/prntscr.com.xml
+++ b/src/chrome/content/rules/prntscr.com.xml
@@ -1,10 +1,12 @@
-<ruleset name="prntscr.com">
+<!--
+	Problematic domains:
 
-	<!--	Direct rewrites:
-				-->
-	<target host="prntscr.com" />
+		- prntscr.com redirects to HTTP
+		- prnt.sc works itself but requires active content from prntscr.com
+-->
+<ruleset name="prntscr.com (broken)" default_off="Mixed content">
+
 	<target host="prnt.sc" />
-
 
 	<rule from="^http:"
 		to="https:" />


### PR DESCRIPTION
`prntsrc.com` redirects all requests to HTTP, causing redirect loops. `prnt.sc` on the other hand, requires active mixed content from `prntsrc.com`. This closes https://github.com/EFForg/https-everywhere/issues/6074.