### PR TITLE
Create FreedomDefined.org.xml

### DIFF
--- a/src/chrome/content/rules/FreedomDefined.org.xml
+++ b/src/chrome/content/rules/FreedomDefined.org.xml
@@ -1,0 +1,14 @@
+<!--
+	Definition of Free Cultural Works (freedomdefined.org)
+	
+	Known non-HTTPS host in *.freedomdefined.org:
+	
+		- www.freedomdefined.org (redirects to freedomdefined.org)
+	
+-->
+<ruleset name="FreedomDefined.org">
+	<target host="freedomdefined.org" />
+	
+	<rule from="^http:"
+		to="https:" />
+</ruleset>


### PR DESCRIPTION
This pull request enforces HTTPS on Definition of Free Cultural Works site ([freedomdefined.org](https://freedomdefined.org/)), as it is recently updated to use [ISRG Let's Encrypt](https://letsencrypt.org/).

The site is used for providing definition of free/libre (green-heading) licenses on [Creative Commons](https://creativecommons.org/), which is linked through an "Approved for Free Cultural Works" badge of each licenses on the site.