### PR TITLE
Add Megabus.com.xml

### DIFF
--- a/src/chrome/content/rules/Megabus.com.xml
+++ b/src/chrome/content/rules/Megabus.com.xml
@@ -1,0 +1,19 @@
+<ruleset name="Megabus">
+	<target host="ca.megabus.com" />
+	<target host="caeu.megabus.com" />
+	<target host="deeu.megabus.com" />
+	<target host="eseu.megabus.com" />
+	<target host="esus.megabus.com" />
+	<target host="frca.megabus.com" />
+	<target host="freu.megabus.com" />
+	<target host="iteu.megabus.com" />
+	<target host="megabus.com" />
+	<target host="megabusgold.com" />
+	<target host="nleu.megabus.com" />
+	<target host="uk.megabus.com" />
+	<target host="us.megabus.com" />
+	<target host="www.megabus.com" />
+	<target host="www.megabusgold.com" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/Megabus.com.xml
+++ b/src/chrome/content/rules/Megabus.com.xml
@@ -1,4 +1,10 @@
+<!--
+	Nonfunctional domains:
+		festivals.megabus.com (wrong domain for certificate)
+-->
 <ruleset name="Megabus">
+	<target host="megabus.com" />
+	<target host="www.megabus.com" />
 	<target host="ca.megabus.com" />
 	<target host="caeu.megabus.com" />
 	<target host="deeu.megabus.com" />
@@ -7,12 +13,11 @@
 	<target host="frca.megabus.com" />
 	<target host="freu.megabus.com" />
 	<target host="iteu.megabus.com" />
-	<target host="megabus.com" />
-	<target host="megabusgold.com" />
 	<target host="nleu.megabus.com" />
 	<target host="uk.megabus.com" />
 	<target host="us.megabus.com" />
-	<target host="www.megabus.com" />
+
+	<target host="megabusgold.com" />
 	<target host="www.megabusgold.com" />
 
 	<rule from="^http:" to="https:" />


### PR DESCRIPTION
The megabusgold.com sites fail fetch-test.sh, probably because of a missing CA certificate in the development environment. I've reported that in issue #6275. This should be okay to go live though.