### PR TITLE
Fix BusinessInsider.xml video

### DIFF
--- a/src/chrome/content/rules/BusinessInsider.xml
+++ b/src/chrome/content/rules/BusinessInsider.xml
@@ -48,6 +48,13 @@
 	<target host="static7.businessinsider.com" />
 	<target host="static8.businessinsider.com" />
 
+	<!--	Fix broken video, see:
+			https://github.com/EFForg/https-everywhere/issues/5014 -->
+		<exclusion pattern="^http://static(\d|-ssl)?.businessinsider.com/assets/js/app/partners/ooyala/skin.json$" />
+		<test url="http://static.businessinsider.com/assets/js/app/partners/ooyala/skin.json" />
+		<test url="http://static1.businessinsider.com/assets/js/app/partners/ooyala/skin.json" />
+		<test url="http://static-ssl.businessinsider.com/assets/js/app/partners/ooyala/skin.json" />
+
 	<target host="static1.uk.businessinsider.com" />
 	<target host="static2.uk.businessinsider.com" />
 	<target host="static3.uk.businessinsider.com" />

--- a/src/chrome/content/rules/BusinessInsider.xml
+++ b/src/chrome/content/rules/BusinessInsider.xml
@@ -66,7 +66,7 @@
 		<!--
 			Exceptions:
 					-->
-	        <exclusion pattern="^http://www\.businessinsider\.com/(?!account|assets/|favicon\.ico|login|register)" />
+	        <exclusion pattern="^http://www\.businessinsider\.com/(?!assets/|favicon\.ico|login)" />
 
 			<!--	+ve:
 					-->
@@ -79,11 +79,8 @@
 
 			<!--	-ve:
 					-->
-			<test url="http://www.businessinsider.com/account" />
 			<test url="http://www.businessinsider.com/favicon.ico" />
 			<test url="http://www.businessinsider.com/login" />
-			<test url="http://www.businessinsider.com/register" />
-
 
 
 	<!--	Not secured by server:

--- a/src/chrome/content/rules/BusinessInsider.xml
+++ b/src/chrome/content/rules/BusinessInsider.xml
@@ -35,9 +35,7 @@
 	<!--	Direct rewrites:
 				-->
 	<target host="businessinsider.com" />
-	<target host="insider.businessinsider.com" />
 	<target host="intelligence.businessinsider.com" />
-	<target host="oascentral.businessinsider.com" />
 	<target host="static.businessinsider.com" />
 	<target host="static-bii.businessinsider.com" />
 	<target host="static-ssl.businessinsider.com" />
@@ -61,8 +59,6 @@
 
 	<!--	Complications:
 				-->
-	<target host="jobs.businessinsider.com" />
-
 		<!--	Many pages redirect to http.
 							-->
 		<!--exclusion pattern="^http://uk\.businessinsider\.com/[\w-]+($|\?)" /-->
@@ -88,16 +84,6 @@
 			<test url="http://www.businessinsider.com/login" />
 			<test url="http://www.businessinsider.com/register" />
 
-		<exclusion pattern="^http://jobs\.businessinsider\.com/(?!c/)" />
-
-			<!--	+ve:
-					-->
-			<test url="http://jobs.businessinsider.com/a/all-jobs/list/q-first+citizens+bank" />
-			<test url="http://jobs.businessinsider.com/a/all-jobs/list/q-intuit" />
-
-			<!--	-ve:
-					-->
-			<test url="http://jobs.businessinsider.com/c/" />
 
 
 	<!--	Not secured by server:
@@ -105,17 +91,12 @@
 	<!--securecookie host="^\.businessinsider\.com$" name="^s$" /-->
 	<!--securecookie host="^intelligence\.businessinsider\.com$" name="^PHPSESSID$" /-->
 
-	<!--	Tracking cookie set by oascentral:
-							-->
 	<securecookie host="^\.businessinsider\.com$" name="^OAX$" />
-	<securecookie host="^(?:intelligence|oascentral)\.businessinsider\.com$" name=".+" />
+	<securecookie host="^intelligence\.businessinsider\.com$" name=".+" />
 
 
         <!--    See Simply-Hired-clients.xml for problematic jobs rules.
 									-->
-        <rule from="^http://jobs\.businessinsider\.com/"
-                to="https://businessinsider.jobamatic.com/" />
-
         <rule from="^http:"
 		to="https:" />
 


### PR DESCRIPTION
This should fix issue #5014 regarding broken video on businessinsider.com (example [here](http://www.businessinsider.com/how-plucking-nose-hairs-can-cause-lethal-infections-2016-6)). Commits 9ea45fbf452bbc49e6f97810e2b2631c9f353ff0 and 1e0802e635d9038d51320bd5b63d8b5725a0c48f fix these errors I get with `fetch-test.sh`:

```
ERROR rules/BusinessInsider.xml: Fetch error: http://www.businessinsider.com/account => https://www.businessinsider.com/account: Too many redirects while fetching 'https://www.businessinsider.com/account'
ERROR rules/BusinessInsider.xml: Fetch error: http://www.businessinsider.com/register => https://www.businessinsider.com/register: Too many redirects while fetching 'https://www.businessinsider.com/register'
ERROR rules/BusinessInsider.xml: Fetch error: http://jobs.businessinsider.com/c/ => https://businessinsider.jobamatic.com/c/: (7, 'Failed to connect to businessinsider.jobamatic.com port 443: Connection refused')
ERROR rules/BusinessInsider.xml: Fetch error: http://insider.businessinsider.com/ => https://insider.businessinsider.com/: (6, 'Could not resolve host: insider.businessinsider.com')
ERROR rules/BusinessInsider.xml: Fetch error: http://oascentral.businessinsider.com/ => https://oascentral.businessinsider.com/: (6, 'Could not resolve host: oascentral.businessinsider.com')
```