### PR TITLE
Add DaButtonFactory.com

### DIFF
--- a/src/chrome/content/rules/DaButtonFactory.com.xml
+++ b/src/chrome/content/rules/DaButtonFactory.com.xml
@@ -1,0 +1,9 @@
+<ruleset name="DaButtonFactory.com">
+	<target host="dabuttonfactory.com" />
+	<target host="www.dabuttonfactory.com" />
+
+	<!-- For Cloudflare cookies. DaButtonFactory itself does not set any. -->
+	<securecookie host=".+" name=".+" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>


### PR DESCRIPTION
[DaButtonFactory.com](https://DaButtonFactory.com) is an online button maker. It offers a simple REST API for button images generation, where an image is returned in response to an HTTP GET request. (The button settings, such as the text, size, and colors, are included in the requested URL query string.)

This API/hotlinking facility is used on thousands of sites around the web.
The use of HTTPS is recommended, and the site and its API are fully available over HTTPS. 
However, since Da Button Factory uses a shared SSL certificate (provided by Cloudflare), we do not redirect HTTP requests to HTTPS, to not mess with old browsers not supporting SNI.
Since the HTTPS everywhere plugin is only available for browsers supporting SNI, it is OK to add a ruleset here.