### PR TITLE
Remove NYTimes downgrade rule.

### DIFF
--- a/src/chrome/content/rules/NYTimes.xml
+++ b/src/chrome/content/rules/NYTimes.xml
@@ -243,11 +243,4 @@
 	<rule from="^http:"
 		to="https:" />
 
-	<!--	404s over https.
-
-		https://mail1.eff.org/pipermail/https-everywhere/2012-June/001448.html
-											-->
-	<rule from="^https://www\.nytimes\.com/svc/community/V3/requestHandler(?=$|\?)"
-		to="http://www.nytimes.com/svc/community/V3/requestHandler" downgrade="1" />
-
 </ruleset>

--- a/utils/downgrade-whitelist.txt
+++ b/utils/downgrade-whitelist.txt
@@ -17,7 +17,6 @@ Marktplaats (buggy)
 National Association of Theatre Owners (partial)
 NewsBlur
 Nextag (self-signed)
-NYTimes.com (needs ruleset tests)
 Oak Ridge National Laboratory (partial)
 SRG SSR (partial)
 Stack Exchange (partial)


### PR DESCRIPTION
Per NYTimes engineer, this is now causing breakage as they migrate to fully
support HTTPS.