### PR TITLE
Init new URLs with default-port of 443, not 80

### DIFF
--- a/src/chrome/content/code/HTTPSRules.js
+++ b/src/chrome/content/code/HTTPSRules.js
@@ -160,7 +160,7 @@ RuleSet.prototype = {
       return null;
     var newuri = Components.classes["@mozilla.org/network/standard-url;1"].
                  createInstance(CI.nsIStandardURL);
-    newuri.init(CI.nsIStandardURL.URLTYPE_STANDARD, 80,
+    newuri.init(CI.nsIStandardURL.URLTYPE_STANDARD, 443,
              newurl, uri.originCharset, null);
     newuri = newuri.QueryInterface(CI.nsIURI);
     return newuri;


### PR DESCRIPTION
Ref: https://github.com/EFForg/https-everywhere/pull/4221

I want this run with the new test suite setup, thus creating this new PR