### PR TITLE
Expand popup window (fixes #6078)

### DIFF
--- a/src/chrome/content/observatory-popup.xul
+++ b/src/chrome/content/observatory-popup.xul
@@ -5,8 +5,8 @@
   xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul" 
   xmlns:html="http://www.w3.org/1999/xhtml" 
   title="&ssl-observatory.popup.title;" 
-  width="500" 
-  height="440" 
+  width="600"
+  height="520"
   align="center"
   onload="document.getElementById('ask-me-later').focus()"
   >


### PR DESCRIPTION
Fixes #6078
@fuglede how does this look?

In order to test, apply the following patch:

```patch
diff --git a/test/firefox/test_profile_skeleton/prefs.js b/test/firefox/test_profile_skeleton/prefs.js
index 42b3f0a..7ff28e9 100644
--- a/test/firefox/test_profile_skeleton/prefs.js
+++ b/test/firefox/test_profile_skeleton/prefs.js
@@ -1,7 +1,7 @@
 // Submit SSL Observatory reports.
-user_pref("extensions.https_everywhere._observatory.enabled", true);
+//user_pref("extensions.https_everywhere._observatory.enabled", true);
 // Don't show any popups that might get in the way of testing.
-user_pref("extensions.https_everywhere._observatory.popup_shown", true);
+//user_pref("extensions.https_everywhere._observatory.popup_shown", true);
 user_pref("extensions.https_everywhere.toolbar_hint_shown", true);
 // Show all logs.
 user_pref("extensions.https_everywhere.LogLevel", 0);
```