### PR TITLE
Delete Homecomputing.fr.xml

### DIFF
--- a/src/chrome/content/rules/Homecomputing.fr.xml
+++ b/src/chrome/content/rules/Homecomputing.fr.xml
@@ -1,7 +1,0 @@
-<ruleset name="Homecomputing.fr" default_off="self-signed">
-  <target host="homecomputing.fr" />
-  <target host="*.homecomputing.fr" />
-
-  <rule from="^http://homecomputing\.fr/" to="https://www.homecomputing.fr/"/>
-  <rule from="^http://([^@/:]*)\.homecomputing\.fr/" to="https://$1.homecomputing.fr/"/>
-</ruleset>


### PR DESCRIPTION
Website have been 404ing since late 2015 (https://web.archive.org/web/20140615000000*/http://homecomputing.fr)