### PR TITLE
Update some Fedora rules

### DIFF
--- a/src/chrome/content/rules/Fedora.xml
+++ b/src/chrome/content/rules/Fedora.xml
@@ -6,20 +6,16 @@
 
 		- Fedora_Hosted.org.xml
 		- Fedora_People.org.xml
+		- Fedorainfracloud.org.xml
 
 
 	Nonfunctional hosts in *fedoraproject.org:
 
-		- infrastructure ²
-		- kojipkgs ²
-		- ols ³
+		- ols ²
 		- pki ¹
-		- planet ³
-		- publictest04 ³
-		- torrent ³
+		- planet ²
 
-	² Dropped
-	³ Refused
+	² Refused
 	¹ Shows another domain
 
 
@@ -60,11 +56,15 @@
 	<target host="badges.fedoraproject.org" />
 	<target host="bodhi.fedoraproject.org" />
 	<target host="boot.fedoraproject.org" />
+	<target host="copr.fedoraproject.org" />
+	<target host="copr-be.cloud.fedoraproject.org" />
 	<target host="dl.fedoraproject.org" />
 	<target host="docs.fedoraproject.org" />
 	<target host="download.fedoraproject.org" />
 	<target host="get.fedoraproject.org" />
+	<target host="infrastructure.fedoraproject.org" />
 	<target host="join.fedoraproject.org" />
+	<target host="kojipkgs.fedoraproject.org" />
 	<target host="lists.fedoraproject.org" />
 	<target host="meetbot.fedoraproject.org" />
 	<target host="mirrors.fedoraproject.org" />
@@ -73,6 +73,7 @@
 	<target host="retrace.fedoraproject.org" />
 	<target host="spins.fedoraproject.org" />
 	<target host="start.fedoraproject.org" />
+	<target host="torrent.fedoraproject.org" />
 	<target host="lists.stg.fedoraproject.org" />
 	<target host="www.fedoraproject.org" />
 

--- a/src/chrome/content/rules/Fedorainfracloud.org.xml
+++ b/src/chrome/content/rules/Fedorainfracloud.org.xml
@@ -1,0 +1,17 @@
+<!--
+        Note that the Fedora Infrastructure Cloud is used for various
+        community-lead projects which are not directly supported by Fedora
+        Infrastructure. Therefore, we cannot wildcard here, and must explicitly
+        list those fedorainfracloud.org subdomains which have a valid SSL
+        certificate.
+-->
+<ruleset name="Fedora Infrastructure Cloud (partial)">
+	<target host="copr.fedorainfracloud.org" />
+	<!--<target host="grafana.fedorainfracloud.org" />-->
+	<target host="graphite.fedorainfracloud.org" />
+	<target host="piwik.fedorainfracloud.org" />
+	<target host="taiga.fedorainfracloud.org" />
+
+	<rule from="^http:"
+		to="https:" />
+</ruleset>


### PR DESCRIPTION
Some formerly http-only subdomains are now SSL-accessible. Also, add
some fedorainfracloud.org projects.

Signed-off-by: Ricky Elrod ricky@elrod.me
