### PR TITLE
Ruleset for bigrock.in

### DIFF
--- a/src/chrome/content/rules/Bigrock.in.xml
+++ b/src/chrome/content/rules/Bigrock.in.xml
@@ -1,0 +1,7 @@
+<ruleset name="Bigrock.in">
+    <target host="bigrock.in" />
+    <target host="www.bigrock.in" />
+    <target host="manage.bigrock.in" />
+
+    <rule from="^http:" to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/Bigrock.in.xml
+++ b/src/chrome/content/rules/Bigrock.in.xml
@@ -1,7 +1,9 @@
 <ruleset name="Bigrock.in">
-    <target host="bigrock.in" />
-    <target host="www.bigrock.in" />
-    <target host="manage.bigrock.in" />
+	<target host="bigrock.in" />
+	<target host="www.bigrock.in" />
+	<target host="manage.bigrock.in" />
 
-    <rule from="^http:" to="https:" />
+	<securecookie host=".+" name=".+" />
+
+	<rule from="^http:" to="https:" />
 </ruleset>


### PR DESCRIPTION
Added a ruleset for a [site](https://www.bigrock.com/ "Bigrock").

This site appears to use HTTPS for the landing pages, but switches to HTTP when logged in. That is easily fixed by forcing HTTPS connections.