### PR TITLE
[Infogr.am] Disable subdomain e.infogr.am

### DIFF
--- a/src/chrome/content/rules/Infogr.am.xml
+++ b/src/chrome/content/rules/Infogr.am.xml
@@ -22,6 +22,14 @@
 	<target host="blog.infogr.am" />
 	<target host="www.infogr.am" />
 
+
+	<!--	Not secured by server:
+					-->
+	<!--securecookie host="^\.infogr\.am$" name="^ig_session$" /-->
+
+	<securecookie host="^(?!e\.infogr\.am$)." name="." />
+
+
 	<rule from="^http:"
 		to="https:" />
 

--- a/src/chrome/content/rules/Infogr.am.xml
+++ b/src/chrome/content/rules/Infogr.am.xml
@@ -23,11 +23,7 @@
 	<target host="www.infogr.am" />
 
 
-	<!--	Not secured by server:
-					-->
-	<!--securecookie host="^\.infogr\.am$" name="^ig_session$" /-->
-
-	<securecookie host="^(?!e\.infogr\.am$)." name="." />
+	<securecookie host=".+" name=".+" />
 
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/Infogr.am.xml
+++ b/src/chrome/content/rules/Infogr.am.xml
@@ -10,39 +10,17 @@
 
 	ᶜ See https://owasp.org/index.php/SecureFlag
 
+
+	Problematic domains:
+
+		- e.infogr.am causes breakage on numerous pages, cf. GH #4182, #4502, #6791, and #6864
+
 -->
 <ruleset name="Infogr.am (partial)">
 
 	<target host="infogr.am" />
 	<target host="blog.infogr.am" />
-	<target host="e.infogr.am" />
 	<target host="www.infogr.am" />
-
-	<!-- Breaks
-		http://www.silive.com/news/index.ssf/2016/02/si_traffic_tickets_almost_doub.html
-	c.f.
-		https://github.com/EFForg/https-everywhere/issues/4182
-	-->
-	<exclusion pattern="^http://e\.infogr\.am/js/embed\.js\?" />
-		<test url="http://e.infogr.am/js/embed.js?gm4" />
-		<test url="http://e.infogr.am/js/embed.js?" />
-	<exclusion pattern="^http://e.infogr.am/top_tarffic_violations\?" /> <!-- [sic] -->
-		<test url="http://e.infogr.am/top_tarffic_violations?src=embed" />
-		<test url="http://e.infogr.am/top_tarffic_violations?" />
-	<!-- Breaks
-		http://www.timesrecordnews.com/news/education/gol-burg-votes-to-arm-teachers-2eb94c42-1f08-3e4e-e053-0100007fb1cf-373284441.html
-	c.f.
-		https://github.com/EFForg/https-everywhere/issues/4502
-	-->
-	<exclusion pattern="^http://e.infogr.am/school_shooting_incidents_from_2014_2016" />
-		<test url="http://e.infogr.am/school_shooting_incidents_from_2014_2016" />
-
-	<!--	Not secured by server:
-					-->
-	<!--securecookie host="^\.infogr\.am$" name="^ig_session$" /-->
-
-	<securecookie host="^(?!e\.infogr\.am$)." name="." />
-
 
 	<rule from="^http:"
 		to="https:" />


### PR DESCRIPTION
This particular subdomain has caused issues a number of places, and the most recent ones do not suggest an easy fix. This closes https://github.com/EFForg/https-everywhere/issues/6791.