### PR TITLE
Add Deviantart.com.xml

### DIFF
--- a/src/chrome/content/rules/Deviantart.com.xml
+++ b/src/chrome/content/rules/Deviantart.com.xml
@@ -1,0 +1,9 @@
+<ruleset name="Deviantart.com">
+	<target host="*.deviantart.com" />
+	<target host="www.deviantart.com" />
+
+	<test url="http://neytirix.deviantart.com/" />
+	<test url="http://welcome.deviantart.com/" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>


### PR DESCRIPTION
Left wildcard is used as seemingly arbitrary subdomains are created
based on usernames. For example, see
https://neytirix.deviantart.com/

also see issue #3069
