### PR TITLE
[ACLU of New Mexico] New ruleset

### DIFF
--- a/src/chrome/content/rules/ACLU-of-New-Mexico.xml
+++ b/src/chrome/content/rules/ACLU-of-New-Mexico.xml
@@ -4,7 +4,7 @@
 
 
 	Problematic domains:
-	- ^aclu-nm.org		(doesn't redirect properly)
+	- ^aclu-nm.org		(broken redirect, example: https://aclu-nm.org/about > https://www.aclu-nm.orgabout/)
 
 -->
 <ruleset name="ACLU of New Mexico">

--- a/src/chrome/content/rules/ACLU-of-New-Mexico.xml
+++ b/src/chrome/content/rules/ACLU-of-New-Mexico.xml
@@ -1,0 +1,21 @@
+<!--
+
+	For other ACLU coverage, see ACLU.xml
+
+
+	Problematic domains:
+	- ^aclu-nm.org		(doesn't redirect properly)
+
+-->
+<ruleset name="ACLU of New Mexico">
+
+	<target host="aclu-nm.org" />
+	<target host="www.aclu-nm.org" />
+
+	<securecookie host="^www\.aclu-nm\.org$" name=".+" />
+
+	<rule from="^http://aclu-nm\.org/"
+		to="https://www.aclu-nm.org/" />
+	<rule from="^http:" to="https:" />
+
+</ruleset>


### PR DESCRIPTION
In the ruleset, it is mentioned that `^aclu-nm.org` doesn't redirect properly. More specifically, `https://aclu-nm.org/` redirects to `https://www.aclu-nm.org`, which works. At the same time, other URLs do not redirect properly. For example, `https://aclu-nm.org/about/` redirects to `https://www.aclu-nm.orgabout` and `https://aclu-nm.org/resources/know-your-rights/` redirects to `https://www.aclu-nm.orgresources/know-your-rights/`. The redirect from `^http://aclu-nm\.org/` to `https://www.aclu-nm.org/` is intended as a workaround for this issue.