### PR TITLE
[24 ways] Add hosts; no longer partial; update rewrites

### DIFF
--- a/src/chrome/content/rules/24-ways.xml
+++ b/src/chrome/content/rules/24-ways.xml
@@ -1,24 +1,9 @@
-<!--
-	CDN buckets:
+<ruleset name="24 ways">
+	<target host="24ways.org" />
+	<target host="cloud.24ways.org" />
+	<target host="media.24ways.org" />
+	<target host="www.24ways.org" />
 
-		- d3dtvigi7xxd4v.cloudfront.net
-
-			- cloud
-
-		- media.24ways.org.s3.amazonaws.com
-
-			- media
-
--->
-<ruleset name="24 ways (partial)">
-
-	<target host="*.24ways.org" />
-
-
-	<rule from="^http://cloud\.24ways\.org/"
-		to="https://d3dtvigi7xxd4v.cloudfront.net/" />
-
-	<rule from="^http://media\.24ways\.org/"
-		to="https://s3.amazonaws.com/media.24ways.org/" />
-
+	<rule from="^http:"
+		to="https:" />
 </ruleset>


### PR DESCRIPTION
Add `24ways.org` and `www.24ways.org`. No longer partial.

Rewrite `cloud.24ways.org` and `media.24ways.org` to themselves instead of their former AWS buckets.