### PR TITLE
Add skiplist to http.checker.config

### DIFF
--- a/test/rules/http.checker.config
+++ b/test/rules/http.checker.config
@@ -8,6 +8,7 @@ check_nonmatch_groups = false
 check_test_formatting = false
 auto_disable = false
 include_default_off = false
+skiplist = utils/ruleset-coverage-whitelist.txt
 
 [certificates]
 # Certificate trust anchors for checking chains in HTTPS connections


### PR DESCRIPTION
The purpose of this commit is to avoid having Travis hit whitelisted rulesets in `test/fetch.sh` which caused some unexpected behaviour in #6684 (and possibly other places?)

I suppose one should really ask oneself why the skiplist is not already in there, and what the expected behaviour actually should be, but when I [put in the config](https://github.com/jsha/https-everywhere-checker/pull/4/commits/05d7c201f857a1fdfcd50ce85f626fbbd9f7b0df) last year, I think I just omitted it by mistake. At least, I can't really come with any reason for doing it on purpose.

For testing, I added the contents of this PR to #6684 after which all tests were green.