### PR TITLE
[Mailinator.com] Update rewrite rules

### DIFF
--- a/src/chrome/content/rules/Mailinator.com.xml
+++ b/src/chrome/content/rules/Mailinator.com.xml
@@ -7,20 +7,13 @@
 
 -->
 <ruleset name="Mailinator.com">
+
 	<target host="mailinator.com" />
 	<target host="*.mailinator.com" />
 
 	<securecookie host="^(?:www\.)?mailinator\.com$" name=".+" />
 
-	<rule from="^http://(www\.)?mailinator\.com/"
-			to="https://$1mailinator.com/" />
-		<test url="http://mailinator.com/" />
-		<test url="http://www.mailinator.com/" />
+	<rule from="^http:"
+		to="https:" />
 
-	<!-- foo.mailinator.com -> https://www.mailinator.com/inbox.jsp?to=foo -->
-	<rule from="^http://([\w-]+)\.mailinator\.com/"
-			to="https://www.mailinator.com/inbox.jsp?to=$1" />
-		<test url="http://foo.mailinator.com/" />
-		<test url="http://bar.mailinator.com/" />
-		<test url="http://foobar.mailinator.com/" />
 </ruleset>

--- a/src/chrome/content/rules/Mailinator.com.xml
+++ b/src/chrome/content/rules/Mailinator.com.xml
@@ -2,11 +2,11 @@
 
 	<target host="mailinator.com" />
 	<target host="*.mailinator.com" />
-	<!-- All subdomains are valid and redirect to 
-		https://www.mailinator.com/ -->
-		<test url="http://testurl1.mailinator.com" />
-		<test url="http://testurl2.mailinator.com" />
-		<test url="http://testurl3.mailinator.com" />
+	<!-- All subdomains are valid and
+		mirror https://www.mailinator.com/ -->
+		<test url="http://testurl1.mailinator.com/" />
+		<test url="http://testurl2.mailinator.com/" />
+		<test url="http://testurl3.mailinator.com/" />
 
 	<securecookie host="^(?:www\.)?mailinator\.com$" name=".+" />
 

--- a/src/chrome/content/rules/Mailinator.com.xml
+++ b/src/chrome/content/rules/Mailinator.com.xml
@@ -10,6 +10,11 @@
 
 	<target host="mailinator.com" />
 	<target host="*.mailinator.com" />
+	<!-- All subdomains are valid and redirect to 
+		https://www.mailinator.com/ -->
+		<test url="http://testurl1.mailinator.com" />
+		<test url="http://testurl2.mailinator.com" />
+		<test url="http://testurl3.mailinator.com" />
 
 	<securecookie host="^(?:www\.)?mailinator\.com$" name=".+" />
 

--- a/src/chrome/content/rules/Mailinator.com.xml
+++ b/src/chrome/content/rules/Mailinator.com.xml
@@ -1,11 +1,3 @@
-<!--
-	Mixed content:
-
-		- css on www from fonts.googleapis.com *
-
-	* Secured by us
-
--->
 <ruleset name="Mailinator.com">
 
 	<target host="mailinator.com" />


### PR DESCRIPTION
I left the wildcard on purpose because I would argue that in this case, it is adequate.

- The website is secured by a wildcard certificate `*.mailinator.com`
- It looks like the website is configured so that any subdomain is a valid mirror of https://www.mailinator.com. For example, I tried https://idk.mailinator.com/ and https://thatsaninterestingbehaviour.mailinator.com/ and they work fine.