### PR TITLE
In HTTP Nowhere mode, attempt HTTPS before block.

### DIFF
--- a/chromium/background.js
+++ b/chromium/background.js
@@ -241,8 +241,6 @@ function onBeforeRequest(details) {
   }
 
   var potentiallyApplicable = all_rules.potentiallyApplicableRulesets(uri.hostname);
-  // If no rulesets could apply, let's get out of here!
-  if (potentiallyApplicable.size === 0) { return {cancel: shouldCancel}; }
 
   if (redirectCounter[details.requestId] >= 8) {
     log(NOTE, "Redirect counter hit for " + canonical_url);
@@ -282,6 +280,15 @@ function onBeforeRequest(details) {
   }
 
   if (httpNowhereOn) {
+    // If loading a main frame, try the HTTPS version as an alternative to
+    // failing.
+    if (shouldCancel) {
+      if (!newuristr) {
+        return {redirectUrl: canonical_url.replace(/^http:/, "https:")};
+      } else {
+        return {redirectUrl: newuristr.replace(/^http:/, "https:")};
+      }
+    }
     if (newuristr && newuristr.substring(0, 5) === "http:") {
       // Abort early if we're about to redirect to HTTP in HTTP Nowhere mode
       return {cancel: true};

--- a/src/chrome/content/code/HTTPS.js
+++ b/src/chrome/content/code/HTTPS.js
@@ -42,14 +42,22 @@ const HTTPS = {
     var blob = HTTPSRules.rewrittenURI(applicable_list, channel.URI.clone());
     var isSTS = securityService.isSecureURI(
         CI.nsISiteSecurityService.HEADER_HSTS, channel.URI, 0);
+    var uri;
     if (blob === null) {
       // Abort insecure non-onion requests if HTTP Nowhere is on
       if (httpNowhereEnabled && channel.URI.schemeIs("http") && !isSTS && !/\.onion$/.test(channel.URI.host)) {
-        IOUtil.abort(channel);
+        var newurl = channel.URI.spec.replace(/^http:/, "https:");
+        uri = CC["@mozilla.org/network/standard-url;1"].
+                    createInstance(CI.nsIStandardURL);
+        uri.init(CI.nsIStandardURL.URLTYPE_STANDARD, 443,
+                newurl, channel.URI.originCharset, null);
+        uri = uri.QueryInterface(CI.nsIURI);
+      } else {
+        return false; // no rewrite
       }
-      return false; // no rewrite
+    } else {
+      uri = blob.newuri;
     }
-    var uri = blob.newuri;
     if (!uri) this.log(WARN, "OH NO BAD ARGH\nARGH");
 
     // Abort downgrading if HTTP Nowhere is on
@@ -66,11 +74,13 @@ const HTTPS = {
     if (c2.redirectionLimit < 10) {
       this.log(WARN, "Redirection loop trying to set HTTPS on:\n  " +
       channel.URI.spec +"\n(falling back to HTTP)");
-      if (!blob.applied_ruleset) {
-        this.log(WARN,"Blacklisting rule for: " + channel.URI.spec);
-        https_everywhere_blacklist[channel.URI.spec] = true;
+      if (blob) {
+        if (!blob.applied_ruleset) {
+          this.log(WARN,"Blacklisting rule for: " + channel.URI.spec);
+          https_everywhere_blacklist[channel.URI.spec] = true;
+        }
+        https_everywhere_blacklist[channel.URI.spec] = blob.applied_ruleset;
       }
-      https_everywhere_blacklist[channel.URI.spec] = blob.applied_ruleset;
       var domain = null;
       try { domain = channel.URI.host; } catch (e) {}
       if (domain) https_blacklist_domains[domain] = true;


### PR DESCRIPTION
This applies to both main frame resources and subresource loads, though in
practice only image subresources get a chance to be rewritten, due to mixed
content blocking.

Loop detection still works, so pages that redirect back to HTTP will get caught
by that and eventually get the "cancelled by extension" message.

Fixes #2115
