### PR TITLE
[ACLU of Arizona] New ruleset

### DIFF
--- a/src/chrome/content/rules/ACLU-of-Arizona.xml
+++ b/src/chrome/content/rules/ACLU-of-Arizona.xml
@@ -2,6 +2,9 @@
 
 	For other ACLU coverage, see ACLU.xml
 
+	Problematic domains:
+	- owa.acluaz.org	(different HTTP/HTTPS content)
+
 -->
 <ruleset name="ACLU of Arizona">
 

--- a/src/chrome/content/rules/ACLU-of-Arizona.xml
+++ b/src/chrome/content/rules/ACLU-of-Arizona.xml
@@ -1,0 +1,15 @@
+<!--
+
+	For other ACLU coverage, see ACLU.xml
+
+-->
+<ruleset name="ACLU of Arizona">
+
+	<target host="acluaz.org" />
+	<target host="www.acluaz.org" />
+
+	<securecookie host="^www\.acluaz\.org$" name=".+" />
+
+	<rule from="^http:" to="https:" />
+
+</ruleset>

--- a/src/chrome/content/rules/ACLU.xml
+++ b/src/chrome/content/rules/ACLU.xml
@@ -2,6 +2,7 @@
 
 	Other ACLU rulesets:
 
+		- ACLU-of-Arizona.xml
 		- ACLU-of-California.xml
 		- ACLU-of-Florida.xml
 		- ACLU-of-Georgia.xml


### PR DESCRIPTION
Note: There is another site, [Changing MCSO](http://www.changingmcso.org/), that is described as "An ACLU of Arizona site" but which does not support HTTPS. As of now, this site is not mentioned or included in the ruleset.