### PR TITLE
Added Kvasir.no

### DIFF
--- a/src/chrome/content/rules/Kvasir.no.xml
+++ b/src/chrome/content/rules/Kvasir.no.xml
@@ -1,0 +1,6 @@
+<ruleset name="Kvasir.no">
+	<target host="kvasir.no" />
+	<target host="www.kvasir.no" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>


### PR DESCRIPTION
New rule for [Kvasir.no](https://kvasir.no/), a Norwegian search engine (Google front-end). Currently the 250th most visited website in Norway, [according to Alexa](https://www.alexa.com/topsites/countries/NO).

Everything works over HTTPS except for this their map service – kart.kvasir.no – which is not included in this patch as that subdomain isn’t available over HTTPS.