### PR TITLE
Create Gsspcln.jp.xml

### DIFF
--- a/src/chrome/content/rules/Gsspcln.jp.xml
+++ b/src/chrome/content/rules/Gsspcln.jp.xml
@@ -1,10 +1,8 @@
 <!--
 	Remark: 
 	 - *.gsspcln.jp have a wildcard DNS and a wildcard certificate
-
-	 - Since only JavaScript test URLs are found, platform="mixedcontent"
 -->
-<ruleset name="Gsspcln.jp" platform="mixedcontent">
+<ruleset name="Gsspcln.jp">
 	<target host="gsspcln.jp" />
 	<target host="*.gsspcln.jp" />
 

--- a/src/chrome/content/rules/Gsspcln.jp.xml
+++ b/src/chrome/content/rules/Gsspcln.jp.xml
@@ -1,0 +1,18 @@
+<!--
+	Remark: 
+	 - *.gsspcln.jp have a wildcard DNS and a wildcard certificate
+
+	 - Since only JavaScript test URLs are found, platform="mixedcontent"
+-->
+<ruleset name="Gsspcln.jp" platform="mixedcontent">
+	<target host="gsspcln.jp" />
+	<target host="*.gsspcln.jp" />
+
+		<test url="http://102355.gsspcln.jp/t/007/864/a1007864.js" />
+		<test url="http://1540.gsspcln.jp/sdk/t/1219.js" />
+		<test url="http://js.gsspcln.jp/l/jssdk_debug.js" />
+		<test url="http://js.gsspcln.jp/t/047/267/a1047267.js" />
+		<test url="http://js.gsspcln.jp/t/061/753/a1061753.js" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>


### PR DESCRIPTION
`*.gsspcln.jp` have a wildcard DNS record and a wildcard certificate. thanks.

Related: https://github.com/EFForg/https-everywhere/issues/3069#issuecomment-263163532, https://github.com/EFForg/https-everywhere/pull/6096.