### PR TITLE
[Energinet.dk] Fix various issues

### DIFF
--- a/src/chrome/content/rules/Energinet.dk.xml
+++ b/src/chrome/content/rules/Energinet.dk.xml
@@ -1,6 +1,34 @@
-<ruleset name="Energinet.net">
+<!--
+	Problematic domains:
+
+		- ^ ¹
+
+	¹: Mismatch
+-->
+<ruleset name="Energinet.dk">
+
 	<target host="energinet.dk" />
 	<target host="www.energinet.dk" />
-	<securecookie host="^www\.energinet\.dk" name=".*"/>
-	<rule from="^http://(?:www\.)?energinet\.dk/" to="https://www.energinet.dk/" />
+
+	<!-- Causes redirect loops -->
+	<exclusion pattern="^http://(www\.)?energinet\.dk/(DA|EN)/" />
+
+		<!-- Matching exception pattern -->
+		<test url="http://energinet.dk/DA/Sider/default.aspx" />
+		<test url="http://energinet.dk/EN/Sider/default.aspx" />
+		<test url="http://www.energinet.dk/DA/El/Sider/Elsystemet-lige-nu.aspx" />
+		<test url="http://www.energinet.dk/EN/El/Sider/Elsystemet-lige-nu.aspx" />
+
+		<!-- Not matching exception pattern -->
+		<test url="http://www.energinet.dk/SiteCollectionImages/Forside/el_kort.jpg" />
+		<test url="http://www.energinet.dk/_layouts/1033/Energinet/Styles/Images/energinetlogo.gif" />
+
+	<!-- Serves different content on HTTP and HTTPS -->
+	<exclusion pattern="http://(www.)?energinet.dk/_layouts/internet.oversaettelse/oversaettelse.aspx" />
+
+		<test url="http://energinet.dk/_layouts/internet.oversaettelse/oversaettelse.aspx" />
+		<test url="http://www.energinet.dk/_layouts/internet.oversaettelse/oversaettelse.aspx" />
+
+	<rule from="^http://(www\.)?energinet\.dk/" to="https://www.energinet.dk/" />
+
 </ruleset>

--- a/src/chrome/content/rules/Energinet.dk.xml
+++ b/src/chrome/content/rules/Energinet.dk.xml
@@ -5,7 +5,7 @@
 
 	¹: Mismatch
 -->
-<ruleset name="Energinet.dk">
+<ruleset name="Energinet.dk (partial)">
 
 	<target host="energinet.dk" />
 	<target host="www.energinet.dk" />


### PR DESCRIPTION
The existing ruleset caused a redirect loop due to the inclusion on the following script on all content containing pages:

```html
	<script type="text/javascript">
	{
	  var url=location.href;
	  if(url.indexOf("https://") > -1)
	  {
	    var newurl=url.replace("https://","http://");
	    location.href=newurl;
	  }
	}
	</script>
```

This fixes that by exclusion of those pages.

Moreover, clicking the "English"/"Danish" link, you'd end up on a page for editing the webpage contents, which is great in itself.