### PR TITLE
[OpenBSD.org] Add ftp.openbsd.org. openbsd.org isn't problematic anymore.

### DIFF
--- a/src/chrome/content/rules/OpenBSD.org.xml
+++ b/src/chrome/content/rules/OpenBSD.org.xml
@@ -2,37 +2,25 @@
 	Nonfunctional hosts in *openbsd.org:
 
 		- cvsweb ²
-		- ftp, ftp.eu, ftp2.eu, &c ²
+		- ftp.eu, ftp2.eu, &c ¹²
 		- man ²
 
+	¹ Mismatched
 	² Refused
-
 
 	Problematic subdomains:
 
-		- ^ ¹
 		- firmware ¹
 		- portroach ¹
 
 	¹ Mismatched
-
 -->
 <ruleset name="OpenBSD.org (partial)">
-
-	<!--	Direct rewrites:
-				-->
+	<target host="openbsd.org" />
+	<target host="ftp.openbsd.org" />
 	<target host="lists.openbsd.org" />
 	<target host="www.openbsd.org" />
 
-	<!--	Complications:
-				-->
-	<target host="openbsd.org" />
-
-
-	<rule from="^http://openbsd\.org/"
-		to="https://www.openbsd.org/" />
-
 	<rule from="^http:"
 		to="https:" />
-
 </ruleset>


### PR DESCRIPTION
* Add `ftp.openbsd.org`.
* `openbsd.org` isn't problematic anymore.

Credit to @massoc.