### PR TITLE
[#8251] Exclusion rule for sg-links.squarespace.com

### DIFF
--- a/src/chrome/content/rules/Squarespace.xml
+++ b/src/chrome/content/rules/Squarespace.xml
@@ -46,11 +46,10 @@
 		<test url="http://static.squarespace.com/universal/scripts-compressed/common-df74a0490af8af881a93-min.js" />
 		<test url="http://static.squarespace.com/universal/scripts-compressed/common-add104b2b7cce25eb854-min.js" />
 
-                <!-- see https://github.com/EFForg/https-everywhere/issues/8251 -->
-                <exclusion pattern="^http://sg-links\.squarespace\.com" />
+		<!-- see https://github.com/EFForg/https-everywhere/issues/8251 -->
+		<exclusion pattern="^http://sg-links\.squarespace\.com" />
 
-                <test url="http://sg-links.squarespace.com/wf/click?upn=randomstring" />
-
+		<test url="http://sg-links.squarespace.com/wf/click?upn=randomstring" />
 
 	<!--	Not secured by server:
 					-->

--- a/src/chrome/content/rules/Squarespace.xml
+++ b/src/chrome/content/rules/Squarespace.xml
@@ -46,6 +46,11 @@
 		<test url="http://static.squarespace.com/universal/scripts-compressed/common-df74a0490af8af881a93-min.js" />
 		<test url="http://static.squarespace.com/universal/scripts-compressed/common-add104b2b7cce25eb854-min.js" />
 
+                <!-- see https://github.com/EFForg/https-everywhere/issues/8251 -->
+                <exclusion pattern="^http://sg-links\.squarespace\.com" />
+
+                <test url="http://sg-links.squarespace.com/wf/click?upn=randomstring" />
+
 
 	<!--	Not secured by server:
 					-->


### PR DESCRIPTION
See https://github.com/EFForg/https-everywhere/issues/8251.

I disabled the chrome selenium test since selenium wasn't playing nicely on my fedora dev environment, but I tested the exclusion rule locally by building a crx, in addition to running the unit tests.