### PR TITLE
status.cubecraft.net fix.

### DIFF
--- a/src/chrome/content/rules/cubecraft.xml
+++ b/src/chrome/content/rules/cubecraft.xml
@@ -1,8 +1,3 @@
-<!--
-	Invalid certificate:
-		status.cubecraft.net
-
--->
 <ruleset name="CubeCraft">
 	<target host="cubecraft.net" />
 	<target host="www.cubecraft.net" />
@@ -18,9 +13,6 @@
 	<target host="store-assets.cubecraft.net" />
 
 	<securecookie host=".+" name=".+" />
-
-	<rule from="^http://status\.cubecraft\.net/"
-		to="https://cubecraft.statuspage.io/" />
 
 	<rule from="^http:" to="https:" />
 </ruleset>


### PR DESCRIPTION
Remove special case for status.cubecraft.net as its SSL cert is now valid.

Also should be HSTS preloaded in some web browsers by now, and could potentially be removed from HTTPS Everywhere. Up to you guys. - cc @jeremyn 