### PR TITLE
Remove downgrades for xkcd and dict.cc.

### DIFF
--- a/src/chrome/content/rules/Dict.cc.xml
+++ b/src/chrome/content/rules/Dict.cc.xml
@@ -122,21 +122,7 @@
 	<target host="entr.dict.cc" />
 	<target host="en-tr.dict.cc" />
 
-	<exclusion pattern="^http://[\w-]+\.dict\.cc/dict/options\.php" />
 
-	<!-- Downgrade rule is required, because website creates broken link by itself, when fetched via HTTPS -->
-	<rule from="^https://([\w-]+)\.dict\.cc/dict/options\.php"
-		to="http://$1.dict.cc/dict/options.php" downgrade="1"/>
-
-	<test url="http://www.dict.cc/dict/options.php" />
-	<test url="https://www.dict.cc/dict/options.php" />
-	<test url="http://deen.dict.cc/dict/options.php" />
-	<test url="https://deen.dict.cc/dict/options.php" />
-	<test url="http://de-en.dict.cc/dict/options.php" />
-	<test url="https://de-en.dict.cc/dict/options.php" />
-
-	<rule from="^http://dict\.cc/"
-		to="https://www.dict.cc/"/>
 	<rule from="^http:"
 		to="https:"/>
 </ruleset>

--- a/src/chrome/content/rules/xkcd.xml
+++ b/src/chrome/content/rules/xkcd.xml
@@ -75,10 +75,10 @@
 	<target host="whatif.xkcd.com" />
 	<target host="what-if.xkcd.com" />
 	<target host="www.xkcd.com" />
+	<target host="c.xkcd.com" />
 
 	<!--	Complications:
 				-->
-	<target host="c.xkcd.com" />
 	<target host="www.store.xkcd.com" />
 
 	<target host="xkcd.org" />
@@ -91,9 +91,6 @@
 		<test url="http://xkcd.com/1663/" />
 		<test url="http://m.xkcd.com/1663/" />
 		<test url="http://www.xkcd.com/1663/" />
-
-	<exclusion pattern="^http://c\.xkcd\.com/" />
-
 
 	<rule from="^http://(www\.|m\.)?xkcd\.org/"
 		to="https://$1xkcd.com/" />

--- a/src/chrome/content/rules/xkcd.xml
+++ b/src/chrome/content/rules/xkcd.xml
@@ -98,12 +98,6 @@
 	<rule from="^http://(www\.|m\.)?xkcd\.org/"
 		to="https://$1xkcd.com/" />
 
-	<rule from="^https://c\.xkcd\.com/"
-		to="http://c.xkcd.com/"
-		downgrade="1" />
-
-		<test url="https://c.xkcd.com/" />
-
 	<rule from="^http://www\.store\.xkcd\.com/"
 		to="https://store.xkcd.com/" />
 

--- a/utils/downgrade-whitelist.txt
+++ b/utils/downgrade-whitelist.txt
@@ -5,7 +5,6 @@ Cheezburger
 Contextly.com (partial)
 Craigslist.org (partial)
 dafont.com (partial)
-dict.cc
 EvoTronix (partial)
 Fourmilab (partial)
 IBTimes.co.uk
@@ -18,4 +17,3 @@ Oak Ridge National Laboratory (partial)
 SRG SSR (partial)
 Stack Exchange (partial)
 University of Alaska Anchorage (partial)
-xkcd


### PR DESCRIPTION
After testing, they are no longer needed.