### PR TITLE
Ruleset for motorola.in

### DIFF
--- a/src/chrome/content/rules/Motorola.in.xml
+++ b/src/chrome/content/rules/Motorola.in.xml
@@ -1,0 +1,8 @@
+<ruleset name="Motorola.in">
+	<target host="motorola.in" />
+	<target host="www.motorola.in" />
+
+	<securecookie host=".+" name=".+" />
+
+	<rule from="^http://(www\.)?motorola\.in/" to="https://www.motorola.in/" />
+</ruleset>


### PR DESCRIPTION
Added a ruleset for a [site](https://www.motorola.in/ "Motorola India").

Only the "www." subdomain is protected by https, so we have to redirect to that from the bare domain.