### PR TITLE
Don't redirect bookshop.europa.eu/uri

### DIFF
--- a/src/chrome/content/rules/Europa.eu.xml
+++ b/src/chrome/content/rules/Europa.eu.xml
@@ -193,8 +193,12 @@
 		<!--	Redirects to http:
 						-->
 		<!--exclusion pattern="^http://ec\.europa\.eu/index_en.htm /-->
+		<exclusion pattern="^http://bookshop\.europa\.eu/uri" />
 		<!--
-			404:
+			
+
+
+:
 					-->
 		<!--exclusion pattern="^http://ec\.europa\.eu/(?:ec_portal/(?:2016/images|stylesheets)/|growth/$|growth/contact/index_\w\w\.htm||index_\w\w\.htm|programmes/$|growth/tools-databases/newsroom/cf/_getimage\.cfm\?doc_id=)" /-->
 		<!--


### PR DESCRIPTION
The /uri path is only served over HTTP and gives a 404 over HTTP.
http://dx.doi.org/10.2759/949874 redirect to a working
http://bookshop.europa.eu/uri?target=EUB:NOTICE:KK0417206:EN:HTML
but
https://bookshop.europa.eu/uri?target=EUB:NOTICE:KK0417206:EN:HTML
gives
> Sorry!
> The page you are looking for could not be found.