### PR TITLE
Create alarabiya.net.xml

### DIFF
--- a/src/chrome/content/rules/alarabiya.net.xml
+++ b/src/chrome/content/rules/alarabiya.net.xml
@@ -1,0 +1,8 @@
+<ruleset name="Al-Arabiya">
+        <target host="alarabiya.net" />
+        <target host="www.alarabiya.net" />
+				<target host="urdu.alarabiya.net" /> 
+        
+        <rule from="^http:"
+                to="https:" />
+</ruleset>


### PR DESCRIPTION
The english.alarabiya.net seem to use https by default. enawafeth.alarabiya.net was not included because SSL_ERROR_BAD_CERT_DOMAIN error. 
https://www.ssllabs.com/ssltest/analyze.html?d=enawafeth.alarabiya.net&s=68.142.93.254&ignoreMismatch=on
https://www.ssllabs.com/ssltest/analyze.html?d=enawafeth.alarabiya.net&s=68.142.93.133&ignoreMismatch=on

Also urdu.alarabiya.net have some mixed content on page due to alarabiya.net ( https://imgur.com/YVZXO4d ), but that should be fixed by adding alarabiya.net to the list, right?