### PR TITLE
Update GoogleTranslate.xml

### DIFF
--- a/src/chrome/content/rules/Google.tld_Subdomains.xml
+++ b/src/chrome/content/rules/Google.tld_Subdomains.xml
@@ -55,16 +55,19 @@
 	<target host="picasaweb.google.com.*" />
 	<target host="scholar.google.com.*" />
 
-	<securecookie host="^(?:accounts|adwords|m|picasaweb)\.google\.[\w.]{2,6}$" name=".+" />
+	<target host="translate.google.*" />
+	<target host="translate.google.co.*" />
+	<target host="translate.google.com.*" />
+	<securecookie host="^(accounts|adwords|m|picasaweb|translate)\.google\.[\w.]{2,6}$" name=".+" />
 
 	<!-- path that 404 on https but 301 on http -->
-	<rule from="^http://news\.google\.((?:com?\.)?\w{2,3})/archivesearch"
+	<rule from="^http://news\.google\.((com?\.)?\w{2,3})/archivesearch"
 			to="https://news.google.$1/news/advanced_news_search" />
 		<test url="http://news.google.ca/archivesearch" />
 		<test url="http://news.google.com/archivesearch" />
 		<test url="http://news.google.com.au/archivesearch" />
 
-	<rule from="^http://(accounts|adwords|finance|groups|id|lh\d|m|news|picasaweb|scholar)\.google\.((?:com?\.)?\w{2,3})/"
+	<rule from="^http://(accounts|adwords|finance|groups|id|lh\d|m|news|picasaweb|scholar|translate)\.google\.((com?\.)?\w{2,3})/"
 			to="https://$1.google.$2/" />
 		<test url="http://accounts.google.ca/" />
 		<test url="http://accounts.google.com/" />
@@ -96,4 +99,7 @@
 		<test url="http://scholar.google.ca/" />
 		<test url="http://scholar.google.com/" />
 		<test url="http://scholar.google.com.au/" />
+		<test url="http://translate.google.com/" />
+		<test url="http://translate.google.co.jp/" />
+		<test url="http://translate.google.com.kh/" />
 </ruleset>

--- a/src/chrome/content/rules/Google.tld_Subdomains.xml
+++ b/src/chrome/content/rules/Google.tld_Subdomains.xml
@@ -24,6 +24,7 @@
 	<target host="news.google.*" />
 	<target host="picasaweb.google.*" />
 	<target host="scholar.google.*" />
+	<target host="translate.google.*" />
 
 	<target host="accounts.google.co.*" />
 	<target host="adwords.google.co.*" />
@@ -39,6 +40,7 @@
 	<target host="news.google.co.*" />
 	<target host="picasaweb.google.co.*" />
 	<target host="scholar.google.co.*" />
+	<target host="translate.google.co.*" />
 
 	<target host="accounts.google.com.*" />
 	<target host="adwords.google.com.*" />
@@ -54,10 +56,8 @@
 	<target host="news.google.com.*" />
 	<target host="picasaweb.google.com.*" />
 	<target host="scholar.google.com.*" />
-
-	<target host="translate.google.*" />
-	<target host="translate.google.co.*" />
 	<target host="translate.google.com.*" />
+
 	<securecookie host="^(accounts|adwords|m|picasaweb|translate)\.google\.[\w.]{2,6}$" name=".+" />
 
 	<!-- path that 404 on https but 301 on http -->

--- a/src/chrome/content/rules/GoogleServices.xml
+++ b/src/chrome/content/rules/GoogleServices.xml
@@ -18,6 +18,7 @@
 		- Google.com_Subdomains.xml
 		- Google.com_Subdomains_Complex.html
 		- Google.org.xml
+		- Google.tld_Subdomains.xml
 		- GoogleAPIs.xml
 		- Google_App_Engine.xml
 		- GoogleImages.xml

--- a/src/chrome/content/rules/GoogleTranslate.xml
+++ b/src/chrome/content/rules/GoogleTranslate.xml
@@ -1,7 +1,0 @@
-<ruleset name="Google Translate">
-	<target host="translate.google.com" />
-
-	<securecookie host=".+" name=".+" />
-
-	<rule from="^http:" to="https:" />
-</ruleset>

--- a/src/chrome/content/rules/GoogleTranslate.xml
+++ b/src/chrome/content/rules/GoogleTranslate.xml
@@ -1,8 +1,7 @@
-<ruleset name="Google Translate (broken)" default_off="redirect loops">
-  <target host="translate.googleapis.com" />
-  <target host="translate.google.com" />
+<ruleset name="Google Translate">
+	<target host="translate.google.com" />
 
-  <rule from="^http://translate\.googleapis\.com/" to="https://translate.googleapis.com/"/>
-  <rule from="^http://translate\.google\.com/"
-      to="https://translate.google.com/" />
+	<securecookie host=".+" name=".+" />
+
+	<rule from="^http:" to="https:" />
 </ruleset>


### PR DESCRIPTION
securecookie for all
remove translate.googleapis.com*

\* Preloaded
[Chromium](https://cs.chromium.org/chromium/src/net/http/transport_security_state_static.json?amp&sq=package:chromium&l=322), [Firefox](https://dxr.mozilla.org/mozilla-aurora/source/security/manager/ssl/nsSTSPreloadList.inc#10327), [Tor](https://gitweb.torproject.org/tor-browser.git/tree/security/manager/ssl/nsSTSPreloadList.inc?h=tor-browser-45.4.0esr-6.5-1#n11430)