### PR TITLE
Delete Kuantokusta.pt.xml

### DIFF
--- a/src/chrome/content/rules/Kuantokusta.pt.xml
+++ b/src/chrome/content/rules/Kuantokusta.pt.xml
@@ -1,7 +1,0 @@
-<ruleset name="Kuantokusta.pt" platform="mixedcontent" default_off='mismatch'>
-	<target host="kuantokusta.pt" />
-	<target host="www.kuantokusta.pt" />
-
-	<rule from="^http:"
-		to="https:" />
-</ruleset>


### PR DESCRIPTION
Server now uses HTTPS with HSTS with long duration, no more need for this rule.