### PR TITLE
[Enigmail.net] Simplify rewrite rule

### DIFF
--- a/src/chrome/content/rules/Enigmail.net.xml
+++ b/src/chrome/content/rules/Enigmail.net.xml
@@ -3,11 +3,7 @@
 	<target host="enigmail.net" />
 	<target host="www.enigmail.net" />
 
-
-	<!--	^ redirects to www over http,
-		so copy that behavior:
-					-->
-	<rule from="^http://(?:www\.)?enigmail\.net/"
-		to="https://www.enigmail.net/" />
+	<rule from="^http:"
+		to="https:" />
 
 </ruleset>


### PR DESCRIPTION
The subdomain `test.enigmail.net` seems to work over https but I am not aware of it being used anywhere yet.