### PR TITLE
Create umontpellier.fr.xml

### DIFF
--- a/src/chrome/content/rules/umontpellier.fr.xml
+++ b/src/chrome/content/rules/umontpellier.fr.xml
@@ -10,6 +10,10 @@
 		app.umontpellier.fr (503)
 		federation.umontpellier.fr (503)
 
+	Redirect to http:
+		edu.umontpellier.fr
+		*.edu.umontpellier.fr
+
 -->
 <ruleset name="Université de Montpellier">
 
@@ -19,15 +23,6 @@
 	<target host="collections.umontpellier.fr" />
 	<target host="cs.umontpellier.fr" />
 	<target host="ebureau.umontpellier.fr" />
-
-	<target host="edu.umontpellier.fr" />
-	<target host="*.edu.umontpellier.fr" />
-
-	<!-- List of subdomains here: https://edu.umontpellier.fr/ -->
-
-		<test url="http://sciences.edu.umontpellier.fr/" />
-		<test url="http://oenologie.edu.umontpellier.fr/" />
-
 	<target host="ent.umontpellier.fr" />
 	<target host="marchefo.umontpellier.fr" />
 	<target host="mmdn.umontpellier.fr" />

--- a/src/chrome/content/rules/umontpellier.fr.xml
+++ b/src/chrome/content/rules/umontpellier.fr.xml
@@ -1,0 +1,45 @@
+<!--
+	Refused:
+		umontpellier.fr
+		www.umontpellier.fr
+		www.fde.umontpellier.fr
+		formations.umontpellier.fr
+		osipe.umontpellier.fr
+
+	No working URL known:
+		app.umontpellier.fr (503)
+		federation.umontpellier.fr (503)
+
+-->
+<ruleset name="Université de Montpellier">
+
+	<target host="assoetud.umontpellier.fr" />
+	<target host="campec.umontpellier.fr" />
+	<target host="cas.umontpellier.fr" />
+	<target host="collections.umontpellier.fr" />
+	<target host="cs.umontpellier.fr" />
+	<target host="ebureau.umontpellier.fr" />
+
+	<target host="edu.umontpellier.fr" />
+	<target host="*.edu.umontpellier.fr" />
+
+	<!-- List of subdomains here: https://edu.umontpellier.fr/ -->
+
+		<test url="http://sciences.edu.umontpellier.fr/" />
+		<test url="http://oenologie.edu.umontpellier.fr/" />
+
+	<target host="ent.umontpellier.fr" />
+	<target host="marchefo.umontpellier.fr" />
+	<target host="mmdn.umontpellier.fr" />
+	<target host="moodle.umontpellier.fr" />
+	<target host="www.moodle.umontpellier.fr" />
+	<target host="orec.umontpellier.fr" />
+	<target host="peluche.umontpellier.fr" />
+	<target host="questionnaire.umontpellier.fr" />
+	<target host="vacens.umontpellier.fr" />
+	<target host="video.umontpellier.fr" />
+	<target host="wifi.umontpellier.fr" />
+	
+	<rule from="^http:" to="https:" />
+
+</ruleset>


### PR DESCRIPTION
This is a low priority PR because as opposed to what I initially thought, most subdomains are secured by default.

The only true redirection here is for `*.edu.umontpellier.fr`.

Please note that I also skipped some subdomains that looked internal or purely make for testing purposes.