### PR TITLE
[Flexyourrights.org] New ruleset

### DIFF
--- a/src/chrome/content/rules/Flexyourrights.org.xml
+++ b/src/chrome/content/rules/Flexyourrights.org.xml
@@ -1,0 +1,6 @@
+<ruleset name="Flexyourrights.org">
+	<target host="flexyourrights.org" />
+	<target host="www.flexyourrights.org" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>


### PR DESCRIPTION
This ruleset is trivial; the site itself 301 redirects to HTTPS on connections to the included targets.

This closes https://trac.torproject.org/projects/tor/ticket/17614.