### PR TITLE
New ruleset for Vinyl-on-demand.com, which enforces HTTPS rules incor…

### DIFF
--- a/src/chrome/content/rules/Vinyl-on-demand.com.xml
+++ b/src/chrome/content/rules/Vinyl-on-demand.com.xml
@@ -1,0 +1,15 @@
+<!--
+	Nonfunctional hosts in *.vinyl-on-demand.com:
+
+	h: http redirect
+	m: certificate mismatch
+	r: connection refused
+	s: self-signed certificate
+	t: timeout on https
+-->
+<ruleset name="Vinyl-on-demand.com">
+	<target host="vinyl-on-demand.com" />
+	<target host="www.vinyl-on-demand.com" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>


### PR DESCRIPTION
…rectly. If a user should for example click a direct non-https link to a release and purchased it, the HTTPS would never be enforced, leaving the customer details exposed. Please see comment for more info.