### PR TITLE
[UserVoice] Exclude email.feedback-poweredby.uservoice.com

### DIFF
--- a/src/chrome/content/rules/Uservoice.xml
+++ b/src/chrome/content/rules/Uservoice.xml
@@ -3,29 +3,38 @@
 
 		- UvCDN.com.xml
 
+	Nonfunctional subdomains:
+
+		- email ¹ ²
+		- email.feedback-poweredby ¹
+
+	¹ Timeout (Mailgun)
+	² <https://trac.torproject.org/projects/tor/ticket/7273>
+
 	Problematic subdomains:
 
-		- email ¹
-		- www6 ²
+		- www6 ¹
 
-	¹ mismatched, CN: *.mailgun.net <https://trac.torproject.org/projects/tor/ticket/7273>
-	² mismatched, CN: *.pardot.com <https://github.com/EFForg/https-everywhere/issues/4514>
+	¹ Mismatched, CN: *.pardot.com <https://github.com/EFForg/https-everywhere/issues/4514>
 -->
 <ruleset name="UserVoice">
 
 	<target host="uservoice.com" />
 	<target host="*.uservoice.com" />
 
-	<exclusion pattern="^http://(email|www6)\.uservoice\.com/" />
+	<exclusion pattern="^http://(email|email\.feedback-poweredby|www6)\.uservoice\.com/" />
 
 		<test url="http://email.uservoice.com/" />
 		<!-- Random search result link -->
 		<test url="http://email.uservoice.com/c/ZD1kNTImaT01M2M1MTlhNDM5NmYxXzNiODgzZmMyYWIzZDkzMTg0NDY1NiU0MHVzZXJ2b2ljZS5jb20maD1mYTg5YzU4ZTVjMTRjZjc4NjM4MWQzYmExZmQxZDA1ZiZsPWh0dHBzJTNBJTJGJTJGd3d3LmRpZ2l0YWxvY2Vhbi5jb20lMkZjb21wYW55JTJGYmxvZyUyRmludHJvZHVjaW5nLW91ci1sb25kb24tcmVnaW9uJTJGJTIzY29tbWVudC0xNDg1ODkyODczJnRyYWNraW5nX2NvZGU9M2ZmOWY3ODZhN2I1NmVmNGNiNTBhYjFmN2VmMDM0YzEmcj1tYXR0JTQwejIyc2UuY28udWs" />
+		<test url="http://email.feedback-poweredby.uservoice.com/" />
+		<!-- Random search result link -->
+		<test url="http://email.feedback-poweredby.uservoice.com/c/eJxVj0GOwyAMRU_T7KiAQCgLFrOZa1TEdlLUFCIgieb2A7MbyYsv-z_bH53kQvshOD0hWUUPY4XiTy2sGJeFzGxn8BNoIYW1N8WPQvlMAegO6TO8HBrR5rPRM9cGpKARuhJWeeCIOGzuVetebuPXTX63unak8_5vTesuKR-f0oQQ3HDNjhhOysVv7AoR01XYvvnaXN1cjnWlUkOKf4TUejLGspUq81AbyDBkgpryD-uHWIid9J0YavbwDnF9QkJyBpRtmTmaBRQHwwUqC_bhFy-VnaYhO9hCrC15Purbl_7vL6PJZGg" />
 		<test url="http://www6.uservoice.com/" />
 		<!-- Sign up link on https://www.uservoice.com/ -->
 		<test url="http://www6.uservoice.com/l/17202/2015-10-15/2zbnhz" />
 
-	<securecookie host="^(?!email\.|www6\.)\w" name=".+" />
+	<securecookie host="^(?!email\.|email\.feedback-poweredby\.|www6\.)\w" name=".+" />
 
 	<test url="http://uservoice.com/" />
 	<test url="http://app.uservoice.com/" />


### PR DESCRIPTION
It points to Mailgun, and needs to be excluded just like `email.uservoice.com`.

(The error has also changed from a certificate mismatch to a timeout.)