### PR TITLE
Updated link

### DIFF
--- a/src/chrome/content/rules/Demonsaw.com.xml
+++ b/src/chrome/content/rules/Demonsaw.com.xml
@@ -36,7 +36,7 @@
 <ruleset name="demonsaw.com (partial)">
 
 	<target host="demonsaw.com" />
-	<target host="wiki.demonsaw.com" />
+	<target host="docs.demonsaw.com" />
 	<target host="www.demonsaw.com" />
 
 


### PR DESCRIPTION
Updated wiki.demonsaw.com (obsolete) to docs.demonsaw.com (current).