### PR TITLE
Update 9gag.xml and Create 9cache.com.xml

### DIFF
--- a/src/chrome/content/rules/9cache.com.xml
+++ b/src/chrome/content/rules/9cache.com.xml
@@ -1,0 +1,6 @@
+<ruleset name="9cache.com">
+  <target host="*.9cache.com" />
+
+  <rule from="^http:"
+          to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/9gag.xml
+++ b/src/chrome/content/rules/9gag.xml
@@ -38,7 +38,6 @@
 		<!--exclusion pattern="^http://m\.9gag\.com/+($|\?|gag/\w+($|\?))" /-->
 		<!--exclusion pattern="^http://m\.9gag\.com/+(?!favicon\.ico|img/|(login|recover|signup)($|\?))" /-->
 		<exclusion pattern="^http://(?:m\.|www\.)?9gag\.com/+(?!(?:about|advertise|faq|login|privacy|recover|signup|tos)(?:$|[?/])|favicon\.ico|img/)" />
-	<target host="assets-9gag-lol.9cache.com" />
   
   
 	<securecookie host="^admin\.9gag\.com$" name=".+" />
@@ -49,8 +48,5 @@
 
 	<rule from="^http://images-cdn\.9gag\.com/"
 		to="https://d24w6bsrhbeh9d.cloudfront.net/" />
-
-	<rule from="^http://assets-9gag-lol\.9cache\.com/"
-		to="https://assets-9gag-lol.9cache.com/" />
 
 </ruleset>


### PR DESCRIPTION
*.9cache.com now serves HTTPS correctly. Removed `*.9cache.com`  rules from 9gag.xml and Create 9cache.com.xml