### PR TITLE
[Archive.org_Way_Back_Machine] Add 2 synonymous domains

### DIFF
--- a/src/chrome/content/rules/Archive.org_Way_Back_Machine.xml
+++ b/src/chrome/content/rules/Archive.org_Way_Back_Machine.xml
@@ -5,6 +5,8 @@
 <ruleset name="Archive.org Way Back Machine">
 
 	<target host="web.archive.org" />
+	<target host="wayback.archive.org" />
+	<target host="waybackmachine.org" />
 
 
 	<!--	Not secured by server:
@@ -15,6 +17,8 @@
 	<securecookie host="^web\.archive\.org$" name=".+" />
 
 
+    <rule from="^http://waybackmachine\.org/"
+        to="https://web.archive.org/" />
 	<rule from="^http:"
 		to="https:" />
 


### PR DESCRIPTION
https://wayback.archive.org has a valid *.archive.org cert.

https://waybackmachine.org fails by presenting the same cert, hence the
redirection.