### PR TITLE
Update wsj.net.xml, Fix #7820

### DIFF
--- a/src/chrome/content/rules/wsj.net.xml
+++ b/src/chrome/content/rules/wsj.net.xml
@@ -13,6 +13,7 @@
 	Nonfunctional hosts in *wsj.net:
 
 		- stvquotes ³
+		- vir ³
 
 	³ 403
 
@@ -20,8 +21,7 @@
 	Problematic hosts in *wsj.net:
 
 		- images.conferences ᵐ
-		- ore ᵐ
-		- vir ᵐ
+		- wsjstream (Mixed Content Blocking)
 
 	ᵐ Mismatched
 
@@ -46,7 +46,6 @@
 	<target host="si.wsj.net" />
 	<target host="cdn.store.wsj.net" />
 	<target host="sts3.wsj.net" />
-	<target host="wsjstream.wsj.net" />
 
 		<test url="http://art-secure.wsj.net/api/photos/aee4b61b3d4d4ed6b56e6f42c50312ac/fit?width=78" />
 		<!--test url="http://asset.wsj.net/public/snippet.production-3d262e16.css" /-->
@@ -62,7 +61,6 @@
 		<test url="http://si.wsj.net/public/resources/images/BN-OA783_sugar0_Z120_20160516145348.jpg" />
 		<test url="http://cdn.store.wsj.net/252743668dc493935bcf6328389bd1006b03d211/img/000000-0.png" />
 		<test url="http://sts3.wsj.net/identity/lifp-files/static/promo/20160404/14372-WSJ-US-AprilSale-LoginScrim-598x106-25June16.jpg" />
-		<test url="http://wsjstream.wsj.net/bg2/signalr/ping?_=1483960647470" />
 	
 	<!--	Complications:
 				-->

--- a/src/chrome/content/rules/wsj.net.xml
+++ b/src/chrome/content/rules/wsj.net.xml
@@ -73,6 +73,9 @@
 			<test url="http://s.wsj.net/blogs/swf/professor.swf" />
 			<test url="http://s.wsj.net/media/swf/main.swf" />
 
+		<exclusion pattern="^http://s\.wsj\.net/video/public/" />
+			<test url="http://s.wsj.net/video/public/videocenter.min-a269c50b.css" />
+			<test url="http://s.wsj.net/video/public/vendor.min-c9c585e0.js" />
 
 	<securecookie host="^\w" name="." />
 

--- a/src/chrome/content/rules/wsj.net.xml
+++ b/src/chrome/content/rules/wsj.net.xml
@@ -47,7 +47,7 @@
 
 		<test url="http://art-secure.wsj.net/api/photos/aee4b61b3d4d4ed6b56e6f42c50312ac/fit?width=78" />
 		<!--test url="http://asset.wsj.net/public/snippet.production-3d262e16.css" /-->
-		<test url="http://fonts.wsj.com/k/qox0wee-d.css" />
+		<test url="http://fonts.wsj.net/wsj-fonts.css" />
 		<test url="http://m.wsj.net/video/20120612/061212nfl/061212nfl_115x65.jpg" />
 		<test url="http://s.wsj.net/static_html_files/pushdownAd.css" />
 		<test url="http://s1.wsj.net/img/orange_bullet.gif" />

--- a/src/chrome/content/rules/wsj.net.xml
+++ b/src/chrome/content/rules/wsj.net.xml
@@ -30,10 +30,12 @@
 
 	<!--	Direct rewrites:
 				-->
+	<target host="art.wsj.net" />
 	<target host="art-secure.wsj.net" />
 	<target host="asset.wsj.net" />
 	<target host="fonts.wsj.net" />
 	<target host="m.wsj.net" />
+	<target host="ore.wsj.net" />
 	<target host="s.wsj.net" />
 	<target host="s1.wsj.net" />
 	<target host="s2.wsj.net" />
@@ -44,6 +46,7 @@
 	<target host="si.wsj.net" />
 	<target host="cdn.store.wsj.net" />
 	<target host="sts3.wsj.net" />
+	<target host="wsjstream.wsj.net" />
 
 		<test url="http://art-secure.wsj.net/api/photos/aee4b61b3d4d4ed6b56e6f42c50312ac/fit?width=78" />
 		<!--test url="http://asset.wsj.net/public/snippet.production-3d262e16.css" /-->
@@ -59,7 +62,8 @@
 		<test url="http://si.wsj.net/public/resources/images/BN-OA783_sugar0_Z120_20160516145348.jpg" />
 		<test url="http://cdn.store.wsj.net/252743668dc493935bcf6328389bd1006b03d211/img/000000-0.png" />
 		<test url="http://sts3.wsj.net/identity/lifp-files/static/promo/20160404/14372-WSJ-US-AprilSale-LoginScrim-598x106-25June16.jpg" />
-
+		<test url="http://wsjstream.wsj.net/bg2/signalr/ping?_=1483960647470" />
+	
 	<!--	Complications:
 				-->
 	<target host="images.conferences.wsj.net" />


### PR DESCRIPTION
This closes #7820. Also fixed: this ruleset contained an invalid test url (fonts.wsj.com observed, fonts.wsj.net expected). 