### PR TITLE
Update Recode.net.xml

### DIFF
--- a/src/chrome/content/rules/Recode.net.xml
+++ b/src/chrome/content/rules/Recode.net.xml
@@ -1,40 +1,13 @@
 <!--
 	For other Vox Media coverage, see Vox.com.xml.
 
-
-	Insecure cookies are set for these hosts: ᶜ
-
-		- www.recode.net
-
-	ᶜ See https://owasp.org/index.php/SecureFlag
-
 -->
 <ruleset name="Recode.net (partial)">
 
 	<target host="recode.net" />
 	<target host="www.recode.net" />
 
-		<!--	Redirects to http:
-						-->
-		<!--exclusion pattern="^http://www\.recode\.net/(?:$|(?:.+/)?\d{4}/)" /-->
-		<!--
-			Exceptions:
-					-->
-		<!--exclusion pattern="^http://www\.recode\.net/(?!/*(?:authors|style|users|(topic_name))(?:$|[?/]))" /-->
-		<!--
-			Avoid potential XHR problems:
-							-->
-		<!--exclusion pattern="^http://www\.recode\.net/.+\.js(?:$|[?/])" /-->
-		<!--
-			Lessen non-Tor distinguishability:
-								-->
-		<!--exclusion pattern="^http://(?:www\.)?recode\.net/+style/" /-->
-		<!--
-			In combination:
-					-->
-		<!--exclusion pattern="^http://(?:www\.)?recode\.net/(?!(?!.+\.js(?:$|[?/]))/*(?:authors|users|(topic_name))(?:$|[?/]))" /-->
-		<exclusion pattern="^http://(?:www\.)?recode\.net/+(?:$|\?|.+\.js(?:$|[?/])|(?:.+/)?\d{4}/|style/)" />
-
+		<exclusion pattern="^http://(www\.)?recode\.net/+($|\?|.+\.js($|[?/])|(.+/)?\d{4}/|services/|style/)" />
 			<!--	+ve:
 					-->
 			<test url="http://www.recode.net/2014/11/7/11632698/introducing-recode-radio" />
@@ -48,14 +21,7 @@
 			<test url="http://www.recode.net/2016/5/19/11711126/mossberg-google-ai" />
 			<test url="http://www.recode.net/2016/5/24/11762436/toyota-uber-investment" />
 			<test url="http://www.recode.net/2016/6/14/11926704/snapchat-advertising-api" />
-			<!--
-			<test url="http://www.recode.net/2016/6/14/11933666/google-fiber-dallas" />
-			<test url="http://www.recode.net/2016/6/25/12031714/bill-cunningham-rip" />
-			<test url="http://www.recode.net/2016/6/27/12041028/tv-hours-per-week-nielsen" />
-			<test url="http://www.recode.net/2016/7/7/12116296/marissa-mayer-deal-mozilla-yahoo-payment" />
-			<test url="http://www.recode.net/2016/8/10/12419420/google-alphabet-anniversary" />
-			<test url="http://www.recode.net/2016/8/4/12379572/apple-tv-guide" />
-			-->
+			<test url="http://www.recode.net/services/user_context" />
 
 			<!--	-ve:
 					-->
@@ -68,83 +34,9 @@
 			<test url="http://www.recode.net/apple-tv" />
 			<test url="http://www.recode.net/att" />
 			<test url="http://www.recode.net/authors/elizabeth-crane" />
