### PR TITLE
Updated fronter.com rule to reflect full (rather than partial) HTTPS support

### DIFF
--- a/src/chrome/content/rules/fronter.com.xml
+++ b/src/chrome/content/rules/fronter.com.xml
@@ -5,32 +5,19 @@
 
 	ʳ Refused
 
-
-	Problematic hosts in *fronter.com:
-
-		- lists ᵉ ˢ
-
-	ᵉ Expired
-	ˢ Self-signed
-
 -->
-<ruleset name="Fronter.com (partial)">
+<ruleset name="fronter.com">
 
 	<target host="fronter.com" />
-	<target host="brasil.fronter.com" />
-	<target host="cdn.fronter.com" />
-	<target host="eng.fronter.com" />
-	<target host="help.fronter.com" />
-	<target host="nor.fronter.com" />
-	<target host="login.fronter.com" />
-	<target host="pol.fronter.com" />
-	<target host="swe.fronter.com" />
-	<target host="www.fronter.com" />
+	<target host="*.fronter.com" />
 
+	<test url="http://login.fronter.com/" />
+	<test url="http://bucket.fronter.com/" />
+	<test url="http://api.fronter.com/" />
+	<test url="http://cdn.fronter.com/" />
+	<test url="http://notifications.fronter.com/" />
 
-	<securecookie host="^\." name="^(?:__cfduid|cf_clearance)$" />
-	<securecookie host="^\w" name="." />
-
+	<securecookie host=".+" name=".+" />
 
 	<rule from="^http:"
 		to="https:" />

--- a/src/chrome/content/rules/webfronter.com.xml
+++ b/src/chrome/content/rules/webfronter.com.xml
@@ -1,0 +1,6 @@
+<ruleset name="webfronter.com">
+	<target host="webfronter.com" />
+	<target host="www.webfronter.com" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>


### PR DESCRIPTION
Every subdomain under fronter.com now supports (and redirects to) HTTPS, so I've removed some conditionals, and replaced them with a wildcard entry. At the same time I've added some explicit test URLs to ensure coverage of what's behind the wildcard, and also removed conditionals for securecookie.

The root of the bottom two test URLs only return 403, but I left them in in case you wanted >3. If testing against a 403 is no good (the redirect still works fine, though), feel free to get rid of them.

I've tried following the style guide, and hope the result is to your satisfaction.

There is one remaining issue, as also noted (presumably) by the rule checker, namely webfronter.us.fronter.com. While this does listen on HTTPS, the returned certificate is mismatched (it matches *.fronter.com but not *.us.fronter.com). I'm not entirely sure how to best handle nor express this in the rule - suggestions are most welcome.

This subdomain is only used to handle a (temporary) redirect from webfronter.us.fronter.com/$1 to webfronter.com/$1, and the target domain _does_ support HTTPS with a matched certificate (although it does not itself redirect visitors to HTTPS; I'll submit a separate rule for that domain).

I expect webfronter.us.fronter.com to become deprecated in a few months time.

FWIW I also fixed lists.fronter.com earlier this week, which now has a new, valid certificate. I have therefore also removed the comment concerning that.

Thanks.
