### PR TITLE
New ruleset HUP.hu

### DIFF
--- a/src/chrome/content/rules/HUP.hu.xml
+++ b/src/chrome/content/rules/HUP.hu.xml
@@ -1,17 +1,13 @@
 <!--
 	Nonfunctional hosts in *.hup.hu:
 
-	h: http redirect
 	m: certificate mismatch
+		- m.hup.hu
 		- wiki.hup.hu
-	r: connection refused
-	s: self-signed certificate
-	t: timeout on https
 -->
 <ruleset name="HUP">
 	<target host="hup.hu" />
 	<target host="www.hup.hu" />
-	<!-- <target host="wiki.hup.hu" /> m -->
 
 	<securecookie host=".+" name=".+" />
 

--- a/src/chrome/content/rules/HUP.hu.xml
+++ b/src/chrome/content/rules/HUP.hu.xml
@@ -1,0 +1,17 @@
+<!--
+	Nonfunctional hosts in *.hup.hu:
+
+	h: http redirect
+	m: certificate mismatch
+		- wiki.hup.hu
+	r: connection refused
+	s: self-signed certificate
+	t: timeout on https
+-->
+<ruleset name="HUP">
+	<target host="hup.hu" />
+	<target host="www.hup.hu" />
+	<!-- <target host="wiki.hup.hu" /> m -->
+
+	<rule from="^http:" to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/HUP.hu.xml
+++ b/src/chrome/content/rules/HUP.hu.xml
@@ -13,5 +13,7 @@
 	<target host="www.hup.hu" />
 	<!-- <target host="wiki.hup.hu" /> m -->
 
+	<securecookie host=".+" name=".+" />
+
 	<rule from="^http:" to="https:" />
 </ruleset>


### PR DESCRIPTION
Hup.hu turned on https support today. Their certificate only contains hup.hu and www.hup.hu currently.