### PR TITLE
[cnzz] Ditch cnzz script sites, fix #5602

### DIFF
--- a/src/chrome/content/rules/Cnzz.com.xml
+++ b/src/chrome/content/rules/Cnzz.com.xml
@@ -3,6 +3,9 @@
 	- cnzz.com
 	- mail.cnzz.com
 	- www.cnzz.com
+	- s[0-9]+.cnzz.com (#5602)
+	- c.cnzz.com (#5602)
+	- w.cnzz.com (#5602)
 	
 	Redirects to http:
 	- adm.cnzz.com
@@ -30,156 +33,11 @@
 -->
 
 <ruleset name="Cnzz.com">
-	<target host="c.cnzz.com" />
 	<target host="db.cnzz.com" />
 	<target host="dplus.cnzz.com" />
 	<target host="icon.cnzz.com" />
 	<target host="mt.cnzz.com" />
 	<target host="tongji.cnzz.com" />
-	<target host="w.cnzz.com" />
-	
-	<target host="s1.cnzz.com" />
-	<target host="s2.cnzz.com" />
-	<target host="s3.cnzz.com" />
-	<target host="s4.cnzz.com" />
-	<target host="s5.cnzz.com" />
-	<target host="s6.cnzz.com" />
-	<target host="s7.cnzz.com" />
-	<target host="s8.cnzz.com" />
-	<target host="s9.cnzz.com" />
-	<target host="s10.cnzz.com" />
-	<target host="s11.cnzz.com" />
-	<target host="s12.cnzz.com" />
-	<target host="s13.cnzz.com" />
-	<target host="s14.cnzz.com" />
-	<target host="s15.cnzz.com" />
-	<target host="s16.cnzz.com" />
-	<target host="s17.cnzz.com" />
-	<target host="s18.cnzz.com" />
-	<target host="s19.cnzz.com" />
-	<target host="s20.cnzz.com" />
-	<target host="s21.cnzz.com" />
-	<target host="s22.cnzz.com" />
-	<target host="s23.cnzz.com" />
-	<target host="s24.cnzz.com" />
-	<target host="s25.cnzz.com" />
-	<target host="s26.cnzz.com" />
-	<target host="s27.cnzz.com" />
-	<target host="s28.cnzz.com" />
-	<target host="s29.cnzz.com" />
-	<target host="s30.cnzz.com" />
-	<target host="s31.cnzz.com" />
-	<target host="s32.cnzz.com" />
-	<target host="s33.cnzz.com" />
-	<target host="s34.cnzz.com" />
-	<target host="s35.cnzz.com" />
-	<target host="s36.cnzz.com" />
-	<target host="s37.cnzz.com" />
-	<target host="s38.cnzz.com" />
-	<target host="s39.cnzz.com" />
-	<target host="s40.cnzz.com" />
-	<target host="s41.cnzz.com" />
-	<target host="s42.cnzz.com" />
-	<target host="s43.cnzz.com" />
-	<target host="s44.cnzz.com" />
-	<target host="s45.cnzz.com" />
-	<target host="s46.cnzz.com" />
-	<target host="s47.cnzz.com" />
-	<target host="s48.cnzz.com" />
-	<target host="s49.cnzz.com" />
-	<target host="s50.cnzz.com" />
-	<target host="s51.cnzz.com" />
-	<target host="s52.cnzz.com" />
-	<target host="s53.cnzz.com" />
-	<target host="s54.cnzz.com" />
-	<target host="s55.cnzz.com" />
-	<target host="s56.cnzz.com" />
-	<target host="s57.cnzz.com" />
-	<target host="s58.cnzz.com" />
-	<target host="s59.cnzz.com" />
-	<target host="s60.cnzz.com" />
-	<target host="s61.cnzz.com" />
-	<target host="s62.cnzz.com" />
-	<target host="s63.cnzz.com" />
-	<target host="s64.cnzz.com" />
-	<target host="s65.cnzz.com" />
-	<target host="s66.cnzz.com" />
-	<target host="s67.cnzz.com" />
-	<target host="s68.cnzz.com" />
-	<target host="s69.cnzz.com" />
-	<target host="s70.cnzz.com" />
-	<target host="s71.cnzz.com" />
-	<target host="s72.cnzz.com" />
-	<target host="s73.cnzz.com" />
-	<target host="s74.cnzz.com" />
-	<target host="s75.cnzz.com" />
-	<target host="s76.cnzz.com" />
-	<target host="s77.cnzz.com" />
-	<target host="s78.cnzz.com" />
-	<target host="s79.cnzz.com" />
-	<target host="s80.cnzz.com" />
-	<target host="s81.cnzz.com" />
-	<target host="s82.cnzz.com" />
-	<target host="s83.cnzz.com" />
-	<target host="s84.cnzz.com" />
-	<target host="s85.cnzz.com" />
-	<target host="s86.cnzz.com" />
-	<target host="s87.cnzz.com" />
-	<target host="s88.cnzz.com" />
-	<target host="s89.cnzz.com" />
-	<target host="s90.cnzz.com" />
-	<target host="s91.cnzz.com" />
-	<target host="s92.cnzz.com" />
-	<target host="s93.cnzz.com" />
-	<target host="s94.cnzz.com" />
-	<target host="s95.cnzz.com" />
-	<target host="s96.cnzz.com" />
-	<target host="s97.cnzz.com" />
-	<target host="s98.cnzz.com" />
-	<target host="s99.cnzz.com" />
-	<target host="s100.cnzz.com" />
-	<target host="s101.cnzz.com" />
-	<target host="s102.cnzz.com" />
-	<target host="s103.cnzz.com" />
-	<target host="s104.cnzz.com" />
-	<target host="s105.cnzz.com" />
-	<target host="s106.cnzz.com" />
-	<target host="s107.cnzz.com" />
-	<target host="s108.cnzz.com" />
-	<target host="s109.cnzz.com" />
-	<target host="s110.cnzz.com" />
-	<target host="s111.cnzz.com" />
-	<target host="s112.cnzz.com" />
-	<target host="s113.cnzz.com" />
-	<target host="s114.cnzz.com" />
-	<target host="s115.cnzz.com" />
-	<target host="s116.cnzz.com" />
-	<target host="s117.cnzz.com" />
-	<target host="s118.cnzz.com" />
-	<target host="s119.cnzz.com" />
-	<target host="s120.cnzz.com" />
-	<target host="s121.cnzz.com" />
-	<target host="s122.cnzz.com" />
-	<target host="s123.cnzz.com" />
-	<target host="s124.cnzz.com" />
-	<target host="s125.cnzz.com" />
-	<target host="s126.cnzz.com" />
-	<target host="s127.cnzz.com" />
-	<target host="s128.cnzz.com" />
-	<target host="s129.cnzz.com" />
-	<target host="s130.cnzz.com" />
-	<target host="s131.cnzz.com" />
-	<target host="s132.cnzz.com" />
-	<target host="s133.cnzz.com" />
-	<target host="s134.cnzz.com" />
-	<target host="s135.cnzz.com" />
-	<target host="s136.cnzz.com" />
-	<target host="s137.cnzz.com" />
-	<target host="s138.cnzz.com" />
-	<target host="s139.cnzz.com" />
-	<target host="s140.cnzz.com" />
-	<target host="s141.cnzz.com" />
-	<target host="s142.cnzz.com" />
 
 	<rule from="^http:" to="https:" />
 

--- a/src/chrome/content/rules/Cnzz.com.xml
+++ b/src/chrome/content/rules/Cnzz.com.xml
@@ -33,7 +33,6 @@
 -->
 
 <ruleset name="Cnzz.com">
-	<target host="db.cnzz.com" />
 	<target host="dplus.cnzz.com" />
 	<target host="icon.cnzz.com" />
 	<target host="mt.cnzz.com" />


### PR DESCRIPTION
These sites generate scripts that refer to other CNZZ hosts with nonfunctional HTTPS when visited through HTTPS.
