### PR TITLE
krautchan.net has a CA signed certificate now. No need to disable it

### DIFF
--- a/src/chrome/content/rules/Krautchan.xml
+++ b/src/chrome/content/rules/Krautchan.xml
@@ -1,4 +1,4 @@
-<ruleset name="Krautchan" default_off="self-signed">
+<ruleset name="Krautchan">
 
 	<target host="krautchan.net"/>
 	<target host="www.krautchan.net"/>


### PR DESCRIPTION
As in the title, the site now uses a "proper" certificate so the rule can be enabled
