### PR TITLE
Politico rules

### DIFF
--- a/src/chrome/content/rules/Politico.xml
+++ b/src/chrome/content/rules/Politico.xml
@@ -38,7 +38,8 @@
 	ˢ Secured by us, see https://www.paulirish.com/2010/the-protocol-relative-url/
 
 -->
-<ruleset name="Politico.com (partial)">
+<ruleset name="Politico.com (partial)"
+	default_off="site breaks">
 
 	<!--	Direct rewrites:
 				-->

--- a/src/chrome/content/rules/Politico_Pro.com.xml
+++ b/src/chrome/content/rules/Politico_Pro.com.xml
@@ -10,7 +10,8 @@
 	ᶜ See https://owasp.org/index.php/SecureFlag
 
 -->
-<ruleset name="Politico Pro.com">
+<ruleset name="Politico Pro.com"
+	default_off="site breaks">
 
 	<target host="politicopro.com" />
 	<target host="images.politicopro.com" />


### PR DESCRIPTION
Politico core and politico pro sites don't yet support https connections, we've received a number of user complaints that our site is breaking accordingly