### PR TITLE
Remove idnes.cz rules

### DIFF
--- a/src/chrome/content/rules/idnes-cz.xml
+++ b/src/chrome/content/rules/idnes-cz.xml
@@ -1,83 +1,33 @@
 <ruleset name="iDNES.cz">
 <!--
-	Problematic domains
-		Redirect to HTTP
-			- idnes.cz
-			- www.idnes.cz
-			- reality.idnes.cz
-		Broken by mixed content
-			- aplikace.idnes.cz
-			- fotbal.idnes.cz
-			- email-cio.mcafeesecure.com
-		Security warning on search
-			- hledej.idnes.cz
-		Timeout
-			- alik.idnes.cz
-			- data.idnes.cz
-			- r.idnes.cz
-		Bad certificate domain
-			- kultura.zpravy.idnes.cz
-		Unknown certificate issuer
-			- topkontakt.idnes.cz
-		Incomplete certificate chain
-			- blog.mcafeesecure.com
-		Connection error
-			- xman.idnes.cz
+    Problematic domains
+        Broken by mixed content
+            - aplikace.idnes.cz
+            - some rajce.idnes.cz sites
+            - icka.idnes.cz
+        Timeout or Connection error
+            - idnes.cz
+            - www.idnes.cz
+            - alik.idnes.cz
+            - data.idnes.cz
+            - r.idnes.cz
+            - all from *.idnes.cz except *.rajce.idnes.cz
+        Unknown certificate issuer
+            - topkontakt.idnes.cz
 -->
-	<target host="auto.idnes.cz" />
-	<target host="blog.idnes.cz" />
-	<target host="bonusweb.idnes.cz" />
-	<target host="brno.idnes.cz" />
-	<target host="budejovice.idnes.cz" />
-	<target host="bydleni.idnes.cz" />
-	<target host="cestiny.idnes.cz" />
-	<target host="cestovani.idnes.cz" />
-	<target host="doprava.idnes.cz" />
-	<target host="ekonomika.idnes.cz" />
-	<target host="finance.idnes.cz" />
-	<target host="hobby.idnes.cz" />
-	<target host="hokej.idnes.cz" />
-	<target host="icka.idnes.cz" />
-	<target host="jihlava.idnes.cz" />
-	<target host="kraje.idnes.cz" />
-	<target host="liberec.idnes.cz" />
-	<target host="mobil.idnes.cz" />
-	<target host="mobilnihry.idnes.cz" />
-	<target host="muj.idnes.cz" />
-	<target host="olomouc.idnes.cz" />
-	<target host="ona.idnes.cz" />
-	<target host="onlinehry.idnes.cz" />
-	<target host="ostrava.idnes.cz" />
-	<target host="pardubice.idnes.cz" />
-	<target host="pocasi.idnes.cz" />
-	<target host="plzen.idnes.cz" />
-	<target host="praha.idnes.cz" />
-	<target host="rajce.idnes.cz" />
-	<target host="*.rajce.idnes.cz" />
-	<target host="revue.idnes.cz" />
-	<target host="rss.idnes.cz" />
-	<target host="rungo.idnes.cz" />
-	<target host="sdeleni.idnes.cz" />
-	<target host="servis.idnes.cz" />
-	<target host="servix.idnes.cz" />
-	<target host="sport.idnes.cz" />
-	<target host="technet.idnes.cz" />
-	<target host="tvprogram.idnes.cz" />
-	<target host="usti.idnes.cz" />
-	<target host="vary.idnes.cz" />
-	<target host="vice.idnes.cz" />
-	<target host="video.idnes.cz" />
-	<target host="volby.idnes.cz" />
-	<target host="wiki.idnes.cz" />
-	<target host="zlin.idnes.cz" />
-	<target host="zpravy.idnes.cz" />
-	
-	<test url="http://www.rajce.idnes.cz/" />
-	<test url="http://martac.rajce.idnes.cz/" />
-	<test url="http://iffine.rajce.idnes.cz/" />
-	<test url="http://jiri-skrobak.rajce.idnes.cz/" />
-	<test url="http://waverka.rajce.idnes.cz/" />
 
-	<rule from="^http:"
-		  to="https:" />
+    <target host="hledej.idnes.cz" />
+    <target host="rajce.idnes.cz" />
+    <target host="*.rajce.idnes.cz" />
+
+    <test url="http://icka.idnes.cz/" />
+    <test url="http://aplikace.idnes.cz/" />
+    <test url="http://www.rajce.idnes.cz/" />
+    <test url="http://martac.rajce.idnes.cz/" />
+    <test url="http://iffine.rajce.idnes.cz/" />
+    <test url="http://jiri-skrobak.rajce.idnes.cz/" />
+    <test url="http://waverka.rajce.idnes.cz/" />
+
+    <rule from="^http:"
+          to="https:" />
 </ruleset>


### PR DESCRIPTION
idnes.cz removed https access which renders its sites unreachable with current rules.
Only rajce.idnes.cz and a few other subdomains remains accessible via https