### PR TITLE
Create ust.hk.xml

### DIFF
--- a/src/chrome/content/rules/ust.hk.xml
+++ b/src/chrome/content/rules/ust.hk.xml
@@ -21,6 +21,7 @@
 
 		Timeout:
 			- www.bm.ust.hk
+			- teaching.ust.hk
 			- w9.ust.hk
 
 		MCB:
@@ -92,8 +93,6 @@
 	<target host="www.sengpp.ust.hk" />
 	<target host="souvenir.ust.hk" />
 	<target host="sqmail.ust.hk" />
-
-	<target host="teaching.ust.hk" />
 
 	<target host="urop.ust.hk" />
 	<target host="ustlib.ust.hk" />

--- a/src/chrome/content/rules/ust.hk.xml
+++ b/src/chrome/content/rules/ust.hk.xml
@@ -12,6 +12,7 @@
 		Unable to get local issuer certificate:
 			- w7.ab.ust.hk
 			- w8.ab.ust.hk
+			- admission.ust.hk
 			- home.cse.ust.hk
 			- lbezone.ust.hk
 			- library.ust.hk
@@ -28,7 +29,6 @@
 			- ihome.ust.hk
 -->
 <ruleset name="The Hong Kong University of Science and Technology (partial)">
-	<target host="admission.ust.hk" />
 	<target host="w3.ab.ust.hk" />
 	<target host="w5.ab.ust.hk" />
 	<test url="http://w5.ab.ust.hk/wcq/cgi-bin/1620/" />

--- a/src/chrome/content/rules/ust.hk.xml
+++ b/src/chrome/content/rules/ust.hk.xml
@@ -17,6 +17,7 @@
 
 		Timeout:
 			- w9.ust.hk
+			- www.math.ust.hk
 -->
 <ruleset name="The Hong Kong University of Science and Technology (partial)">
 	<target host="w3.ab.ust.hk" />
@@ -58,7 +59,6 @@
 
 	<target host="intranet.math.ust.hk" />
 	<target host="webwork.math.ust.hk" />
-	<target host="www.math.ust.hk" />
 	<target host="myaccount.ust.hk" />
 
 	<target host="login.psft.ust.hk" />

--- a/src/chrome/content/rules/ust.hk.xml
+++ b/src/chrome/content/rules/ust.hk.xml
@@ -21,8 +21,14 @@
 		Timeout:
 			- www.bm.ust.hk
 			- w9.ust.hk
+
+		MCB:
+			- home.cse.ust.hk
+			- home.ust.hk
+			- ihome.ust.hk
 -->
 <ruleset name="The Hong Kong University of Science and Technology (partial)">
+	<target host="admission.ust.hk" />
 	<target host="w3.ab.ust.hk" />
 	<target host="w5.ab.ust.hk" />
 	<test url="http://w5.ab.ust.hk/wcq/cgi-bin/1620/" />
@@ -84,6 +90,7 @@
 	<test url="http://sdb.science.ust.hk/mySCI/" />
 	<target host="tle.seng.ust.hk" />
 	<target host="www.sengpp.ust.hk" />
+	<target host="souvenir.ust.hk" />
 	<target host="sqmail.ust.hk" />
 
 	<target host="teaching.ust.hk" />
@@ -95,7 +102,14 @@
 
 	<target host="www.ust.hk" />
 
-	<securecookie host=".+" name=".+" />
+	<securecookie host="access\.ust\.hk$" name=".+" />
+	<securecookie host="cas\.ust\.hk$" name=".+" />
+	<securecookie host="canvas\.ust\.hk$" name=".+" />
+	<securecookie host="career\.ust\.hk$" name=".+" />
+	<securecookie host="adfs\.connect\.ust\.hk$" name=".+" />
+	<securecookie host="myaccount\.ust\.hk$" name=".+" />
+	<securecookie host="psft\.ust\.hk$" name=".+" />
+	<securecookie host="sqmail\.ust\.hk$" name=".+" />
 
 	<rule from="^http:" 
 			to="https:" />

