### PR TITLE
Updated NBC ruleset

### DIFF
--- a/src/chrome/content/rules/National-Broadcasting-Company.xml
+++ b/src/chrome/content/rules/National-Broadcasting-Company.xml
@@ -5,20 +5,21 @@
 		- S-nbcnews.com.xml
 
 -->
-<ruleset name="National Broadcasting Company" default_off="mismatch">
+<ruleset name="National Broadcasting Company">
 
-	<!--	Akamai.
-			-->
+	<target host="acc-api.nbc.com" />
+	<target host="apt.nbc.com" />
+	<target host="edit.nbc.com" />
+	<target host="login.nbc.com" />
+	<target host="m.nbc.com" />
+	<target host="sportsevents.nbc.com" />
+	<target host="ssologin.nbc.com" />
+	<target host="www.nbc.com" />
 	<target host="nbc.com" />
-	<target host="*.nbc.com" />
 
+	<securecookie host="^www\.nbc\.com$" name=".+" />
 
-	<securecookie host="^(?:www)?\.nbc\.com$" name=".*" />
-
-
-	<!--	!www redirects to www.
-					-->
-	<rule from="^http://(?:www\.)?nbc\.com/"
-		to="https://www.nbc.com/" />
+	<rule from="^http:"
+		to="https:" />
 
 </ruleset>


### PR DESCRIPTION
Given the subdomains as reported by: https://www.wolframalpha.com/input/?i=nbc.com . This rule seems to be sufficient.
