### PR TITLE
[Wired.co.uk] Add subdomains

### DIFF
--- a/src/chrome/content/rules/wired.co.uk.xml
+++ b/src/chrome/content/rules/wired.co.uk.xml
@@ -7,15 +7,29 @@
 		- s3.amazonaws.com/img.wired.co.uk/	| d2f0ban6dhfdsw.cloudfront.net
 			- AWS permanently redirects.
 
+	Refused:
+		wired.co.uk
+
+	Invalid certificate:
+		cdni.wired.co.uk
+
+	No working URL known:
+		app.wired.co.uk
+
 -->
 <ruleset name="Wired.co.uk (partial)">
 
-	<!--	Complications:
-				-->
+	<target host="wired.co.uk" />
+	<target host="www.wired.co.uk" />
 	<target host="cdni.wired.co.uk" />
 
+	<rule from="^http://wired\.co\.uk/"
+		to="https://www.wired.co.uk/" />
 
 	<rule from="^http://cdni\.wired\.co\.uk/"
 		to="https://d2f0ban6dhfdsw.cloudfront.net/" />
+	
+	<rule from="^http:"
+		to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/wired.co.uk.xml
+++ b/src/chrome/content/rules/wired.co.uk.xml
@@ -17,7 +17,7 @@
 		app.wired.co.uk
 
 -->
-<ruleset name="Wired.co.uk (partial)">
+<ruleset name="Wired.co.uk">
 
 	<target host="wired.co.uk" />
 	<target host="www.wired.co.uk" />


### PR DESCRIPTION
I have no idea whether the subdomain `cdni.wired.co.uk` is still used. I couldn't find it in the website source.