### PR TITLE
Create zdoom.xml

### DIFF
--- a/src/chrome/content/rules/zdoom.xml
+++ b/src/chrome/content/rules/zdoom.xml
@@ -1,8 +1,12 @@
+<!--
+	Invalid certificate:
+		www.zdoom.org
+-->
 <ruleset name="ZDoom">
-        <target host="zdoom.org" />
-        <target host="forum.zdoom.org" />
-        <target host="remilia.zdoom.org" />
+	<target host="zdoom.org" />
+	<target host="forum.zdoom.org" />
+	<target host="remilia.zdoom.org" />
 
-        <rule from="^http:"
-                to="https:" />
+	<securecookie host=".+" name=".+" />
+	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/zdoom.xml
+++ b/src/chrome/content/rules/zdoom.xml
@@ -1,0 +1,8 @@
+<ruleset name="ZDoom">
+        <target host="zdoom.org" />
+        <target host="forum.zdoom.org" />
+        <target host="remilia.zdoom.org" />
+
+        <rule from="^http:"
+                to="https:" />
+</ruleset>


### PR DESCRIPTION
Adding the website zdoom.org which is now supporting HTTPS on their servers.
Contains zdoom.org, forum.zdoom.org, and remilia.zdoom.org
There is no www subdomain in the .xml because the site does not normally use the www subdomain, and it is not in the HTTPS certificate.