### PR TITLE
[Pastebin.com] Update ruleset after site update

### DIFF
--- a/src/chrome/content/rules/Pastebin.com.xml
+++ b/src/chrome/content/rules/Pastebin.com.xml
@@ -1,26 +1,10 @@
-<!--
-	NB: Tor users cannot view* this website due to CloudFlare settings.
-
-	See:
-
-		- https://blog.torproject.org/blog/call-arms-helping-internet-services-accept-anonymous-users
-		- https://support.cloudflare.com/hc/en-us/articles/203306930-Does-CloudFlare-block-Tor-
-		- https://support.cloudflare.com/hc/en-us/articles/200170206-How-do-I-turn-I-m-Under-Attack-mode-on-
-
-	* without enabling javascript, for security and privacy implications see e.g.:
-
-		- https://www.mozilla.org/security/known-vulnerabilities/firefox.html
-		- https://trac.torproject.org/projects/tor/query?status=!closed&keywords=~tbb-fingerprinting
-		- https://panopticlick.eff.org
-
--->
 <ruleset name="Pastebin.com (buggy)" default_off="breaks CSS on pastes">
 
 	<target host="pastebin.com" />
 	<target host="www.pastebin.com" />
+	<target host="deals.pastebin.com" />
 
-
-	<rule from="^http://(www\.)?pastebin\.com/(?=adserver/|cache/|etc/|favicon\.ico|i/|raw\.php)"
-		to="https://$1pastebin.com/" />
+	<rule from="^http:"
+		to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Pastebin.com.xml
+++ b/src/chrome/content/rules/Pastebin.com.xml
@@ -1,4 +1,4 @@
-<ruleset name="Pastebin.com (buggy)" default_off="breaks CSS on pastes">
+<ruleset name="Pastebin.com">
 
 	<target host="pastebin.com" />
 	<target host="www.pastebin.com" />


### PR DESCRIPTION
Pastebin has apparently gone through an update (not sure when...) and:

- https is now enabled by default
- Tor users are not blocked by cloudflare anymore

