### PR TITLE
added ruleset for juwelo.de

### DIFF
--- a/src/chrome/content/rules/Juwelo.de.xml
+++ b/src/chrome/content/rules/Juwelo.de.xml
@@ -1,0 +1,15 @@
+<!--
+	Nonfunctional hosts in *.juwelo.de:
+
+	h: http redirect
+	m: certificate mismatch
+	r: connection refused
+	s: self-signed certificate
+	t: timeout on https
+-->
+<ruleset name="Juwelo.de">
+	<target host="juwelo.de" />
+	<target host="www.juwelo.de" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>


### PR DESCRIPTION
Tested with FirefoxDeveloperEdition on Mac since Firefox is disabling unsigned extensions.