### PR TITLE
Create Element14.com.xml

### DIFF
--- a/src/chrome/content/rules/Element14.com.xml
+++ b/src/chrome/content/rules/Element14.com.xml
@@ -1,0 +1,50 @@
+<!--
+	Non-functional hosts
+		Timeout was reached:
+			 - click.e-marketing.element14.com
+			 - mta.e-marketing.element14.com
+			 - view.e-marketing.element14.com
+			 - www.in.ftprdap.element14.com
+
+		SSL peer certificate was not OK:
+			 - m.element14.com
+			 - metrics.element14.com
+			 - us.element14.com
+
+		Peer certificate cannot be authenticated with given CA certificates:
+			 - downloads.element14.com
+			 - piregistration.element14.com
+
+		Incomplete certificate chain error:
+			 - planet.element14.com
+
+		Status code mismatch:
+			 - files1beta.element14.com
+
+		Secure connection redirects to plaintext:
+			 - partner.element14.com
+-->
+<ruleset name="Element14.com (partial)">
+	<target host="element14.com" />
+	<target host="www.element14.com" />
+	<target host="api.element14.com" />
+		<test url="http://api.element14.com/pffind/services/SearchService?wsdl" />
+	<target host="au.element14.com" />
+	<target host="beta.element14.com" />
+	<target host="cn.element14.com" />
+	<target host="files1.element14.com" />
+		<test url="http://files1.element14.com/community/docs/DOC-29408/l/kntsk60fmlyfact-sheetpdf" />
+		<test url="http://files1.element14.com/community/docs/DOC-25813/l/%E7%94%B5%E7%BC%86%E4%B8%8E%E8%BF%9E%E6%8E%A5%E5%99%A8-%E4%BA%8C-pdf" />
+	<target host="hk.element14.com" />
+	<target host="in.element14.com" />
+	<target host="kr.element14.com" />
+	<target host="my.element14.com" />
+	<target host="nz.element14.com" />
+	<target host="ph.element14.com" />
+	<target host="sg.element14.com" />
+	<target host="smetrics.element14.com" />
+	<target host="th.element14.com" />
+	<target host="tw.element14.com" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/Element14.com.xml
+++ b/src/chrome/content/rules/Element14.com.xml
@@ -22,9 +22,6 @@
 			 - files1.element14.com
 			 - files1beta.element14.com
 
-		Secure connection redirects to plaintext:
-			 - partner.element14.com
-
 		Inconsistent behavior on Travis:
 			 - au.element14.com
 			 - cn.element14.com
@@ -44,6 +41,9 @@
 	<target host="api.element14.com" />
 		<test url="http://api.element14.com/pffind/services/SearchService?wsdl" />
 	<target host="beta.element14.com" />
+	<target host="partner.element14.com" />
+		<test url="http://partner.element14.com/files/eagle-software-box-small.jpg" />
+		<test url="http://partner.element14.com/files/analytics.js" />
 
 	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Element14.com.xml
+++ b/src/chrome/content/rules/Element14.com.xml
@@ -20,6 +20,7 @@
 
 		Status code mismatch:
 			 - au.element14.com
+			 - cn.element14.com
 			 - files1.element14.com
 			 - files1beta.element14.com
 
@@ -32,7 +33,6 @@
 	<target host="api.element14.com" />
 		<test url="http://api.element14.com/pffind/services/SearchService?wsdl" />
 	<target host="beta.element14.com" />
-	<target host="cn.element14.com" />
 	<target host="hk.element14.com" />
 	<target host="in.element14.com" />
 	<target host="kr.element14.com" />

--- a/src/chrome/content/rules/Element14.com.xml
+++ b/src/chrome/content/rules/Element14.com.xml
@@ -25,7 +25,6 @@
 
 		Secure connection redirects to plaintext:
 			 - partner.element14.com
-
 -->
 <ruleset name="Element14.com (partial)">
 	<target host="element14.com" />

--- a/src/chrome/content/rules/Element14.com.xml
+++ b/src/chrome/content/rules/Element14.com.xml
@@ -25,7 +25,7 @@
 		Secure connection redirects to plaintext:
 			 - partner.element14.com
 
-		Inconsistent behavior:
+		Inconsistent behavior on Travis:
 			 - au.element14.com
 			 - cn.element14.com
 			 - in.element14.com

