### PR TITLE
Create CompilerDev.org.xml

### DIFF
--- a/src/chrome/content/rules/CompilerDev.org.xml
+++ b/src/chrome/content/rules/CompilerDev.org.xml
@@ -1,0 +1,17 @@
+<!--
+	Nonfunctional hosts in *.compilerdev.org:
+
+	h: http redirect
+	m: certificate mismatch
+	r: connection refused
+	s: self-signed certificate
+	t: timeout on https
+-->
+<ruleset name="CompilerDev.org">
+	<target host="compilerdev.org" />
+	<target host="www.compilerdev.org" />
+	<target host="wiki.compilerdev.org" />
+	<target host="forum.compilerdev.org" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>


### PR DESCRIPTION
The following domains should be upgraded to HTTPS:

* [compilerdev.org](https://compilerdev.org)
* [www.compilerdev.org](https://www.compilerdev.org)
* [forum.compilerdev.org](https://forum.compilerdev.org)
* [wiki.compilerdev.org](https://wiki.compilerdev.org)

Thanks.