--- a/src/chrome/content/rules/ust.hk.xml
+++ b/src/chrome/content/rules/ust.hk.xml
@@ -6,6 +6,14 @@
 			- algebra.math.ust.hk
 			- hrmsxprod.psft.ust.hk
 			- sci.success.ust.hk
+		
+		Unable to get local issuer certificate:
+			- w7.ab.ust.hk
+			- home.cse.ust.hk
+			- lbezone.ust.hk
+			- library.ust.hk
+			- search.ust.hk
+			- ss.ust.hk
 
 		Timeout:
 			- w9.ust.hk
@@ -16,7 +24,6 @@
 	<test url="http://w5.ab.ust.hk/wcq/cgi-bin/1620/" />
 	<target host="w6.ab.ust.hk" />
 	<test url="http://w6.ab.ust.hk/fbs/" />
-	<target host="w7.ab.ust.hk" />
 	<target host="www.ab.ust.hk" />
 	<target host="access.ust.hk" />
 	<target host="alumni.ust.hk" />
@@ -29,7 +36,6 @@
 	<target host="course.cse.ust.hk" />
 	<test url="http://course.cse.ust.hk/comp3711/03subarray.pdf" />
 	<target host="ftp.cse.ust.hk" />
-	<target host="home.cse.ust.hk" />
 	<target host="www.cse.ust.hk" />
 
 	<target host="download.ust.hk" />
@@ -47,9 +53,7 @@
 	<target host="lbcube.ust.hk" />
 	<target host="lbdb.ust.hk" />
 	<test url="http://lbdb.ust.hk/ce/" />
-	<target host="lbezone.ust.hk" />
 	<target host="lbjcrs.ust.hk" />
-	<target host="library.ust.hk" />
 	<target host="lists.ust.hk" />
 
 	<target host="intranet.math.ust.hk" />
@@ -64,9 +68,7 @@
 	<target host="sao.ust.hk" />
 	<target host="sdb.science.ust.hk" />
 	<test url="http://sdb.science.ust.hk/mySCI/" />
-	<target host="search.ust.hk" />
 	<target host="sqmail.ust.hk" />
-	<target host="ss.ust.hk" />
 
 	<target host="teaching.ust.hk" />
 