-			<!--
-			<test url="http://www.recode.net/authors/eric-johnson" />
-			<test url="http://www.recode.net/blackberry" />
-			<test url="http://www.recode.net/btw" />
-			<test url="http://www.recode.net/capital-gains" />
-			<test url="http://www.recode.net/comcast" />
-			<test url="http://www.recode.net/comings-and-goings" />
-			<test url="http://www.recode.net/commerce" />
-			<test url="http://www.recode.net/contact" />
-			<test url="http://www.recode.net/culture" />
-			<test url="http://www.recode.net/dell" />
-			<test url="http://www.recode.net/earnings" />
-			<test url="http://www.recode.net/education" />
-			<test url="http://www.recode.net/enterprise" />
-			<test url="http://www.recode.net/facebook" />
-			<test url="http://www.recode.net/fitness" />
-			<test url="http://www.recode.net/general" />
-			<test url="http://www.recode.net/google-news" />
-			<test url="http://www.recode.net/ibm" />
-			<test url="http://www.recode.net/ios" />
-			<test url="http://www.recode.net/ipad" />
-			<test url="http://www.recode.net/lg" />
-			<test url="http://www.recode.net/masthead" />
-			<test url="http://www.recode.net/media" />
-			<test url="http://www.recode.net/mergers-and-acquisitions" />
-			<test url="http://www.recode.net/microsoft" />
-			<test url="http://www.recode.net/mobile" />
-			<test url="http://www.recode.net/nbcu" />
-			<test url="http://www.recode.net/nest-labs" />
-			<test url="http://www.recode.net/netflix" />
-			<test url="http://www.recode.net/news" />
-			<test url="http://www.recode.net/nfl" />
-			<test url="http://www.recode.net/pandora" />
-			<test url="http://www.recode.net/pc" />
-			<test url="http://www.recode.net/podcasts" />
-			<test url="http://www.recode.net/policy" />
-			<test url="http://www.recode.net/politics" />
-			<test url="http://www.recode.net/product-news" />
-			<test url="http://www.recode.net/recode-decode-podcast-kara-swisher" />
-			<test url="http://www.recode.net/recode-media-podcast" />
-			<test url="http://www.recode.net/reviews" />
-			<test url="http://www.recode.net/robots" />
-			<test url="http://www.recode.net/roku" />
-			<test url="http://www.recode.net/samsung" />
-			<test url="http://www.recode.net/science" />
-			<test url="http://www.recode.net/security" />
-			<test url="http://www.recode.net/siri" />
-			<test url="http://www.recode.net/smartwatch" />
-			<test url="http://www.recode.net/social" />
-			<test url="http://www.recode.net/softbank" />
-			<test url="http://www.recode.net/software" />
-			<test url="http://www.recode.net/sports" />
-			<test url="http://www.recode.net/streaming" />
-			<test url="http://www.recode.net/style/1d4b45923b01ad105fd341e6de48b500/chorus.css" />
-			<test url="http://www.recode.net/t-mobile" />
-			<test url="http://www.recode.net/tv" />
-			<test url="http://www.recode.net/twitter" />
-			-->
 			<test url="http://www.recode.net/users/LaurenGoode" />
-			<!--
-			<test url="http://www.recode.net/vc" />
-			<test url="http://www.recode.net/verizon" />
-			<test url="http://www.recode.net/video" />
-			<test url="http://www.recode.net/vr" />
-			<test url="http://www.recode.net/web-video" />
-			<test url="http://www.recode.net/windows" />
-			<test url="http://www.recode.net/wireless" />
-			<test url="http://www.recode.net/yahoo" />
-			-->
-
-
-	<!--	Not secured by server:
-					-->
-	<!--securecookie host="^www\.recode\.net$" name="^_chorus_unison_testing_v4$" /-->
 
 	<securecookie host="^\." name="^(?:_gat?$|_gat_|aps-trtmnt$)" />
-
 
 	<rule from="^http:"
 		to="https:" />


### PR DESCRIPTION
This fixes https://github.com/EFForg/https-everywhere/issues/7312, removes non-capturing group markers in the exclusion, and removes some comments. For reference, #7312 seems to be caused by a CORS problem related to:

http://www.recode.net/services/optimally_sized_images?imgkeys=51313827:standard:1:268x268:jpg,51313831:standard:1:268x268:jpg,51314537:standard:1:268x268:jpg,51329485:standard:1:268x268:jpg,51331885:standard:1:268x268:jpg,51358883:*:1:235x176:jpg,51359343:*:1:235x176:jpg,51359435:*:1:235x176:jpg,51360153:*:1:235x176:jpg&asset_keys=
