### PR TITLE
[ProtonMail Hidden Service] New ruleset

### DIFF
--- a/src/chrome/content/rules/ProtonMail.com.xml
+++ b/src/chrome/content/rules/ProtonMail.com.xml
@@ -1,6 +1,6 @@
 <!--
 	Other ProtonMail rulesets:
-		- ProtoniRockerXow.onion.xml
+		- Protonirockerxow.onion.xml
 
 	Server sends includeSubDomains in STS header.
 

--- a/src/chrome/content/rules/ProtonMail.com.xml
+++ b/src/chrome/content/rules/ProtonMail.com.xml
@@ -1,4 +1,6 @@
 <!--
+	Other ProtonMail rulesets:
+		- ProtoniRockerXow.onion.xml
 
 	Server sends includeSubDomains in STS header.
 

--- a/src/chrome/content/rules/ProtoniRockerXow.onion.xml
+++ b/src/chrome/content/rules/ProtoniRockerXow.onion.xml
@@ -1,0 +1,25 @@
+<!--
+	Other ProtonMail rulesets:
+		- ProtonMail.com.xml
+
+	This ruleset covers ProtonMail hidden services on Tor.
+	Note: This should be something like platform=tor, to indicate
+	that these rules should not go through the fetch tester on the
+	non-Tor Internet because they will fail. As an approximation to
+	that, we just use platform="mixedcontent", since Tor Browser is a
+	mixedcontent platform, and the https-everywhere-checker will skip
+	non-default platforms.
+	
+-->
+<ruleset name="ProtonMail Hidden Service" platform="mixedcontent">
+
+	<!--	Direct rewrites:
+				-->
+	<target host="protonirockerxow.onion" />
+
+	<securecookie host=".+" name=".+" />
+
+	<rule from="^http:"
+		to="https:" />
+
+</ruleset>

--- a/src/chrome/content/rules/Protonirockerxow.onion.xml
+++ b/src/chrome/content/rules/Protonirockerxow.onion.xml
@@ -2,6 +2,9 @@
 	Other ProtonMail rulesets:
 		- ProtonMail.com.xml
 
+	Invalid certificates:
+		- *.protonirockerxow.onion
+
 	This ruleset covers ProtonMail hidden services on Tor.
 	Note: This should be something like platform=tor, to indicate
 	that these rules should not go through the fetch tester on the
@@ -13,8 +16,6 @@
 -->
 <ruleset name="ProtonMail Hidden Service" platform="mixedcontent">
 
-	<!--	Direct rewrites:
-				-->
 	<target host="protonirockerxow.onion" />
 
 	<securecookie host=".+" name=".+" />


### PR DESCRIPTION
ProtonMail just launched a Tor hidden service that requires HTTPS.

https://protonmail.com/blog/tor-encrypted-email/
https://techcrunch.com/2017/01/19/protonmail-adds-tor-onion-site-to-fight-risk-of-state-censorship/
http://www.theregister.co.uk/2017/01/19/protonmail_launches_tor_hidden_service/