### PR TITLE
BME.hu: redirect vik.wiki alias to wiki.sch.bme.hu

### DIFF
--- a/src/chrome/content/rules/BME.hu.xml
+++ b/src/chrome/content/rules/BME.hu.xml
@@ -81,8 +81,10 @@
 	<!-- Wigner Jeno szakkolegium -->
 	<target host="wjsz.bme.hu" />
 	<!-- Simonyi Karoly szakkolegium -->
+	<!-- expired
 	<target host="simonyi.bme.hu" />
 	<target host="www.simonyi.bme.hu" />
+	-->
 	<!-- Automatizalasi tanszek -->
 	<target host="aut.bme.hu" />
 	<target host="www.aut.bme.hu" />

--- a/src/chrome/content/rules/BME.hu.xml
+++ b/src/chrome/content/rules/BME.hu.xml
@@ -52,6 +52,7 @@
 	<target host="lists.sch.bme.hu" />
 	<target host="kepzes.sch.bme.hu" />
 	<target host="printer.sch.bme.hu" />
+	<target host="vik.wiki" />
 	<target host="wiki.sch.bme.hu" />
 	<target host="home.sch.bme.hu" />
 	<!-- <target host="spot.sch.bme.hu" /> -->
@@ -129,6 +130,10 @@
 	<!-- Hop directly to https NEPTUN -->
 	<rule from="^http://(www\.)?neptun\.bme\.hu/"
 	      to="https://www.kth.bme.hu/neptun/"/>
+
+	<!-- Redirect vik.wiki alias to wiki.sch.bme.hu which has a cert -->
+	<rule from="^http://vik\.wiki/"
+		  to="https://wiki.sch.bme.hu/" />
 
 	<rule from="^http:"
 	      to="https:" />


### PR DESCRIPTION
vik.wiki is an alias for wiki.sch.bme.hu, which has an SSL certificate.

This change redirects all vik.wiki requests to wiki.sch.bme.hu (vik.wiki itself doesn't support HTTPS due to cert mismatch)