### PR TITLE
Exclude click.e.twitter.com from the ruleset.

### DIFF
--- a/src/chrome/content/rules/Twitter.xml
+++ b/src/chrome/content/rules/Twitter.xml
@@ -109,11 +109,7 @@
 		<test url="http://apps.twitter.com/" />
 		<test url="http://blog.twitter.com/" />
 		<test url="http://api.twitter.com/" />
-		<test url="http://cdn.api.twitter.com/" />
-		<test url="http://urls.api.twitter.com/" />
-		<test url="http://urls-real.api.twitter.com/" />
 		<test url="http://business.twitter.com/" />
-		<test url="http://cert.twitter.com/" />
 		<test url="http://dev.twitter.com/" />
 		<test url="http://engineering.twitter.com/" />
 		<test url="http://firefox.twitter.com/" />

--- a/src/chrome/content/rules/Twitter.xml
+++ b/src/chrome/content/rules/Twitter.xml
@@ -137,7 +137,7 @@
 		<test url="http://userstream.twitter.com/" />
 		<test url="http://www.twitter.com/" />
 
-		<exclusion pattern="^http://(?:status|app\.tweet|images\.tweet|click.e)\.twitter\.com/" />
+		<exclusion pattern="^http://(?:status|app\.tweet|images\.tweet|click\.e)\.twitter\.com/" />
 
 			<test url="http://status.twitter.com/" />
 			<test url="http://app.tweet.twitter.com/" />

--- a/src/chrome/content/rules/Twitter.xml
+++ b/src/chrome/content/rules/Twitter.xml
@@ -141,11 +141,12 @@
 		<test url="http://userstream.twitter.com/" />
 		<test url="http://www.twitter.com/" />
 
-		<exclusion pattern="^http://(?:status|app\.tweet|images\.tweet)\.twitter\.com/" />
+		<exclusion pattern="^http://(?:status|app\.tweet|images\.tweet|click.e)\.twitter\.com/" />
 
 			<test url="http://status.twitter.com/" />
 			<test url="http://app.tweet.twitter.com/" />
 			<test url="http://images.tweet.twitter.com/" />
+			<test url="http://click.e.twitter.com/" />
 
 
 	<!--	Not secured by server:


### PR DESCRIPTION
Fixes #7415.