### PR TITLE
PCWelt

### DIFF
--- a/src/chrome/content/rules/Pcwelt.de.xml
+++ b/src/chrome/content/rules/Pcwelt.de.xml
@@ -1,5 +1,59 @@
-<ruleset name="Pcwelt.de" platform="mixedcontent">
-<target host="*.pcwelt.de"/>
-<!--cert is not valid for download.pcwelt.de , matches llnw.net -->
-<rule from="^http://(mobil|www)\.pcwelt\.de/" to="https://$1.pcwelt.de/"/>
+<!--
+	403:
+		- custom.pcwelt.de
+
+	Cert mismatch:
+		- apps.pcwelt.de
+		- (www.)browsercheck.pcwelt.de
+		- download.pcwelt.de
+		- forum.pcwelt.de
+		- go.pcwelt.de
+		- (www.)gutscheine.pcwelt.de
+		- images.pcwelt.de
+		- insider-portal.pcwelt.de
+		- beta.insider-portal.pcwelt.de
+		- jobs.pcwelt.de
+		- (www.)leseraktion.pcwelt.de
+		- liwww.pcwelt.de
+		- m.pcwelt.de
+		- markt.pcwelt.de
+		- newsletter.pcwelt.de
+		- p.pcwelt.de
+		- premium.pcwelt.de
+		- r1.pcwelt.de
+		- r2.pcwelt.de
+		- www.shirtshop.pcwelt.de
+		- (www.)software.pcwelt.de
+		- start-dsl.pcwelt.de
+		- tarife.pcwelt.de
+		- wallpaper.pcwelt.de
+		- wiki.pcwelt.de
+		- ww.pcwelt.de
+		- w3.pcwelt.de
+
+	Connection refused:
+		- videos.pcwelt.de
+-->
+
+<ruleset name="Pcwelt.de" >
+
+	<target host="pcwelt.de" />
+	<target host="www.pcwelt.de" />
+	<target host="amp.pcwelt.de" />
+	<target host="api.pcwelt.de" />
+	<target host="beta.pcwelt.de" />
+	<target host="bilder.pcwelt.de" />
+	<target host="fbia.pcwelt.de" />
+	<target host="fia.pcwelt.de" />
+	<target host="magazin.pcwelt.de" />
+	<target host="mobil.pcwelt.de" />
+	<target host="shirtshop.pcwelt.de" />
+	<target host="shop.pcwelt.de" />
+	<target host="specials.pcwelt.de" />
+	<target host="whitepaper.pcwelt.de" />
+
+
+	<rule from="^http:"
+		to="https:" />
+
 </ruleset>


### PR DESCRIPTION
- disable PCWelt rule for mobile & www subdomains, which redirect to plain
- add bilder subdomain
