### PR TITLE
Add people.seas.harvard.edu

### DIFF
--- a/src/chrome/content/rules/Harvard-University.xml
+++ b/src/chrome/content/rules/Harvard-University.xml
@@ -29,7 +29,6 @@
 		- news ᵈ
 		- reference.pin		(reused_issuer_and_serial)
 		- mirrors.seas ⁴
-		- people.seas ᵈ
 		- thestorymap ⁴
 		- worldmap ᵈ
 		- www.wjh ⁴
@@ -181,6 +180,7 @@
 	<target host="computefest.seas.harvard.edu" />
 	<target host="iacs.seas.harvard.edu" />
 	<target host="micro.seas.harvard.edu" />
+	<target host="people.seas.harvard.edu" />
 	<target host="robobees.seas.harvard.edu" />
 
 	<target host="shanghaicenter.harvard.edu" />


### PR DESCRIPTION
There was a comment indicating that this domain used to only accessible
over plain http, but that is no longer the case.