### PR TITLE
Update Cyberport.hk.xml

### DIFF
--- a/src/chrome/content/rules/Cyberport.hk.xml
+++ b/src/chrome/content/rules/Cyberport.hk.xml
@@ -84,7 +84,7 @@
 	<target host="tenantbus.cyberport.hk" />
 	<target host="webmail.cyberport.hk" />
 
-	<rule from="^http://(www\.)?cyberport\.hk/"
+	<rule from="^http://cyberport\.hk/"
 			to="https://www.cyberport.hk/" />
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Cyberport.hk.xml
+++ b/src/chrome/content/rules/Cyberport.hk.xml
@@ -77,11 +77,15 @@
 			 - vpn.cyberport.hk
 -->
 <ruleset name="Cyberport.hk (partial)">
+	<target host="cyberport.hk" />
 	<target host="www.cyberport.hk" />
 	<target host="autodiscover.cyberport.hk" />
 	<target host="eprocure.cyberport.hk" />
 	<target host="tenantbus.cyberport.hk" />
 	<target host="webmail.cyberport.hk" />
+
+	<rule from="^http://(www\.)?cyberport\.hk/"
+			to="https://www.cyberport.hk/" />
 
 	<rule from="^http:" to="https:" />
 </ruleset>


### PR DESCRIPTION
Added a new rule for `^` due to the following observation. In this case HTTPSE cannot rewrite the `www` URL and the page is loaded over plaintext connection. Related: #8973.

Firefox on Debian:
`http://cyberport.hk/ (302)` -> `http://cyberport.hk/en (301)` -> `http://www.cyberport.hk/en (200)`

Firefox on Windows 10:
`http://cyberport.hk/ (302)` -> `http://cyberport.hk/en (200)`