### PR TITLE
sets default_off for Sanger Institute

### DIFF
--- a/src/chrome/content/rules/Wellcome-Trust-Sanger-Institute.xml
+++ b/src/chrome/content/rules/Wellcome-Trust-Sanger-Institute.xml
@@ -1,4 +1,4 @@
-<ruleset name="Wellcome Trust Sanger Institute (partial)">
+<ruleset name="Wellcome Trust Sanger Institute (partial)" default_off="broken">
 
 	<target host="sanger.ac.uk"/>
 	<target host="www.sanger.ac.uk"/>

--- a/src/chrome/content/rules/Wellcome-Trust-Sanger-Institute.xml
+++ b/src/chrome/content/rules/Wellcome-Trust-Sanger-Institute.xml
@@ -1,4 +1,4 @@
-<ruleset name="Wellcome Trust Sanger Institute (partial)" default_off="broken">
+<ruleset name="Wellcome Trust Sanger Institute (partial)" default_off="redirects to http">
 
 	<target host="sanger.ac.uk"/>
 	<target host="www.sanger.ac.uk"/>


### PR DESCRIPTION
The Sanger institute web site is broken in various ways (the most obvious being that all icons are broken and represented by placeholder boxes) when using https everywhere.