### PR TITLE
Remove platform="mixedcontent" for KrebsOnSecurity

### DIFF
--- a/src/chrome/content/rules/KrebsOnSecurity.com.xml
+++ b/src/chrome/content/rules/KrebsOnSecurity.com.xml
@@ -1,28 +1,16 @@
 <!--
-	Nonfunctional subdomains:
+	KrebsOnSecurity previously used s.krebsonsecurity.com for analytics,
+	but the code for that is currently commented out and the subdomain does't resolve.
 
-		- s *
-
-	* Shows ^krebsonsecurity.com
-
-
-	Mixed content:
-
-		- css from $self ¹
-		- Images from $self ¹
-		- Bug from s.krebsonsecurity.com *
-
-	¹ Secured by us
-	* Unsecurable <= 404
-
+	When it was active, it did 404 over HTTPS.
 -->
-<ruleset name="Krebs on Security.com (partial, broken MCB)" platform="mixedcontent">
+<ruleset name="Krebs on Security.com">
 
 	<target host="krebsonsecurity.com" />
 	<target host="www.krebsonsecurity.com" />
 
 
-	<securecookie host="^(?:www\.)?krebsonsecurity\.com$" name=".*" />
+	<securecookie host=".+" name=".+" />
 
 
 	<rule from="^http:"


### PR DESCRIPTION
MCB issues were resolved some time ago when the site moved  to a different DDoS mitigation provider.

This commit also changes the `<securecookie>` tag to be conformant with the style guide.