### PR TITLE
Update Nike.com.xml

### DIFF
--- a/src/chrome/content/rules/Nike.com.xml
+++ b/src/chrome/content/rules/Nike.com.xml
@@ -139,7 +139,8 @@
 	<target host="modus.nike.com" />
 	<target host="nikeplus.nike.com" />
 	<target host="nikevideo.nike.com" />
-	<target host="store.nike.com" />
+	<!-- <target host="store.nike.com" /> breaks postMessage API
+  The target origin provided (‘http://store.nike.com’) does not match the recipient window’s origin (‘https://secure-store.nike.com’) -->
 
 		<!--exclusion pattern="^http://www\.nike\.com/+(?!apps/|content/|dat/tealeaftarget\.html|etc/|nikeos/scripts/)" /-->
 
@@ -160,8 +161,8 @@
 	<rule from="^http://nikeplus\.nike\.com/"
 		to="https://secure-nikeplus.nike.com/" />
 
-	<rule from="^http://store\.nike\.com/"
-		to="https://secure-store.nike.com/" />
+	<!-- <rule from="^http://store\.nike\.com/"
+		to="https://secure-store.nike.com/" /> breaks postMessage API -->
 
 	<rule from="^http:"
 		to="https:" />


### PR DESCRIPTION
due to store - > secure-store redirect the page breaks quite nasty 
"The target origin provided (‘http://store.nike.com’) does not match the recipient window’s origin (‘https://secure-store.nike.com’)"


The page remains frozen on some cookie warning loading - please see screenshot 

![screen shot 2017-03-06 at 17 53 51](https://cloud.githubusercontent.com/assets/5583036/23620029/e071de94-0295-11e7-83d0-b5ac4768f6dd.png)
