### PR TITLE
Exclude farmer.golang.org

### DIFF
--- a/src/chrome/content/rules/Go_Lang.org.xml
+++ b/src/chrome/content/rules/Go_Lang.org.xml
@@ -6,6 +6,7 @@
 
 	<target host="golang.org" />
 	<target host="*.golang.org" />
+	<exclusion pattern="^http://farmer.golang.org/" />
 
 		<test url="http://blog.golang.org/" />
 		<test url="http://http2.golang.org/" />


### PR DESCRIPTION
This is a public record of failed builder runs.
It uses a self-signed cert, and there is
no plan for that to change.
See the discussion at https://github.com/golang/go/issues/16442.