### PR TITLE
Fix math.uwaterloo.ca policy

### DIFF
--- a/src/chrome/content/rules/University-of-Waterloo.xml
+++ b/src/chrome/content/rules/University-of-Waterloo.xml
@@ -29,7 +29,6 @@
 		- csclub
 		- development		( → ^)
 		- hr			(→ ^)
-		- (www.)math
 		- ripple
 
 -->
@@ -39,7 +38,7 @@
 	<target host="*.uwaterloo.ca" />
 
 
-	<rule from="^http://((?:cecspilot\.cecssys|crysp|csclub|(?:www\.)?cs|(?:www\.)?math|ripple|www)\.)?uwaterloo\.ca/"
+	<rule from="^http://((?:cecspilot\.cecssys|crysp|csclub|(?:www\.)?cs|ripple|www)\.)?uwaterloo\.ca/"
 		to="https://$1uwaterloo.ca/" />
 
 	<rule from="^http://campaign\.uwaterloo\.ca/(?=$|\?)"


### PR DESCRIPTION
http://www.math.uwaterloo.ca/tsp/pubs/ loads successfully but
https://www.math.uwaterloo.ca/tsp/pubs/ does not.
