### PR TITLE
Enable for www.montereybayaquarium.org

### DIFF
--- a/src/chrome/content/rules/Monterey_Bay_Aquarium.xml
+++ b/src/chrome/content/rules/Monterey_Bay_Aquarium.xml
@@ -1,13 +1,7 @@
-<!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://montereybayaquarium.org/ => https://montereybayaquarium.org/: (51, "SSL: no alternative certificate subject name matches target host name 'montereybayaquarium.org'")
-	!www: cert only matches www
+<ruleset name="Monterey Bay Aquarium">
 
--->
-<ruleset name="Monterey Bay Aquarium" default_off='failed ruleset test'>
-
-	<target host="montereybayaquarium.org" />
 	<target host="www.montereybayaquarium.org" />
+	<exclusion pattern="^http://montereybayaquarium.org/.*" /> <!-- Cert only matches www -->
 
 
 	<securecookie host="^www\.montereybayaquarium\.org$" name=".+" />

--- a/src/chrome/content/rules/Monterey_Bay_Aquarium.xml
+++ b/src/chrome/content/rules/Monterey_Bay_Aquarium.xml
@@ -1,12 +1,7 @@
 <ruleset name="Monterey Bay Aquarium">
-
 	<target host="www.montereybayaquarium.org" />
-	<exclusion pattern="^http://montereybayaquarium.org/.*" /> <!-- Cert only matches www -->
-
 
 	<securecookie host="^www\.montereybayaquarium\.org$" name=".+" />
 
-
 	<rule from="^http:" to="https:" />
-
 </ruleset>

--- a/src/chrome/content/rules/Monterey_Bay_Aquarium.xml
+++ b/src/chrome/content/rules/Monterey_Bay_Aquarium.xml
@@ -4,4 +4,6 @@
 	<securecookie host="^www\.montereybayaquarium\.org$" name=".+" />
 
 	<rule from="^http:" to="https:" />
+
+	<test url="http://www.montereybayaquarium.org/" />
 </ruleset>

--- a/src/chrome/content/rules/Monterey_Bay_Aquarium.xml
+++ b/src/chrome/content/rules/Monterey_Bay_Aquarium.xml
@@ -1,9 +1,20 @@
+<!--
+	Invalid certificate:
+		https://montereybayaquarium.org
+		https://tmp.montereybayaquarium.org
+	Time out:
+		https://static.montereybayaquarium.org
+		https://storage.montereybayaquarium.org
+-->
 <ruleset name="Monterey Bay Aquarium">
 	<target host="www.montereybayaquarium.org" />
+	<target host="affiliate.montereybayaquarium.org" />
+	<target host="m.montereybayaquarium.org" />
+	<target host="mobile.montereybayaquarium.org" />
+	<target host="newsroom.montereybayaquarium.org" />
+	<target host="tickets.montereybayaquarium.org" />
 
-	<securecookie host="^www\.montereybayaquarium\.org$" name=".+" />
+	<securecookie host="^(www|affiliate|m|mobile|newsroom|tickets)\.montereybayaquarium\.org" name=".+" />
 
 	<rule from="^http:" to="https:" />
-
-	<test url="http://www.montereybayaquarium.org/" />
 </ruleset>

--- a/src/chrome/content/rules/Monterey_Bay_Aquarium.xml
+++ b/src/chrome/content/rules/Monterey_Bay_Aquarium.xml
@@ -1,10 +1,10 @@
 <!--
 	Invalid certificate:
-		https://montereybayaquarium.org
-		https://tmp.montereybayaquarium.org
+		montereybayaquarium.org
+		tmp.montereybayaquarium.org
 	Time out:
-		https://static.montereybayaquarium.org
-		https://storage.montereybayaquarium.org
+		static.montereybayaquarium.org
+		storage.montereybayaquarium.org
 -->
 <ruleset name="Monterey Bay Aquarium">
 	<target host="www.montereybayaquarium.org" />
@@ -14,7 +14,7 @@
 	<target host="newsroom.montereybayaquarium.org" />
 	<target host="tickets.montereybayaquarium.org" />
 
-	<securecookie host="^(www|affiliate|m|mobile|newsroom|tickets)\.montereybayaquarium\.org" name=".+" />
+	<securecookie host="^(www|affiliate|m|mobile|newsroom|tickets)\.montereybayaquarium\.org$" name=".+" />
 
 	<rule from="^http:" to="https:" />
 </ruleset>


### PR DESCRIPTION
The cert is only valid for www., so exclude the bare host.