### PR TITLE
[Yale.edu] Add e360.yale.edu

### DIFF
--- a/src/chrome/content/rules/Yale_University.xml
+++ b/src/chrome/content/rules/Yale_University.xml
@@ -31,8 +31,8 @@
 -->
 <ruleset name="Yale.edu (partial)">
 
-	<!--	Direct rewrites:
-				-->
+	<target host="e360.yale.edu" />
+	
 	<target host="affiliate.law.yale.edu" />
 	<target host="fa.law.yale.edu" />
 	<target host="inside.law.yale.edu" />


### PR DESCRIPTION
**This is not a complete update of the `Yale.edu` ruleset. I simply noticed a subdomain that can and therefore should be secured.**