### PR TITLE
[Mozilla] Add exclusion for subdomain symbolapi

### DIFF
--- a/src/chrome/content/rules/Mozilla.xml
+++ b/src/chrome/content/rules/Mozilla.xml
@@ -231,7 +231,7 @@
 
 				https://mail1.eff.org/pipermail/https-everywhere-rules/2013-June/001635.html
 													-->
-		<exclusion pattern="^http://(?:europe|bonsai|browserquest|trychooser\.pub\.build|(?!image)\w+\.e|graphs|krakenbenchmark|mig|sfx-images|alerts\.telemetry|w(?:ebsite|ww)-archive)\.mozilla\.org/" />
+		<exclusion pattern="^http://(?:europe|bonsai|browserquest|trychooser\.pub\.build|(?!image)\w+\.e|graphs|krakenbenchmark|mig|sfx-images|symbolapi|alerts\.telemetry|w(?:ebsite|ww)-archive)\.mozilla\.org/" />
 
 			<test url="http://bonsai.mozilla.org/" />
 			<test url="http://browserquest.mozilla.org/" />
@@ -241,6 +241,7 @@
 			<test url="http://krakenbenchmark.mozilla.org/" />
 			<test url="http://mig.mozilla.org/" />			
 			<test url="http://sfx-images.mozilla.org/" />
+			<test url="http://symbolapi.mozilla.org/" />
 			<test url="http://alerts.telemetry.mozilla.org/" />
 			<test url="http://website-archive.mozilla.org/" />
 			<test url="http://www-archive.mozilla.org/" />
@@ -293,6 +294,7 @@
 
 		<test url="http://affiliates-cdn.mozilla.org/" />
 
+	<!--	Would this rule be safe?
 	<!--	Would this rule be safe?
 
 	<rule from="^http://click\.e\.mozilla\.org/"

--- a/src/chrome/content/rules/Mozilla.xml
+++ b/src/chrome/content/rules/Mozilla.xml
@@ -295,7 +295,6 @@
 		<test url="http://affiliates-cdn.mozilla.org/" />
 
 	<!--	Would this rule be safe?
-	<!--	Would this rule be safe?
 
 	<rule from="^http://click\.e\.mozilla\.org/"
 		to="https://click.virt.s4.exacttarget.com/" /-->


### PR DESCRIPTION
This fixes https://github.com/EFForg/https-everywhere/issues/6613.