### PR TITLE
Add support for goip.de

### DIFF
--- a/src/chrome/content/rules/Goip.de.xml
+++ b/src/chrome/content/rules/Goip.de.xml
@@ -1,0 +1,6 @@
+<ruleset name="Goip.de">
+	<target host="goip.de" />
+	<target host="www.goip.de" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>


### PR DESCRIPTION
This site is a dns provider, so all subdomains should not be included.
Even though there are a lot.