### PR TITLE
Add ruleset for parkrun.com and subdomains

### DIFF
--- a/src/chrome/content/rules/Parkrun.com.xml
+++ b/src/chrome/content/rules/Parkrun.com.xml
@@ -1,0 +1,15 @@
+<ruleset name="parkrun.com">
+
+    <target host="parkrun.com" />
+    <target host="developer.parkrun.com" />
+    <target host="images.parkrun.com" />
+    <target host="poster.parkrun.com" />
+    <!-- status.parkrun.com doesn't respond to HTTPS connections -->
+    <target host="tools.parkrun.com" />
+    <target host="webmail.parkrun.com" />
+    <target host="www.parkrun.com" />
+
+    <rule from="^http:"
+        to="https:" />
+
+</ruleset>


### PR DESCRIPTION
parkrun.org.uk is fetching one tiny image from parkrun.com which is causing mixed-content warnings, so this commit fixes that.

parkrun.com has a valid certificate for parkrun.com and *.parkrun.com.