### PR TITLE
Force HTTPS for Tibia forums

### DIFF
--- a/src/chrome/content/rules/tibia.com.xml
+++ b/src/chrome/content/rules/tibia.com.xml
@@ -1,4 +1,6 @@
 <ruleset name="tibia.com">
+	<securecookie host="^secure\.(test\.)?tibia\.com$" name=".+" />
+
 	<target host="www.tibia.com" />
 	<target host="forum.tibia.com" />
 	<rule from="^http://(www|forum)\.tibia\.com/" to="https://secure.tibia.com/" />
@@ -13,5 +15,4 @@
 	<target host="secure.test.tibia.com" />
 	<rule from="^http:" to="https:" />
 
-	<securecookie host="^secure\.(test\.)?tibia\.com$" name="." />
 </ruleset>

--- a/src/chrome/content/rules/tibia.com.xml
+++ b/src/chrome/content/rules/tibia.com.xml
@@ -17,7 +17,8 @@
 
 	<target host="secure.tibia.com" />
 	<target host="secure.test.tibia.com" />
-	<securecookie host="^secure\.(test\.)?tibia\.com$" name=".+" />
-	<rule from="^http:" to="https:" />
 
+	<securecookie host="^secure\.(test\.)?tibia\.com$" name=".+" />
+
+	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/tibia.com.xml
+++ b/src/chrome/content/rules/tibia.com.xml
@@ -1,0 +1,17 @@
+<ruleset name="tibia.com">
+	<target host="www.tibia.com" />
+	<target host="forum.tibia.com" />
+	<rule from="^http://(www|forum)\.tibia\.com/" to="https://secure.tibia.com/" />
+	<rule from="^http://forum\.tibia\.com/$" to="https://secure.tibia.com/forum/" />
+
+	<target host="www.test.tibia.com" />
+	<target host="forum.test.tibia.com" />
+	<rule from="^http://(www|forum)\.test\.tibia\.com/" to="https://secure.test.tibia.com/" />
+	<rule from="^http://forum\.test\.tibia\.com/$" to="https://secure.test.tibia.com/forum/" />
+
+	<target host="secure.tibia.com" />
+	<target host="secure.test.tibia.com" />
+	<rule from="^http:" to="https:" />
+
+	<securecookie host="^secure\.(test\.)?tibia\.com$" name="." />
+</ruleset>

--- a/src/chrome/content/rules/tibia.com.xml
+++ b/src/chrome/content/rules/tibia.com.xml
@@ -5,6 +5,7 @@
 		to="https://secure.tibia.com/forum/" />
 	<rule from="^http://(www|forum)\.tibia\.com/"
 		to="https://secure.tibia.com/" />
+	<test url="http://forum.tibia.com/forum/" />
 
 	<target host="www.test.tibia.com" />
 	<target host="forum.test.tibia.com" />
@@ -12,9 +13,11 @@
 		to="https://secure.test.tibia.com/forum/" />
 	<rule from="^http://(www|forum)\.test\.tibia\.com/"
 		to="https://secure.test.tibia.com/" />
+	<test url="http://forum.test.tibia.com/forum/" />
 
 	<target host="secure.tibia.com" />
 	<target host="secure.test.tibia.com" />
 	<securecookie host="^secure\.(test\.)?tibia\.com$" name=".+" />
 	<rule from="^http:" to="https:" />
+
 </ruleset>

--- a/src/chrome/content/rules/tibia.com.xml
+++ b/src/chrome/content/rules/tibia.com.xml
@@ -1,18 +1,20 @@
 <ruleset name="tibia.com">
-	<securecookie host="^secure\.(test\.)?tibia\.com$" name=".+" />
-
 	<target host="www.tibia.com" />
 	<target host="forum.tibia.com" />
-	<rule from="^http://(www|forum)\.tibia\.com/" to="https://secure.tibia.com/" />
-	<rule from="^http://forum\.tibia\.com/$" to="https://secure.tibia.com/forum/" />
+	<rule from="^http://forum\.tibia\.com/$"
+		to="https://secure.tibia.com/forum/" />
+	<rule from="^http://(www|forum)\.tibia\.com/"
+		to="https://secure.tibia.com/" />
 
 	<target host="www.test.tibia.com" />
 	<target host="forum.test.tibia.com" />
-	<rule from="^http://(www|forum)\.test\.tibia\.com/" to="https://secure.test.tibia.com/" />
-	<rule from="^http://forum\.test\.tibia\.com/$" to="https://secure.test.tibia.com/forum/" />
+	<rule from="^http://forum\.test\.tibia\.com/$"
+		to="https://secure.test.tibia.com/forum/" />
+	<rule from="^http://(www|forum)\.test\.tibia\.com/"
+		to="https://secure.test.tibia.com/" />
 
 	<target host="secure.tibia.com" />
 	<target host="secure.test.tibia.com" />
+	<securecookie host="^secure\.(test\.)?tibia\.com$" name=".+" />
 	<rule from="^http:" to="https:" />
-
 </ruleset>

--- a/src/chrome/content/rules/www.tibia.com.xml
+++ b/src/chrome/content/rules/www.tibia.com.xml
@@ -1,6 +1,0 @@
-<ruleset name="www.tibia.com">
-	<target host="www.tibia.com" />
-	<target host="www.test.tibia.com" />
-	<rule from="^http://www\.tibia\.com/" to="https://secure.tibia.com/" />
-	<rule from="^http://www\.test\.tibia\.com/" to="https://secure.test.tibia.com/" />
-</ruleset>


### PR DESCRIPTION
`http://forum.tibia.com/forum/*` is now available over HTTPS through `https://secure.tibia.com/forum/*`.