### PR TITLE
Remove donate.crossorigin.me mismatch

### DIFF
--- a/src/chrome/content/rules/crossorigin.me.xml
+++ b/src/chrome/content/rules/crossorigin.me.xml
@@ -1,9 +1,3 @@
-<!--
-donate.crossorigin.me ¹
-
-
-¹ mismatch
--->
 <ruleset name="crossorigin.me">
 	<target host="crossorigin.me" />
 	<target host="www.crossorigin.me" />


### PR DESCRIPTION
The subdomain no longer exists, so including it in the file doesn't really make sense. (Source: I maintain [crossorigin.me](https://github.com/technoboy10/crossorigin.me))