### PR TITLE
Disabled ruleset due to expired certificate (thesprawl.org)

### DIFF
--- a/src/chrome/content/rules/Sprawl.xml
+++ b/src/chrome/content/rules/Sprawl.xml
@@ -1,10 +1,8 @@
-<ruleset name="The Sprawl.org">
+<ruleset name="The Sprawl.org" default_off="Certificate expired">
 
 	<target host="thesprawl.org" />
 	<target host="www.thesprawl.org" />
 
-
-	<rule from="^http:"
-		to="https:" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>


### PR DESCRIPTION
Fixes https://github.com/EFForg/https-everywhere/issues/6892