### PR TITLE
Add PersecutionOfAhmadis.org.xml

### DIFF
--- a/src/chrome/content/rules/PersecutionOfAhmadis.org.xml
+++ b/src/chrome/content/rules/PersecutionOfAhmadis.org.xml
@@ -1,0 +1,8 @@
+<ruleset name="PersecutionOfAhmadis.org">
+	<target host="persecutionofahmadis.org" />
+	<target host="www.persecutionofahmadis.org" />
+
+	<securecookie host=".+" name=".+" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>


### PR DESCRIPTION
The mixed content blocking hides a YouTube link at the bottom of https://www.persecutionofahmadis.org, however the site itself redirects HTTP to HTTPS so at least we are not making things worse.