### PR TITLE
Update nsICookieManager calls (#5791)

### DIFF
--- a/src/chrome/content/code/HTTPS.js
+++ b/src/chrome/content/code/HTTPS.js
@@ -161,8 +161,8 @@ const HTTPS = {
                             .getService(Components.interfaces.nsICookieManager2);
       //some braindead cookies apparently use umghzabilliontrabilions
       var expiry = Math.min(c.expiry, Math.pow(2,31));
-      cookieManager.remove(c.host, c.name, c.path, false);
-      cookieManager.add(c.host, c.path, c.name, c.value, true, c.isHTTPOnly, c.isSession, expiry);
+      cookieManager.remove(c.host, c.name, c.path, false, c.originAttributes);
+      cookieManager.add(c.host, c.path, c.name, c.value, true, c.isHTTPOnly, c.isSession, expiry, c.originAttributes);
     }
   },
   


### PR DESCRIPTION
Updated `cookieManager` calls to match the updated API.

Tested and fixes #5791 on Mac 10.12 / Firefox ESR (45), current release (49), and dev edition (51).