### PR TITLE
Add MetaEbene.me 

### DIFF
--- a/src/chrome/content/rules/MetaEbene.xml
+++ b/src/chrome/content/rules/MetaEbene.xml
@@ -1,0 +1,57 @@
+<!--
+	Invalid certificate:
+		- feeds.metaebene.me
+		- docs.podlove.org
+		- translate.podlove.org
+
+	TimeOut:
+		- tim.geekheim.de
+-->
+<ruleset name="Metaebene">
+
+	<target host="bundesradio.de" />
+	<target host="cre-podcast.de" />
+	<target host="cre.fm" />
+	<target host="das-sendezentrum.de" />
+	<target host="der-lautsprecher.de" />
+	<target host="die-sondersendung.de" />
+	<target host="diesondersendung.de" />
+	<target host="fokus-europa.de" />
+	<target host="fokuseuropa.de" />
+	<target host="forschergeist.de" />
+	<target host="freakshow.fm" />
+	<target host="futurologischer-salon.de" />
+	<target host="interhemd.de" />
+	<target host="kolophon.oreilly.de" />
+	<target host="logbuch-netzpolitik.de" />
+
+	<target host="blinkenlights.metaebene.me" />
+	<target host="diegesellschafter.metaebene.me" />
+	<target host="meta.metaebene.me" />
+	<target host="slackin.community.metaebene.me" />
+	<target host="test.metaebene.me" />
+	<target host="webciety.metaebene.me" />
+	<target host="metaebene.me" />
+
+	<target host="mobile-macs.de" />
+	<target host="mobilemacs.de" />
+	<target host="newz-of-the-world.com" />
+	<target host="newzoftheworld.com" />
+	<target host="not-safe-for-work.de" />
+	<target host="notsafeforwork.de" />
+
+	<target host="podlove.de" />
+
+	<target host="auth.podlove.org" />
+	<target host="cdn.podlove.org" />
+	<target host="community.podlove.org" />
+	<target host="publisher.podlove.org" />
+	<target host="podlove.org" />
+
+	<target host="raumzeit-podcast.de" />
+	<target host="tim.pritlove.org" />
+	<target host="ukw.fm" />
+
+	<rule from="^http:" to="https:"/>
+
+</ruleset>


### PR DESCRIPTION
small passive mixed-content warning because audio-files are loaded from the meta-subdomain that has no valid cert, but that is minor.
