### PR TITLE
Urgent: fix redirect loops for meta.*.stackexchange.com

### DIFF
--- a/src/chrome/content/rules/Stack-Exchange.xml
+++ b/src/chrome/content/rules/Stack-Exchange.xml
@@ -7,7 +7,7 @@
 
 		- www.stackapps.com ==> Mismatched
 		- mathoverflow.com ==> No response (only a redirect to mathoverflow.net anyway)
-		- meta.*.stackexchange.com ==> Mismatched
+		- meta.*.stackexchange.com ==> Mismatched (now *.meta.stackexchange.com)
 		- blog.*  ==> Mixed Active Content
 		- www.stackoverflow.blog ==> Mismatched
 
@@ -46,13 +46,16 @@
 		<test url="http://unix.stackexchange.com/" />
 		<test url="http://writers.stackexchange.com/" />
 
-		<!-- deeper domains cause certificate mismatch errors - there is also a downgrade rule below -->
-		<exclusion pattern="^http://([\w.-]+)\.([\w-]+)\.stackexchange\.com"/>
+		<!-- old child meta domains cause certificate mismatch errors -->
+		<exclusion pattern="^http://meta\.([\w-]+)\.stackexchange\.com"/>
 		<test url="http://meta.unix.stackexchange.com/" />
 		<test url="http://meta.opendata.stackexchange.com/" />
-		<test url="http://blog.gaming.stackexchange.com/" />
 		<test url="https://meta.unix.stackexchange.com/" />
 		<test url="https://meta.opendata.stackexchange.com/" />
+
+		<!-- gaming blog causes certificate mismatch errors -->
+		<exclusion pattern="^http://blog\.gaming\.stackexchange\.com"/>
+		<test url="http://blog.gaming.stackexchange.com/" />
 		<test url="https://blog.gaming.stackexchange.com/" />
 
 		<!-- but this one should not -->
@@ -138,11 +141,13 @@
 	<securecookie host="^teststackoverflow\.com$" name=".+" />
 
 <!-- Rules -->
-	
-	<!-- https links from other pages to these will cause MCB for important elements, hence the downgrades -->
-	<rule from="^https://([\w.-]+)\.([\w-]+)\.stackexchange\.com/" 
-		to="http://$1.$2.stackexchange.com/" downgrade="1" />
 
+	<!-- meta.* sites moved to *.meta - we can safely redirect to their new equivalents, which support https -->
+	<rule from="^https://meta\.([\w-]+)\.stackexchange\.com/" to="https://$1.meta.stackexchange.com/" />
+	
+	<!-- old gaming blog link does not support https -->
+	<rule from="^https://blog\.gaming\.stackexchange\.com/" to="http://blog.gaming.stackexchange.com/" downgrade="1" />
+	
 	<rule from="^http://www\.stackoverflow\.blog/" to="https://stackoverflow.blog/" />
 	
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Stack-Exchange.xml
+++ b/src/chrome/content/rules/Stack-Exchange.xml
@@ -56,7 +56,6 @@
 		<!-- gaming blog causes certificate mismatch errors -->
 		<exclusion pattern="^http://blog\.gaming\.stackexchange\.com"/>
 		<test url="http://blog.gaming.stackexchange.com/" />
-		<test url="https://blog.gaming.stackexchange.com/" />
 
 		<!-- but this one should not -->
 		<exclusion pattern="^https://qa\.sockets\.stackexchange\.com/" />
@@ -143,11 +142,9 @@
 <!-- Rules -->
 
 	<!-- meta.* sites moved to *.meta - we can safely redirect to their new equivalents, which support https -->
+	<!-- details: https://meta.stackexchange.com/questions/292058/network-wide-https-its-time -->
 	<rule from="^https://meta\.([\w-]+)\.stackexchange\.com/" to="https://$1.meta.stackexchange.com/" />
-	
-	<!-- old gaming blog link does not support https -->
-	<rule from="^https://blog\.gaming\.stackexchange\.com/" to="http://blog.gaming.stackexchange.com/" downgrade="1" />
-	
+
 	<rule from="^http://www\.stackoverflow\.blog/" to="https://stackoverflow.blog/" />
 	
 	<rule from="^http:" to="https:" />


### PR DESCRIPTION
The `meta.*.stackexchange.com` domains have moved to `*.meta.stackexchange.com` to for HTTPS support via a wildcard. This now does the appropriate redirects to the new homes. Child `blog.*.stackexchange.com` sites (actually only gaming) are unchanged and will not move...they continue to downgrade.

Long-term, we can narrow this entire rule set down to the blogs, all other domains are getting HTTPS support and HSTS headers.

This is an urgent issue since users of HTTPS Everywhere are currently getting redirect loops from us rolling out HTTPS support here. It's also my first time modifying these rulesets, if I'm doing something completely incorrectly please let me know and I'll fix it ASAP, or feel free to do so on your end, whatever fixes redirects for our combined user base faster. Thanks!

cc @bardiharborow @Bisaloo @jeremyn 