### PR TITLE
Adding support for sub-domains for KProxy.com

### DIFF
--- a/src/chrome/content/rules/KProxy.xml
+++ b/src/chrome/content/rules/KProxy.xml
@@ -1,7 +1,7 @@
 <ruleset name="KProxy.com">
 
 	<target host="kproxy.com" />
-	<target host="www.kproxy.com" />
+	<target host="*.kproxy.com" />
 	<!--	* for cross-domain cookie.	-->
 	
 

--- a/src/chrome/content/rules/KProxy.xml
+++ b/src/chrome/content/rules/KProxy.xml
@@ -5,15 +5,15 @@
 	<!--	* for cross-domain cookie.	-->
 	
 	
-	<test url="http://server1.kproxy.com" />
-	<test url="http://server2.kproxy.com" />
-	<test url="http://server3.kproxy.com" />
-	<test url="http://server4.kproxy.com" />
-	<test url="http://server5.kproxy.com" />
-	<test url="http://server6.kproxy.com" />
-	<test url="http://server7.kproxy.com" />
-	<test url="http://server8.kproxy.com" />
-	<test url="http://server9.kproxy.com" />
+	<test url="http://server1.kproxy.com/" />
+	<test url="http://server2.kproxy.com/" />
+	<test url="http://server3.kproxy.com/" />
+	<test url="http://server4.kproxy.com/" />
+	<test url="http://server5.kproxy.com/" />
+	<test url="http://server6.kproxy.com/" />
+	<test url="http://server7.kproxy.com/" />
+	<test url="http://server8.kproxy.com/" />
+	<test url="http://server9.kproxy.com/" />
 	
 
 

--- a/src/chrome/content/rules/KProxy.xml
+++ b/src/chrome/content/rules/KProxy.xml
@@ -4,6 +4,17 @@
 	<target host="*.kproxy.com" />
 	<!--	* for cross-domain cookie.	-->
 	
+	
+	<test url="http://server1.kproxy.com" />
+	<test url="http://server2.kproxy.com" />
+	<test url="http://server3.kproxy.com" />
+	<test url="http://server4.kproxy.com" />
+	<test url="http://server5.kproxy.com" />
+	<test url="http://server6.kproxy.com" />
+	<test url="http://server7.kproxy.com" />
+	<test url="http://server8.kproxy.com" />
+	<test url="http://server9.kproxy.com" />
+	
 
 
 	<!--	Observed cookie domains:


### PR DESCRIPTION
Examples: https://server1.kproxy.com/ https://server2.kproxy.com/ https://server3.kproxy.com/ https://server4.kproxy.com/ https://server5.kproxy.com/ https://server6.kproxy.com/ https://server7.kproxy.com/ https://server8.kproxy.com/ https://server9.kproxy.com/