### PR TITLE
Create ruleset Indapass.hu.xml (login provider)

### DIFF
--- a/src/chrome/content/rules/Indapass.hu.xml
+++ b/src/chrome/content/rules/Indapass.hu.xml
@@ -1,0 +1,20 @@
+<!--
+	Nonfunctional hosts in *.indapass.hu:
+
+	h: http redirect
+	m: certificate mismatch
+	r: connection refused
+	s: self-signed certificate
+	t: timeout on https
+-->
+<ruleset name="indapass.hu">
+	<target host="indapass.hu" />
+	<target host="www.indapass.hu" />
+	<target host="avatar.indapass.hu" />
+	<target host="daemon.indapass.hu" />
+	<target host="ident.indapass.hu" />
+	<target host="management.ident.indapass.hu" />
+	<target host="management.indapass.hu" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>


### PR DESCRIPTION
Indapass.hu is a single sign on provider of the index.hu page group. They have working SSL, but don't use it by default. (Not even for logins.)