### PR TITLE
[Roblox] Add some subdomains

### DIFF
--- a/src/chrome/content/rules/Roblox.xml
+++ b/src/chrome/content/rules/Roblox.xml
@@ -1,45 +1,66 @@
 <ruleset name="Roblox">
 	<!--
-	Those subdomains have an expired certificate:
-
-	- bloxcon.roblox.com
-
 	Those subdomains do not support encryption:
 
+	- de.roblox.com
+	- developer.roblox.com
 	- devforum.roblox.com
+	- es.roblox.com
+	- fr.roblox.com
 	- mail.roblox.com
+	- pt.roblox.com
 	- shop.roblox.com
 	- uk.roblox.com
-	- de.roblox.com
+	- wiki.roblox.com
 
 	Those subdomains have a certificate only valid for other domain names:
 
-	- blog.roblox.com
-	- corp.roblox.com
 	- help.roblox.com
 	- js.roblox.com
 	- polls.roblox.com
 	- setup.roblox.com
 	- social.roblox.com
-	- wiki.roblox.com
 
 	content.roblox.com supports encryption with a valid certificate, but
 	returns invalid responses with and without encryption.
 	-->
 
 	<target host="roblox.com" />
+	<target host="abuse.roblox.com" />
+	<target host="affiliates.roblox.com" />
 	<target host="api.roblox.com" />
 	<target host="*.api.roblox.com" />
 	<target host="assetgame.roblox.com" />
+	<target host="auth.roblox.com" />
+	<target host="avatar.roblox.com" />
+	<target host="blog.roblox.com" />
+	<target host="bloxcon.roblox.com" />
+	<target host="careers.roblox.com" />
 	<target host="chat.roblox.com" />
+	<target host="community.roblox.com" />
+	<target host="confluence.roblox.com" />
+	<target host="corp.roblox.com" />
 	<target host="data.roblox.com" />
+	<target host="develop.roblox.com" />
 	<target host="ecsv2.roblox.com" />
 	<target host="en.help.roblox.com" />
 	<target host="forum.roblox.com" />
+	<target host="gamepersistence.roblox.com" />
+	<target host="inventory.roblox.com" />
+	<target host="jira.roblox.com" />
+	<target host="job.roblox.com" />
+	<target host="jobs.roblox.com" />
 	<target host="m.roblox.com" />
+	<target host="misc.roblox.com" />
+	<target host="news.roblox.com" />
+	<target host="nl.roblox.com" />
 	<target host="notifications.roblox.com" />
+	<target host="partners.roblox.com" />
+	<target host="publish.roblox.com" />
 	<target host="realtime.roblox.com" />
+	<target host="sales.roblox.com" />
 	<target host="search.roblox.com" />
+	<target host="static.roblox.com" />
 	<target host="web.roblox.com" />
 	<target host="www.roblox.com" />
 	<target host="*.rbxcdn.com" />
@@ -49,9 +70,12 @@
 	<test url="http://api.roblox.com/docs" />
 	<test url="http://assetgame.roblox.com/Asset/" />
 	<test url="http://clientsettings.api.roblox.com/" />
+	<test url="http://confluence.roblox.com/login.action" />
 	<test url="http://ephemeralcounters.api.roblox.com/" />
 	<test url="http://forum.roblox.com/forum/" />
+	<test url="http://jira.roblox.com/secure/Dashboard.jspa" />
 	<test url="http://m.roblox.com/login" />
+	<test url="http://nl.roblox.com/Catalog" />
 	<test url="http://www.roblox.com/Catalog/" />
 	<test url="http://web.roblox.com/Catalog/" />
 


### PR DESCRIPTION
The subdomains blog.roblox.com and corp.roblox.com support HTTPS, as do a few other subdomains.