### PR TITLE
Ruleset for cellebrite.com

### DIFF
--- a/src/chrome/content/rules/Cellebrite.com.xml
+++ b/src/chrome/content/rules/Cellebrite.com.xml
@@ -1,0 +1,8 @@
+<ruleset name="Cellebrite.com">
+	<target host="cellebrite.com" />
+	<target host="www.cellebrite.com" />
+
+	<securecookie host=".+" name=".+" />
+
+	<rule from="^http://(www\.)?cellebrite\.com/" to="https://www.cellebrite.com/" />
+</ruleset>


### PR DESCRIPTION
Added a ruleset for a [site](https://www.cellebrite.com/ "Cellebrite").

Only the "www." subdomain is protected by https, so we have to redirect to that from the bare domain.