### PR TITLE
Added Swedish Tax Agency [skatteverket.se]

### DIFF
--- a/src/chrome/content/rules/Skatteverket.se.xml
+++ b/src/chrome/content/rules/Skatteverket.se.xml
@@ -1,0 +1,10 @@
+<ruleset name="Skatteverket">
+	<target host="skatteverket.se" />
+	<target host="www.skatteverket.se" />
+	<target host="www4.skatteverket.se" />
+	<target host="sso.skatteverket.se" />
+
+	<!-- root domain does not support https, redirect -->
+	<rule from="^http://skatteverket\.se/" to="https://www.skatteverket.se/"/>
+	<rule from="^http:" to="https:" />
+</ruleset>


### PR DESCRIPTION
The Swedish National Tax Agency website is one of the only two ways to do tax-deceleration (the other way is by post). This website has a national rank of 87 and I find it very surprising that it has not yet been included given the sites nature.