### PR TITLE
Added dragonsmoke.cloud rule

### DIFF
--- a/src/chrome/content/rules/Dragonsmoke.cloud.xml
+++ b/src/chrome/content/rules/Dragonsmoke.cloud.xml
@@ -1,0 +1,15 @@
+<!--
+	Nonfunctional hosts in *.dragonsmoke.cloud:
+
+	h: http redirect
+	m: certificate mismatch
+	r: connection refused
+	s: self-signed certificate
+	t: timeout on https
+-->
+<ruleset name="Dragonsmoke.cloud">
+	<target host="dragonsmoke.cloud" />
+	<target host="www.dragonsmoke.cloud" />
+
+	<rule from="^http://(www\.)?dragonsmoke\.cloud/" to="https://www.dragonsmoke.cloud/" />
+</ruleset>


### PR DESCRIPTION
I've recently set up the web site dragonsmoke.cloud with HTTPS, so I thought I'd submit a rule for HTTPS Everywhere.