### PR TITLE
update deezer.com -> default off because it breaks the navigation links

### DIFF
--- a/src/chrome/content/rules/Deezer.xml
+++ b/src/chrome/content/rules/Deezer.xml
@@ -1,4 +1,4 @@
-<ruleset name="Deezer.com">
+<ruleset name="Deezer.com" default_off="breaks navigation links">
 
 	<!--	Direct rewrites:
 				-->


### PR DESCRIPTION
disable deezer.com rules  by default as it breaks navigation links