### PR TITLE
Excluded qa.sockets.stackexchange.com from Stack Exchange ruleset

### DIFF
--- a/src/chrome/content/rules/Stack-Exchange.xml
+++ b/src/chrome/content/rules/Stack-Exchange.xml
@@ -54,7 +54,11 @@
 		<test url="https://meta.unix.stackexchange.com/" />
 		<test url="https://meta.opendata.stackexchange.com/" />
 		<test url="https://blog.gaming.stackexchange.com/" />
-		
+
+		<!-- but this one should not -->
+		<exclusion pattern="^https://qa\.sockets\.stackexchange\.com/" />
+		<test url="https://qa.sockets.stackexchange.com/" />
+
 		<!-- subdomains with no https support -->
 		<exclusion pattern="^http://elections\.stackexchange\.com" />
 			<test url="http://elections.stackexchange.com/" />

--- a/src/chrome/content/rules/Stack-Exchange.xml
+++ b/src/chrome/content/rules/Stack-Exchange.xml
@@ -28,7 +28,6 @@
 	<target host="www.mathoverflow.net" />
 	
 	<!-- Serverfault -->
-	<target host="clc.serverfault.com" />
 	<target host="meta.serverfault.com" />
 	<target host="serverfault.com" />
 	


### PR DESCRIPTION
This host should not be downgraded to http, since it's a hop
to enable websockets. Close #3884

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/efforg/https-everywhere/7518)
<!-- Reviewable:end -->