--- a/src/chrome/content/rules/Element14.com.xml
+++ b/src/chrome/content/rules/Element14.com.xml
@@ -23,6 +23,7 @@
 
 		Secure connection redirects to plaintext:
 			 - partner.element14.com
+
 -->
 <ruleset name="Element14.com (partial)">
 	<target host="element14.com" />

--- a/src/chrome/content/rules/Element14.com.xml
+++ b/src/chrome/content/rules/Element14.com.xml
@@ -19,14 +19,24 @@
 			 - planet.element14.com
 
 		Status code mismatch:
-			 - au.element14.com
-			 - cn.element14.com
-			 - in.element14.com
 			 - files1.element14.com
 			 - files1beta.element14.com
 
 		Secure connection redirects to plaintext:
 			 - partner.element14.com
+
+		Inconsistent behavior:
+			 - au.element14.com
+			 - cn.element14.com
+			 - in.element14.com
+			 - hk.element14.com
+			 - kr.element14.com
+			 - my.element14.com
+			 - nz.element14.com
+			 - ph.element14.com
+			 - sg.element14.com
+			 - th.element14.com
+			 - tw.element14.com
 -->
 <ruleset name="Element14.com (partial)">
 	<target host="element14.com" />
@@ -34,15 +44,6 @@
 	<target host="api.element14.com" />
 		<test url="http://api.element14.com/pffind/services/SearchService?wsdl" />
 	<target host="beta.element14.com" />
-	<target host="hk.element14.com" />
-	<target host="kr.element14.com" />
-	<target host="my.element14.com" />
-	<target host="nz.element14.com" />
-	<target host="ph.element14.com" />
-	<target host="sg.element14.com" />
-	<target host="smetrics.element14.com" />
-	<target host="th.element14.com" />
-	<target host="tw.element14.com" />
 
 	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Element14.com.xml
+++ b/src/chrome/content/rules/Element14.com.xml
@@ -21,6 +21,7 @@
 		Status code mismatch:
 			 - au.element14.com
 			 - cn.element14.com
+			 - in.element14.com
 			 - files1.element14.com
 			 - files1beta.element14.com
 
@@ -34,7 +35,6 @@
 		<test url="http://api.element14.com/pffind/services/SearchService?wsdl" />
 	<target host="beta.element14.com" />
 	<target host="hk.element14.com" />
-	<target host="in.element14.com" />
 	<target host="kr.element14.com" />
 	<target host="my.element14.com" />
 	<target host="nz.element14.com" />

--- a/src/chrome/content/rules/Element14.com.xml
+++ b/src/chrome/content/rules/Element14.com.xml
@@ -19,6 +19,8 @@
 			 - planet.element14.com
 
 		Status code mismatch:
+			 - au.element14.com
+			 - files1.element14.com
 			 - files1beta.element14.com
 
 		Secure connection redirects to plaintext:
@@ -30,12 +32,8 @@
 	<target host="www.element14.com" />
 	<target host="api.element14.com" />
 		<test url="http://api.element14.com/pffind/services/SearchService?wsdl" />
-	<target host="au.element14.com" />
 	<target host="beta.element14.com" />
 	<target host="cn.element14.com" />
-	<target host="files1.element14.com" />
-		<test url="http://files1.element14.com/community/docs/DOC-29408/l/kntsk60fmlyfact-sheetpdf" />
-		<test url="http://files1.element14.com/community/docs/DOC-25813/l/%E7%94%B5%E7%BC%86%E4%B8%8E%E8%BF%9E%E6%8E%A5%E5%99%A8-%E4%BA%8C-pdf" />
 	<target host="hk.element14.com" />
 	<target host="in.element14.com" />
 	<target host="kr.element14.com" />

--- a/src/chrome/content/rules/Element14.com.xml
+++ b/src/chrome/content/rules/Element14.com.xml
@@ -45,5 +45,5 @@
 		<test url="http://partner.element14.com/files/eagle-software-box-small.jpg" />
 		<test url="http://partner.element14.com/files/analytics.js" />
 
-	<rule from="^http:" to="https:" />
+	<!-- <rule from="^http:" to="https:" /> do not merge yet --> 
 </ruleset>


### PR DESCRIPTION
Related: #3069, #4073, #4224 . 

Remark: 
 - `au.element14.com`, `cn.element14.com`, `in.element14.com` etc do not pass the Travis build because of the different status codes, however, I cannot reproduce this issue using `curl` in the command line. (why?) 