### PR TITLE
Fix how 'Location' is parsed from header text

### DIFF
--- a/test/rules/src/https_everywhere_checker/http_client.py
+++ b/test/rules/src/https_everywhere_checker/http_client.py
@@ -378,9 +378,9 @@ class HTTPFetcher(object):
 				raise HTTPFetcherError("Pycurl fetch failed for '%s'" % newUrl)
 			elif httpCode in (301, 302, 303, 307):
 				location = None
-				for piece in headerStr.lower().split('\n'):
-					if piece.startswith('location:'):
-						location = ':'.join(piece.split(':')[1:]).strip()
+				for piece in headerStr.split('\n'):
+					if piece.lower().startswith('location:'):
+						location = piece[len('location:'):].strip()
 				if location is None:
 					raise HTTPFetcherError("Redirect for '%s' missing location header" % newUrl)
 				

--- a/test/rules/src/https_everywhere_checker/http_client.py
+++ b/test/rules/src/https_everywhere_checker/http_client.py
@@ -378,11 +378,11 @@ class HTTPFetcher(object):
 				raise HTTPFetcherError("Pycurl fetch failed for '%s'" % newUrl)
 			elif httpCode in (301, 302, 303, 307):
 				location = None
-				for piece in headerStr.split('\n'):
-					if piece.startswith('Location:'):
+				for piece in headerStr.lower().split('\n'):
+					if piece.startswith('location:'):
 						location = ''.join(piece.split(': ')[1:])
 				if location is None:
-					raise HTTPFetcherError("Redirect for '%s' missing Location" % newUrl)
+					raise HTTPFetcherError("Redirect for '%s' missing location header" % newUrl)
 				
 				location = self.absolutizeUrl(newUrl, location)
 				logging.debug("Following redirect %s => %s", newUrl, location)

--- a/test/rules/src/https_everywhere_checker/http_client.py
+++ b/test/rules/src/https_everywhere_checker/http_client.py
@@ -380,7 +380,7 @@ class HTTPFetcher(object):
 				location = None
 				for piece in headerStr.lower().split('\n'):
 					if piece.startswith('location:'):
-						location = ''.join(piece.split(': ')[1:])
+						location = ':'.join(piece.split(':')[1:]).strip()
 				if location is None:
 					raise HTTPFetcherError("Redirect for '%s' missing location header" % newUrl)
 				


### PR DESCRIPTION
This fixes the test problem identified in pull request #6871 , where [this code](https://github.com/EFForg/https-everywhere/blob/a37a897b014360893646a8699715bc5e58c011d0/test/rules/src/https_everywhere_checker/http_client.py#L382-L389) apparently (?) never finds the `Location` header, for example:

```
(Pdb) self._headerRe
regex.Regex('(?P<name>\\S+?): (?P<value>.*?)\\r\\n', flags=regex.V0)
(Pdb) headerStr
'HTTP/1.1 301 Moved Permanently\nServer: Apache\nDate: Tue Jun  1 12:48:03 PDT 1999 PDT\nReferer: http://itunes.com/\nLocation: http://www.apple.com/itunes/?cid=OAS-US-DOMAINS-itunes.com\nContent-type: text/html\nContent-length: 311\n\n'
(Pdb) headers = self._headerRe.findall(headerStr)
(Pdb) headers
[]
(Pdb)
```

Note that if in fact `location` has been incorrectly `False`-y for a while, then it's possible the code immediately after the `raise HTTPFetcherError` line has not been run recently or ever, and this fix may reveal new bugs in it.

Pinging @fuglede @Hainish @J0WI for review.