### PR TITLE
[Bitbucket.org] status's certificate is good now; fix name capitalization

### DIFF
--- a/src/chrome/content/rules/BitBucket.xml
+++ b/src/chrome/content/rules/BitBucket.xml
@@ -9,20 +9,12 @@
 		- s3.amazonaws.com/bitbucket-assetroot/
 		- dwz7u9t8u8usb.cloudfront.net
 
-		- bitbucket.statuspage.io
-
-			- status
-
 
 	Problematic subdomains:
 
 		- portix	(works; mismatched, CN: bitbucket.org)
-		- status ²
-
-	² Refused; mismatched, CN: *.statuspage.io
-
 -->
-<ruleset name="BitBucket.org (partial)">
+<ruleset name="Bitbucket.org (partial)">
 
 	<!--	Direct rewrites:
 				-->
@@ -31,18 +23,12 @@
 
 	<target host="bitbucket.org" />
 	<target host="blog.bitbucket.org" />
-	<target host="www.bitbucket.org" />
-
-	<!--	Complications:
-				-->
 	<target host="status.bitbucket.org" />
+	<target host="www.bitbucket.org" />
 
 
 	<securecookie host="." name="." />
 
-
-	<rule from="^http://status\.bitbucket\.org/"
-		to="https://bitbucket.statuspage.io/" />
 
 	<rule from="^http:"
 		to="https:" />

--- a/src/chrome/content/rules/Bitbucket-mismatches.xml
+++ b/src/chrome/content/rules/Bitbucket-mismatches.xml
@@ -1,8 +1,8 @@
 <!--
-	For rules that are on by default, see BitBucket.xml.
+	For rules that are on by default, see Bitbucket.xml.
 
 -->
-<ruleset name="BitBucket.org (mismatches)" default_off="mismatched">
+<ruleset name="Bitbucket (mismatches)" default_off="mismatched">
 
 	<!--	Direct rewrites:
 				-->

--- a/src/chrome/content/rules/Bitbucket.xml
+++ b/src/chrome/content/rules/Bitbucket.xml
@@ -1,5 +1,5 @@
 <!--
-	For problematic rules, see BitBucket-mismatches.xml.
+	For problematic rules, see Bitbucket-mismatches.xml.
 
 	For other Atlassian coverage, see Atlassian.xml.
 
@@ -14,7 +14,7 @@
 
 		- portix	(works; mismatched, CN: bitbucket.org)
 -->
-<ruleset name="Bitbucket.org (partial)">
+<ruleset name="Bitbucket (partial)">
 
 	<!--	Direct rewrites:
 				-->


### PR DESCRIPTION
* `status.bitbucket.org`'s certificate is no longer mismatched; remove workaround

* Change the `<ruleset name>` from "BitBucket.org (partial)" to "Bitbucket.org (partial)". I didn't rename the files.