### PR TITLE
[UrlQuery] Disable ruleset

### DIFF
--- a/src/chrome/content/rules/UrlQuery.xml
+++ b/src/chrome/content/rules/UrlQuery.xml
@@ -1,4 +1,4 @@
-<ruleset name="urlQuery">
+<ruleset name="urlQuery" default_off="SSL error">
 	<target host="urlquery.net" />
 	<target host="www.urlquery.net" />
 


### PR DESCRIPTION
This fixes https://github.com/EFForg/https-everywhere/issues/6560