### PR TITLE
[444.hu] Create mixedcontent ruleset

### DIFF
--- a/src/chrome/content/rules/444.hu.xml
+++ b/src/chrome/content/rules/444.hu.xml
@@ -1,6 +1,8 @@
 <!--
 	Nonfunctional domains:
 	- 4cdn.hu (image assets)
+	- img.444.hu (refused)
+	- q.444.hu (expired)
 	- cimlap.444.hu (expired)
 
 	Articles try to load social media sharing stats from cimlap.444.hu
@@ -8,7 +10,10 @@
 -->
 <ruleset name="444.hu (mixedcontent)" platform="mixedcontent">
 	<target host="444.hu" />
+	<target host="barkacs.444.hu" />
 	<target host="daazo.444.hu" />
+	<target host="ddd.444.hu" />
+	<target host="eszakinyitas.444.hu" />
 	<target host="ezerkolibri.444.hu" />
 	<target host="feminfo.444.hu" />
 	<target host="fortepan.444.hu" />
@@ -23,10 +28,11 @@
 	<target host="pulispace.444.hu" />
 	<target host="sciencemeetup.444.hu" />
 	<target host="tldr.444.hu" />
+	<target host="velemenyvezer.444.hu" />
 	<target host="verde.444.hu" />
 	<target host="vifon.444.hu" />
 	<target host="yolovilag.444.hu" />
 
 	<rule from="^http:"
-		  to="https://" />
+		  to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/444.hu.xml
+++ b/src/chrome/content/rules/444.hu.xml
@@ -1,0 +1,32 @@
+<!--
+	Nonfunctional domains:
+	- 4cdn.hu (image assets)
+	- cimlap.444.hu (expired)
+
+	Articles try to load social media sharing stats from cimlap.444.hu
+	which is why the ruleset is mixedcontent only
+-->
+<ruleset name="444.hu (mixedcontent)" platform="mixedcontent">
+	<target host="444.hu" />
+	<target host="daazo.444.hu" />
+	<target host="ezerkolibri.444.hu" />
+	<target host="feminfo.444.hu" />
+	<target host="fortepan.444.hu" />
+	<target host="geccodejoakecod.444.hu" />
+	<target host="geekz.444.hu" />
+	<target host="hello90.444.hu" />
+	<target host="hetibeton.444.hu" />
+	<target host="kepek.444.hu" />
+	<target host="lathatatlangyerekek.444.hu" />
+	<target host="mivoltma.444.hu" />
+	<target host="nokedli.444.hu" />
+	<target host="pulispace.444.hu" />
+	<target host="sciencemeetup.444.hu" />
+	<target host="tldr.444.hu" />
+	<target host="verde.444.hu" />
+	<target host="vifon.444.hu" />
+	<target host="yolovilag.444.hu" />
+
+	<rule from="^http:"
+		  to="https://" />
+</ruleset>


### PR DESCRIPTION
444.hu has a wildcard certificate. It tries to fetch social media sharing statistics via cimlap.444.hu which uses an old, expired wildcard certificate, which is why I've marked this ruleset as mixedcontent.