### PR TITLE
Add exclusion to Github-Pages.xml (issue #2507)

### DIFF
--- a/src/chrome/content/rules/Github-Pages.xml
+++ b/src/chrome/content/rules/Github-Pages.xml
@@ -8,12 +8,16 @@
 
 	<!-- pages that require http -->
 	<exclusion pattern="^http://duckietv\.github\.io/DuckieTV/?" />
+	<!-- See https://github.com/EFForg/https-everywhere/issues/2507 -->
+	<exclusion pattern="^http://googletrends\.github\.io/(GOPDebate1|iframe-scaffolder)/" />
 	<exclusion pattern="^http://ibotpeaches\.github\.io/Apktool/?" />
 	<exclusion pattern="^http://schizoduckie\.github\.io/DuckieTorrent/?" />
 	<exclusion pattern="^http://schizoduckie\.github\.io/PimpMyuTorrent/?" />
 
 	<test url="http://duckietv.github.io/DuckieTV" />
 	<test url="http://duckietv.github.io/DuckieTV/" />
+	<test url="http://googletrends.github.io/GOPDebate1/" />
+	<test url="http://googletrends.github.io/iframe-scaffolder/" />
 	<test url="http://ibotpeaches.github.io/Apktool" />
 	<test url="http://ibotpeaches.github.io/Apktool/" />
 	<test url="http://schizoduckie.github.io/DuckieTorrent" />


### PR DESCRIPTION
This should fix issue #2507.

I'm also open to a general exclusion on `googletrends.github.io` if whoever reviews this prefers that approach instead.