### PR TITLE
Added rule for academicintegrity.ucsd.edu in UCSD.edu.xml

### DIFF
--- a/src/chrome/content/rules/UCSD.edu.xml
+++ b/src/chrome/content/rules/UCSD.edu.xml
@@ -389,6 +389,7 @@ Fetch error: http://www.mytritonlink.ucsd.edu/ => https://act.ucsd.edu/myTritonl
    <target host="www-cse.ucsd.edu" />
    <target host="www-ne.ucsd.edu" />
    <target host="www-structures.ucsd.edu" />
+   <target host="academicintegrity.ucsd.edu" />
 <!-- only some features known to support https; protect them against sslstripping (not Firesheep) -->
    <target host="act.ucsd.edu" />
    <target host="health.ucsd.edu" />
@@ -530,6 +531,8 @@ Fetch error: http://www.mytritonlink.ucsd.edu/ => https://act.ucsd.edu/myTritonl
        to="https://www-ne.ucsd.edu/" />
    <rule from="^http://www-structures\.ucsd\.edu/"
        to="https://www-structures.ucsd.edu/" />
+   <rule from="^http://academicintegrity\.ucsd\.edu/"
+       to="https://academicintegrity.ucsd.edu/" />
 
    <rule from="^http://health\.ucsd\.edu/(_layouts/|page_ad/|request_appt|Style\ Library/|WebResource\.axd)"
            to="https://health.ucsd.edu/$1" />


### PR DESCRIPTION
Added rule for academicintegrity.ucsd.edu as it works fine with both [HTTP](http://academicintegrity.ucsd.edu) and [HTTPS](https://academicintegrity.ucsd.edu).
