### PR TITLE
[Mastodon.social] New ruleset

### DIFF
--- a/src/chrome/content/rules/Mastodon.social.xml
+++ b/src/chrome/content/rules/Mastodon.social.xml
@@ -3,6 +3,8 @@
 	<target host="*.mastodon.social" />
 
 	<test url="http://assets.mastodon.social/assets/fluffy-elephant-friend-6b47d8e924332955795ff4b2d8fc446437d26b28bfc67d6be2a4d88995ab2c1f.png" />
+	<test url="http://assets.mastodon.social/assets/logo-5701d8d94bca66668f49a2803c984e960dfe0bf93a71f2d86be9455e66505cee.png" />
+	<test url="http://assets.mastodon.social/assets/application_public-9d3c2ebe4e03291e9cc84b69d4debd32c0ac57b93af8cc7b3001fbe36b9a2b8a.js" />
 
 	<securecookie host=".+" name=".+" />
 

--- a/src/chrome/content/rules/Mastodon.social.xml
+++ b/src/chrome/content/rules/Mastodon.social.xml
@@ -1,0 +1,10 @@
+<ruleset name="Mastodon.social">
+	<target host="mastodon.social" />
+	<target host="*.mastodon.social" />
+
+	<test url="http://assets.mastodon.social/assets/fluffy-elephant-friend-6b47d8e924332955795ff4b2d8fc446437d26b28bfc67d6be2a4d88995ab2c1f.png" />
+
+	<securecookie host=".+" name=".+" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/Mastodon.social.xml
+++ b/src/chrome/content/rules/Mastodon.social.xml
@@ -1,10 +1,13 @@
+<!--
+	Site serves an HSTS header with includeSubdomains.
+-->
 <ruleset name="Mastodon.social">
 	<target host="mastodon.social" />
 	<target host="*.mastodon.social" />
 
+	<test url="http://www.mastodon.social/" />
 	<test url="http://assets.mastodon.social/assets/fluffy-elephant-friend-6b47d8e924332955795ff4b2d8fc446437d26b28bfc67d6be2a4d88995ab2c1f.png" />
 	<test url="http://assets.mastodon.social/assets/logo-5701d8d94bca66668f49a2803c984e960dfe0bf93a71f2d86be9455e66505cee.png" />
-	<test url="http://assets.mastodon.social/assets/application_public-9d3c2ebe4e03291e9cc84b69d4debd32c0ac57b93af8cc7b3001fbe36b9a2b8a.js" />
 
 	<securecookie host=".+" name=".+" />
 


### PR DESCRIPTION
Site serves HSTS header with 1 year `max-age` and `includeSubdomains`, but no `preload`.