### PR TITLE
Remove trailing slashes from Videa.hu.xml rule

### DIFF
--- a/src/chrome/content/rules/Videa.hu.xml
+++ b/src/chrome/content/rules/Videa.hu.xml
@@ -7,5 +7,5 @@
 	<target host="videa.hu" />
 
 	<rule from="^http:"
-		  to="https://" />
+		  to="https:" />
 </ruleset>


### PR DESCRIPTION
This should fix a problem introduced by pull request #6860 .

@fuglede @Hainish @J0WI This is breaking Travis, see [here](https://travis-ci.org/EFForg/https-everywhere/jobs/160021213).