### PR TITLE
Update derstandard.at.xml

### DIFF
--- a/src/chrome/content/rules/derstandard.at.xml
+++ b/src/chrome/content/rules/derstandard.at.xml
@@ -4,9 +4,6 @@
 		- parship
 		- text
 		- tv
-
-	Problematic:
-		- redirect on some pages, only css, images and js are working
 -->
 <ruleset name="derStandard.at (partial)">
 	<target host="derstandard.at"/>
@@ -16,21 +13,12 @@
 	<target host="livestat.derstandard.at"/>
 	<target host="mobil.derstandard.at"/>
 
-	<exclusion pattern="^http://derstandard\.at/$" />
-	<exclusion pattern="^http://www\.derstandard\.at/$" />
-	<exclusion pattern="^http://mobil\.derstandard\.at/$" />
-
-	<rule from="^http://(www\.)?derstandard\.at/(ajax|css|img|js|kursinfo|wetter/Content/img)/"
-		to="https://derstandard.at/$2/"/>
-	<rule from="^http://mobil\.derstandard\.at/(ajax|css|img|js|kursinfo|wetter/Content/img)/"
-		to="https://mobil.derstandard.at/$1/"/>
-	<rule from="^http://epaper\.derstandard\.at/"
-		to="https://epaper.derstandard.at/" />
-	<rule from="^http://images\.derstandard\.at/"
-		to="https://images.derstandard.at/" />
-	<rule from="^http://livestat\.derstandard\.at/"
-		to="https://livestat.derstandard.at/" />
-
+	<rule from="^http:"
+		to="https:" />
+	
+	<test url="http://derstandard.at/" />
+	<test url="http://www.derstandard.at/" />
+	<test url="http://mobil.derstandard.at/" />
 	<test url="http://derstandard.at/ajax/bottomnavinfo.ashx" />
 	<test url="http://mobil.derstandard.at/ajax/bottomnavinfo.ashx" />
 	<test url="http://www.derstandard.at/ajax/bottomnavinfo.ashx" />


### PR DESCRIPTION
I'm not sure what exactly is meant by the mismatches here, but from my testing the whole page of der standard.at can be accessed via https now. I'm just not sure how to handle https://dst.at (see also https://www.ssllabs.com/ssltest/analyze.html?d=dst.at).