### PR TITLE
[Racked.com] Default off (CORS issues). racked.com isn't problematic.

### DIFF
--- a/src/chrome/content/rules/Racked.com.xml
+++ b/src/chrome/content/rules/Racked.com.xml
@@ -1,25 +1,16 @@
 <!--
 	For other Vox Media coverage, see Vox.com.xml.
 
+	Problematic subdomains:
 
-	^racked.com: Refused
+		- www *
 
+	* CORS issues, https://github.com/EFForg/https-everywhere/issues/7381
 -->
-<ruleset name="Racked.com">
-
-	<!--	Direct rewrites:
-				-->
-	<target host="www.racked.com" />
-
-	<!--	Complications:
-				-->
+<ruleset name="Racked.com" default_off="CORS issues">
 	<target host="racked.com" />
-
-
-	<rule from="^http://racked\.com/"
-		to="https://www.racked.com/" />
+	<target host="www.racked.com" />
 
 	<rule from="^http:"
 		to="https:" />
-
 </ruleset>


### PR DESCRIPTION
- Default off (CORS issues). #7381.
- `racked.com` is no longer problematic.

So it's good news and bad news. But mostly bad news.

As i wrote in #7381, it would be possible to add an exclusion instead of turning off the ruleset entirely, but it would make the ruleset entirely useless (at least on some pages).
