### PR TITLE
Remove uspsoig.gov

### DIFF
--- a/src/chrome/content/rules/US-government.xml
+++ b/src/chrome/content/rules/US-government.xml
@@ -249,9 +249,6 @@ Fetch error: http://wtr.nhtsa.gov/ => https://wtr.nhtsa.gov/: (7, 'Failed to con
 	<target host="intelligence.house.gov"/>
 	<target host="wtr.nhtsa.gov" />
 	<target host="postalinspectors.uspis.gov"/>
-	<target host="uspsoig.gov"/>
-	<target host="www.uspsoig.gov"/>
-
 
 	<securecookie host="^safeharbor\.export\.gov$" name=".*"/>
 	<securecookie host="^(?:.*\.)?census\.gov$" name=".*"/>
@@ -270,8 +267,4 @@ Fetch error: http://wtr.nhtsa.gov/ => https://wtr.nhtsa.gov/: (7, 'Failed to con
 
 	<rule from="^http://postalinspectors\.uspis\.gov/"
 		to="https://postalinspectors.uspis.gov/"/>
-
-	<rule from="^http://(www\.)?uspsoig\.gov/"
-		to="https://$1uspsoig.gov/"/>
-
 </ruleset>


### PR DESCRIPTION
Preloaded

[Chromium](https://cs.chromium.org/chromium/src/net/http/transport_security_state_static.json?amp&sq=package:chromium&l=1864), [Firefox](https://dxr.mozilla.org/mozilla-aurora/source/security/manager/ssl/nsSTSPreloadList.inc#10630), [Tor](https://gitweb.torproject.org/tor-browser.git/tree/security/manager/ssl/nsSTSPreloadList.inc?h=tor-browser-45.4.0esr-6.5-1#n11412)
