### PR TITLE
[Modernpgp] Disable ruleset

### DIFF
--- a/src/chrome/content/rules/Modernpgp.org.xml
+++ b/src/chrome/content/rules/Modernpgp.org.xml
@@ -1,7 +1,4 @@
-<!--
-Cloudflare SSL
--->
-<ruleset name="Modernpgp.org">
+<ruleset name="Modernpgp.org" default_off="Mismatch">
     <target host="modernpgp.org" />
     <target host="www.modernpgp.org" />
 


### PR DESCRIPTION
Both included target hosts serve bad certificates. This closes https://trac.torproject.org/projects/tor/ticket/20126.