### PR TITLE
Add additional Flexnow rule for ruhr-uni-bochum.de

### DIFF
--- a/src/chrome/content/rules/Ruhr-Uni-Bochum.de.xml
+++ b/src/chrome/content/rules/Ruhr-Uni-Bochum.de.xml
@@ -60,6 +60,7 @@
 	<target host="linux.rz.ruhr-uni-bochum.de" />
 	<target host="www.rz.ruhr-uni-bochum.de" />
 	<target host="www.ruhr-uni-bochum.de" />
+	<target host="fn2.flexnow.ruhr-uni-bochum.de" />
 	<target host="www.flexnow.ruhr-uni-bochum.de" />
 
 	<!--	Complications:


### PR DESCRIPTION
The system uses the `fn2.flexnow.ruhr-uni-bochum.de` domain after logging in.