### PR TITLE
Add basic ruleset for jku.at subdomains

### DIFF
--- a/src/chrome/content/rules/Jku.at.xml
+++ b/src/chrome/content/rules/Jku.at.xml
@@ -1,0 +1,10 @@
+<ruleset name="Jku.at">
+	<target host="kusss.jku.at" />
+	<target host="moodle.jku.at" />
+
+	<target host="www.pervasive.jku.at" />
+
+	<target host="ess.jku.at" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>


### PR DESCRIPTION
Adding some important subdomains of jku.at which should be used with https only.
