### PR TITLE
Exclude easyjet.com/ejcms/cache15m/api/.*

### DIFF
--- a/src/chrome/content/rules/EasyJet.com.xml
+++ b/src/chrome/content/rules/EasyJet.com.xml
@@ -31,13 +31,6 @@ Non-2xx HTTP code: http://easyjet.com/ (200) => http://easyjet.com/ (403)
 	* Some pages redirect to http
 
 
-	Fully covered subdomains:
-
-		- onboarding
-		- js.sc
-		- media.sc
-
-
 	These altnames don't exist:
 
 		- sc.easyjet.com
@@ -53,18 +46,14 @@ Non-2xx HTTP code: http://easyjet.com/ (200) => http://easyjet.com/ (403)
 <ruleset name="easyJet.com (partial)" default_off='failed ruleset test'>
 
 	<target host="easyjet.com" />
-	<target host="*.easyjet.com" />
+	<target host="www.easyjet.com" />
+	<target host="onboarding.easyjet.com" />
+	<target host="js.sc.easyjet.com" />
+	<target host="media.sc.easyjet.com" />
 		<!--
-			Redirect to http:
-						-->
-		<!--exclusion pattern="^http://stafftravel\.easyjet\.com/($|en$)" /-->
-		<!--exclusion pattern="^http://www\.easyjet\.com/($|en/$|en/searchpod\.mvc/showborderless3\?)" /-->
-		<!--
-			Exceptions:
+			CORS issues:
 					-->
-		<exclusion pattern="^http://stafftravel\.easyjet\.com/+(?!asp/en/stafftravel\.asp|common/|favicon\.ico)" />
-		<!--exclusion pattern="^http://www\.easyjet\.com/+(?!Content/|ejcms/|favicon\.ico|fonts/)" /-->
-
+		<exclusion pattern="^http://(?:www\.)?easyjet\.com/ejcms/cache15m/api/" />
 
 	<rule from="^http://(?:www\.)?easyjet\.com/(?=Content/|ejcms/|favicon\.ico|fonts/)"
 		to="https://www.easyjet.com/" />


### PR DESCRIPTION
I get the following error in Chrome when this is rewritten:
XMLHttpRequest cannot load
https://www.easyjet.com/ejcms/cache15m/api/flights/search?AdminFeePerBookin…,LGW,LTN,SEN,STN&PreferredOriginIatas=LGW,LTN,SEN,STN&StartDate=2017-02-01.
Credentials flag is 'true', but the 'Access-Control-Allow-Credentials'
header is ''. It must be 'true' to allow credentials. Origin
'http://www.easyjet.com' is therefore not allowed access.

This breaks the functionality of the website.

This change also simplifies stafftravel. by explicitly listing the supported subdomains, and just not bothering with the giant exclude regex of stafftravel. which is practically excluding the whole subdomain.