### PR TITLE
bot.brew.sh: add ruleset

### DIFF
--- a/src/chrome/content/rules/bot.brew.sh.xml
+++ b/src/chrome/content/rules/bot.brew.sh.xml
@@ -1,0 +1,4 @@
+<ruleset name="bot.brew.sh">
+	<target host="bot.brew.sh" />
+	<rule from="^http:" to="https:" />
+</ruleset>


### PR DESCRIPTION
Simple ruleset to force redirection from `bot.brew.sh` to `https://bot.brew.sh`.