### PR TITLE
Update ruleset-coverage-whitelist-cleanup.sh

### DIFF
--- a/utils/ruleset-coverage-whitelist-cleanup.sh
+++ b/utils/ruleset-coverage-whitelist-cleanup.sh
@@ -15,7 +15,8 @@ fi
 # Run from ruleset folder to simplify sha256sum output
 cd src/chrome/content/rules
 WLIST=../../../../utils/ruleset-coverage-whitelist.txt
-DELIM="  "
+TCHAR=" "
+DELIM="$TCHAR$TCHAR"
 
 while IFS=$DELIM read listed_hash file; do
   display_hash=$(echo $listed_hash | cut -c-7)
@@ -32,3 +33,6 @@ while IFS=$DELIM read listed_hash file; do
     fi
   fi
 done < "$WLIST"
+
+# Sorting by the second column (ruleset name)
+sort -t"$TCHAR" -b -k2 -o "$WLIST" "$WLIST"

--- a/utils/ruleset-coverage-whitelist-cleanup.sh
+++ b/utils/ruleset-coverage-whitelist-cleanup.sh
@@ -35,4 +35,4 @@ while IFS=$DELIM read listed_hash file; do
 done < "$WLIST"
 
 # Sorting by the second column (ruleset name)
-sort -t"$TCHAR" -b -k2 -o "$WLIST" "$WLIST"
+sort -t"$TCHAR" -b -u -k2 -o "$WLIST" "$WLIST"


### PR DESCRIPTION
This close #9801 

I notice that ruleset-coverage-whitelist.txt is not sorted correctly. Related: https://github.com/EFForg/https-everywhere/pull/9603#issuecomment-295272854

Ref: https://stackoverflow.com/questions/29244351/how-to-sort-a-file-in-place

