### PR TITLE
Unmark norwegian.com as mixedcontent

### DIFF
--- a/src/chrome/content/rules/Norwegian.com.xml
+++ b/src/chrome/content/rules/Norwegian.com.xml
@@ -1,7 +1,17 @@
-<ruleset name="Norwegian.com" platform="mixedcontent">
-  <target host="www.norwegian.com" />
+<!--
+	Invalid:
+		annualreport.norwegian.com
+		brand.norwegian.com/
+		careers.norwegian.com
+		media.norwegian.com
+-->
+
+<ruleset name="Norwegian.com">
   <target host="norwegian.com" />
-  <rule from="^http://www\.norwegian\.com/" to="https://www.norwegian.com/"/>
-  <rule from="^http://norwegian\.com/" to="https://www.norwegian.com/"/>
+  <target host="www.norwegian.com" />
+
+  <securecookie host="^(www\.)?norwegian.com$" name=".+" />
+
+  <rule from="^http:" to="https:" />
 </ruleset>
 


### PR DESCRIPTION
In the last 3 years, the HTTPS version of the site got better.

Also simplify rule, restrict cookies, and add comment of bad subdomains.