### PR TITLE
Remove default_off for Proxy.org rule

### DIFF
--- a/src/chrome/content/rules/Proxy.org.xml
+++ b/src/chrome/content/rules/Proxy.org.xml
@@ -1,20 +1,4 @@
-<!--
-Disabled by https-everywhere-checker because:
-Non-2xx HTTP code: http://proxy.org/ (200) => https://proxy.org/ (403)
-	Fully covered subdomains:
-
-		- (www.)
-		- helpdesk
-
-
-	Mixed content:
-
-		- Images from ^proxy.org *
-
-	* Secured by us, doesn't trip MCB anyway
-
--->
-<ruleset name="Proxy.org" default_off='failed ruleset test'>
+<ruleset name="Proxy.org">
 
 	<target host="proxy.org" />
 	<target host="helpdesk.proxy.org" />


### PR DESCRIPTION
Seems to pass ruleset test, and works in Firefox locally.

Partial #3069 