### PR TITLE
[Vancity] Add new rules due to invalid certs

### DIFF
--- a/src/chrome/content/rules/Vancity.xml
+++ b/src/chrome/content/rules/Vancity.xml
@@ -22,10 +22,14 @@
 	<target host="webmail.vancity.com" />
 	<target host="myvisaaccount.com" />
 	<target host="www.myvisaaccount.com" />
+	<target host="vancityinsurance.com" />
 	<target host="www.vancityinsurance.com" />
+	<target host="myreloadable.ca" />
 	<target host="www.myreloadable.ca" />
 
 	<securecookie host=".+" name=".+" />
 
+	<rule from="^http://vancityinsurance\.com/" to="https://www.vancityinsurance.com/" />
+	<rule from="^http://myreloadable\.ca/" to="https://www.myreloadable.ca/" />
 	<rule from="^http:" to="https:" />
 </ruleset>


### PR DESCRIPTION
See discussion at #7580.

There are invalid certificates at `https://vancityinsurance.com/` and `https://myreloadable.ca/`. But we should still redirect from `http://` to `https://www.` because the `www.` subdomains do have valid certs.

cc @J0WI 