### PR TITLE
Create ComicFury.xml

### DIFF
--- a/src/chrome/content/rules/ComicFury.xml
+++ b/src/chrome/content/rules/ComicFury.xml
@@ -1,0 +1,26 @@
+<!--
+	ComicFury Webcomic Hosting (comicfury.com)
+	
+	Other known HTTPS hosts associated with comicfury.com:
+	
+		- everythingfury.com (redirects to http://comicfury.com/)
+		- www.everythingfury.com (redirects to http://comicfury.com/)
+	
+	Other known non-HTTPS hosts associated with comicfury.com:
+	
+		- *.thecomicseries.com
+		- *.the-comic.org
+		- *.thecomicstrip.org
+		- *.webcomic.ws
+		- *.cfw.me
+	
+-->
+<ruleset name="ComicFury">
+	<target host="comicfury.com" />
+	<target host="www.comicfury.com" />
+	<target host="everythingfury.com" />
+	<target host="www.everythingfury.com" />
+	
+	<rule from="^http:"
+		to="https:" />
+</ruleset>


### PR DESCRIPTION
This pull request enforces HTTPS on the main domain of ComicFury webcomic hosting site ([comicfury.com](https://comicfury.com/)), as it is recently updated to use [ISRG Let's Encrypt](https://letsencrypt.org/).