--- a/src/chrome/content/rules/ust.hk.xml
+++ b/src/chrome/content/rules/ust.hk.xml
@@ -1,0 +1,83 @@
+<!--
+	Non-functional hosts:
+		Invalid Certificates:
+			- connect.ust.hk
+			- o365.ust.hk
+			- algebra.math.ust.hk
+			- hrmsxprod.psft.ust.hk
+			- sci.success.ust.hk
+
+		Timeout:
+			- w9.ust.hk
+-->
+<ruleset name="The Hong Kong University of Science and Technology (partial)">
+	<target host="w3.ab.ust.hk" />
+	<target host="w5.ab.ust.hk" />
+	<test url="http://w5.ab.ust.hk/wcq/cgi-bin/1620/" />
+	<target host="w6.ab.ust.hk" />
+	<test url="http://w6.ab.ust.hk/fbs/" />
+	<target host="w7.ab.ust.hk" />
+	<target host="www.ab.ust.hk" />
+	<target host="access.ust.hk" />
+	<target host="alumni.ust.hk" />
+
+	<target host="cas.ust.hk" />
+	<target host="canvas.ust.hk" />
+	<target host="career.ust.hk" />
+	<target host="adfs.connect.ust.hk" />
+	<target host="bigdata.cse.ust.hk" />
+	<target host="course.cse.ust.hk" />
+	<test url="http://course.cse.ust.hk/comp3711/03subarray.pdf" />
+	<target host="ftp.cse.ust.hk" />
+	<target host="home.cse.ust.hk" />
+	<target host="www.cse.ust.hk" />
+
+	<target host="download.ust.hk" />
+
+	<target host="owa.exchange.ust.hk" />
+
+	<target host="ielm.ust.hk" />
+	<target host="www.ielm.ust.hk" />
+	<target host="illiad.ust.hk" />
+	<target host="itsc.ust.hk" />
+	<target host="itscapps.ust.hk" />
+
+	<target host="lbapps.ust.hk" />
+	<target host="lbbooking.ust.hk" />
+	<target host="lbcube.ust.hk" />
+	<target host="lbdb.ust.hk" />
+	<test url="http://lbdb.ust.hk/ce/" />
+	<target host="lbezone.ust.hk" />
+	<target host="lbjcrs.ust.hk" />
+	<target host="library.ust.hk" />
+	<target host="lists.ust.hk" />
+
+	<target host="intranet.math.ust.hk" />
+	<target host="webwork.math.ust.hk" />
+	<target host="www.math.ust.hk" />
+	<target host="myaccount.ust.hk" />
+
+	<target host="login.psft.ust.hk" />
+	<target host="sisprod.psft.ust.hk" />
+	<test url="https://sisprod.psft.ust.hk/psp/SISPROD/" />
+
+	<target host="sao.ust.hk" />
+	<target host="sdb.science.ust.hk" />
+	<test url="https://sdb.science.ust.hk/mySCI/" />
+	<target host="search.ust.hk" />
+	<target host="sqmail.ust.hk" />
+	<target host="ss.ust.hk" />
+
+	<target host="teaching.ust.hk" />
+
+	<target host="ustlib.ust.hk" />
+
+	<target host="video.ust.hk" />
+
+	<target host="www.ust.hk" />
+
+	<securecookie host=".+" name=".+" />
+
+	<rule from="^http:" 
+			to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/ust.hk.xml
+++ b/src/chrome/content/rules/ust.hk.xml
@@ -49,6 +49,8 @@
 	<target host="itsc.ust.hk" />
 	<target host="itscapps.ust.hk" />
 
+	<target host="join.ust.hk" />
+
 	<target host="lbapps.ust.hk" />
 	<target host="lbbooking.ust.hk" />
 	<target host="lbcube.ust.hk" />
@@ -60,7 +62,9 @@
 	<target host="intranet.math.ust.hk" />
 	<target host="webwork.math.ust.hk" />
 	<target host="myaccount.ust.hk" />
+	<target host="mystudyabroad.ust.hk" />
 
+	<target host="pg.ust.hk" />
 	<target host="login.psft.ust.hk" />
 	<target host="sisprod.psft.ust.hk" />
 	<test url="http://sisprod.psft.ust.hk/psp/SISPROD/" />
@@ -68,6 +72,7 @@
 	<target host="sao.ust.hk" />
 	<target host="sdb.science.ust.hk" />
 	<test url="http://sdb.science.ust.hk/mySCI/" />
+	<target host="www.sengpp.ust.hk" />
 	<target host="sqmail.ust.hk" />
 
 	<target host="teaching.ust.hk" />

--- a/src/chrome/content/rules/ust.hk.xml
+++ b/src/chrome/content/rules/ust.hk.xml
@@ -1,7 +1,9 @@
 <!--
 	Non-functional hosts:
 		Invalid Certificates:
+			- arr.ust.hk
 			- connect.ust.hk
+			- ias.ust.hk
 			- o365.ust.hk
 			- algebra.math.ust.hk
 			- hrmsxprod.psft.ust.hk
@@ -9,6 +11,7 @@
 		
 		Unable to get local issuer certificate:
 			- w7.ab.ust.hk
+			- w8.ab.ust.hk
 			- home.cse.ust.hk
 			- lbezone.ust.hk
 			- library.ust.hk
@@ -16,6 +19,7 @@
 			- ss.ust.hk
 
 		Timeout:
+			- www.bm.ust.hk
 			- w9.ust.hk
 -->
 <ruleset name="The Hong Kong University of Science and Technology (partial)">
@@ -27,7 +31,10 @@
 	<target host="www.ab.ust.hk" />
 	<target host="access.ust.hk" />
 	<target host="alumni.ust.hk" />
+	<target host="asset.ust.hk" />
 
+	<target host="bme.ust.hk" />
+	
 	<target host="cas.ust.hk" />
 	<target host="canvas.ust.hk" />
 	<target host="career.ust.hk" />
@@ -35,11 +42,13 @@
 	<target host="bigdata.cse.ust.hk" />
 	<target host="course.cse.ust.hk" />
 	<test url="http://course.cse.ust.hk/comp3711/03subarray.pdf" />
+	<target host="cssystem.cse.ust.hk" />
 	<target host="ftp.cse.ust.hk" />
 	<target host="www.cse.ust.hk" />
 
 	<target host="download.ust.hk" />
 
+	<target host="epst.ust.hk" />
 	<target host="owa.exchange.ust.hk" />
 
 	<target host="ielm.ust.hk" />
@@ -73,11 +82,13 @@
 	<target host="sao.ust.hk" />
 	<target host="sdb.science.ust.hk" />
 	<test url="http://sdb.science.ust.hk/mySCI/" />
+	<target host="tle.seng.ust.hk" />
 	<target host="www.sengpp.ust.hk" />
 	<target host="sqmail.ust.hk" />
 
 	<target host="teaching.ust.hk" />
 
+	<target host="urop.ust.hk" />
 	<target host="ustlib.ust.hk" />
 
 	<target host="video.ust.hk" />

--- a/src/chrome/content/rules/ust.hk.xml
+++ b/src/chrome/content/rules/ust.hk.xml
@@ -17,7 +17,6 @@
 
 		Timeout:
 			- w9.ust.hk
-			- www.math.ust.hk
 -->
 <ruleset name="The Hong Kong University of Science and Technology (partial)">
 	<target host="w3.ab.ust.hk" />
@@ -48,6 +47,7 @@
 	<target host="illiad.ust.hk" />
 	<target host="itsc.ust.hk" />
 	<target host="itscapps.ust.hk" />
+	<target host="itsm.ust.hk" />
 
 	<target host="join.ust.hk" />
 
@@ -61,6 +61,7 @@
 
 	<target host="intranet.math.ust.hk" />
 	<target host="webwork.math.ust.hk" />
+	<target host="www.math.ust.hk" />
 	<target host="myaccount.ust.hk" />
 	<target host="mystudyabroad.ust.hk" />
 

--- a/src/chrome/content/rules/ust.hk.xml
+++ b/src/chrome/content/rules/ust.hk.xml
@@ -59,11 +59,11 @@
 
 	<target host="login.psft.ust.hk" />
 	<target host="sisprod.psft.ust.hk" />
-	<test url="https://sisprod.psft.ust.hk/psp/SISPROD/" />
+	<test url="http://sisprod.psft.ust.hk/psp/SISPROD/" />
 
 	<target host="sao.ust.hk" />
 	<target host="sdb.science.ust.hk" />
-	<test url="https://sdb.science.ust.hk/mySCI/" />
+	<test url="http://sdb.science.ust.hk/mySCI/" />
 	<target host="search.ust.hk" />
 	<target host="sqmail.ust.hk" />
 	<target host="ss.ust.hk" />


### PR DESCRIPTION
Fixed the ruleset style and added more hosts from #4875. An email on the invalid certificate of https://o365.ust.hk has been sent to the university administration, I will add https://o365.ust.hk to the targets once the host is fixed. BTW, https://hrmsxprod.psft.ust.hk serves an invalid certificate and is non-functional on the default port but  a valid one on https://hrmsxprod.psft.ust.hk:8044, any clarification on whether a port specific rule should/ possibly be created #4389?