### PR TITLE
Reenable gametracker.com rules

### DIFF
--- a/src/chrome/content/rules/Gametracker.com.xml
+++ b/src/chrome/content/rules/Gametracker.com.xml
@@ -1,11 +1,7 @@
-<!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://image.www.gametracker.com/ => https://image.www.gametracker.com/: (60, 'SSL certificate problem: certificate has expired')
--->
-<ruleset name="Gametracker.com (partial)" default_off='failed ruleset test'>
+<ruleset name="Gametracker.com (partial)">
   <target host="www.gametracker.com"/>
   <target host="gametracker.com"/>
-  <target host="image.www.gametracker.com"/>
+  <target host="image.gametracker.com"/>
   <rule from="^http://(?:www\.)?gametracker\.com/" to="https://www.gametracker.com/"/>
-  <rule from="^http://image\.www\.gametracker\.com/" to="https://image.www.gametracker.com/"/>
+  <rule from="^http://image\.gametracker\.com/" to="https://image.gametracker.com/"/>
 </ruleset>

--- a/src/chrome/content/rules/Gametracker.com.xml
+++ b/src/chrome/content/rules/Gametracker.com.xml
@@ -1,7 +1,6 @@
-<ruleset name="Gametracker.com (partial)">
+<ruleset name="Gametracker.com">
   <target host="www.gametracker.com"/>
   <target host="gametracker.com"/>
   <target host="image.gametracker.com"/>
-  <rule from="^http://(?:www\.)?gametracker\.com/" to="https://www.gametracker.com/"/>
-  <rule from="^http://image\.gametracker\.com/" to="https://image.gametracker.com/"/>
+  <rule from="^http:" to="https:" />
 </ruleset>


### PR DESCRIPTION
A variety of TLS issues on gametracker.com have been fixed, and all endpoints now support https:// .  The old image.www.gametracker.com URL no longer exists.