### PR TITLE
Additional subdomain in VigLink.xml

### DIFF
--- a/src/chrome/content/rules/VigLink.xml
+++ b/src/chrome/content/rules/VigLink.xml
@@ -30,8 +30,8 @@
 	<target host="apicdn.viglink.com" />
 	<target host="cdn.viglink.com" />
 	<target host="publishers.viglink.com" />
-	<target host="www.viglink.com" />
 	<target host="redirect.viglink.com" />
+	<target host="www.viglink.com" />
 
 	<!--	Complications:
 				-->

--- a/src/chrome/content/rules/VigLink.xml
+++ b/src/chrome/content/rules/VigLink.xml
@@ -31,6 +31,7 @@
 	<target host="cdn.viglink.com" />
 	<target host="publishers.viglink.com" />
 	<target host="www.viglink.com" />
+	<target host="redirect.viglink.com" />
 
 	<!--	Complications:
 				-->


### PR DESCRIPTION
Example: `https://redirect.viglink.com/?u=http%3A%2F%2Fhyperboleandahalf.blogspot.com%2F2010%2F12%2Fyear-kenny-loggins-ruined-christmas.html&key=cfdfcf52dffd0a702a61bad27507376d`