### PR TITLE
[Wire.com] Update ruleset

### DIFF
--- a/src/chrome/content/rules/Wire.com.xml
+++ b/src/chrome/content/rules/Wire.com.xml
@@ -1,44 +1,20 @@
-<!--
-	Nonfunctional subdomains:
-
-		- blog *
-
-	* Tumblr
-
-
-	^: reset
-
-
-	Fully covered subdomains:
-
-		- (www.)	(^ → www)
-		- sunrise
-		- support
-
-
-	Insecure cookies are set for these domains:
-
-		- sunrise.wire.com
-		- www.wire.com
-
--->
-<ruleset name="Wire.com (partial)">
+<ruleset name="Wire.com">
 
 	<target host="wire.com" />
 	<target host="*.wire.com" />
+	<target host="wire.innocraft.cloud" />
 
+	<test url="http://account.wire.com/" />
+	<test url="http://app.wire.com/" />
+	<test url="http://blog.wire.com/" />
+	<test url="http://get.wire.com/" />
+	<test url="http://prod-assets.wire.com/" />
+	<test url="http://prod-nginz-https.wire.com/" />
+	<test url="http://prod-nginz-ssl.wire.com/" />
+	<test url="http://support.wire.com/" />
+	<test url="http://www.wire.com/" />
 
-	<!--	Not secured by server:
-					-->
-	<!--securecookie host="^(sunrise|www)\.wire\.com$" name="^session$" /-->
+	<securecookie host=".+" name=".+" />
 
-	<securecookie host="^(?:sunrise|www)\.wire\.com$" name=".+" />
-
-
-	<rule from="^http://(?:www\.)?wire\.com/"
-		to="https://www.wire.com/" />
-
-	<rule from="^http://su(nrise|pport)\.wire\.com/"
-		to="https://su$1.wire.com/" />
-
+	<rule from="^http:" to="https:" />
 </ruleset>


### PR DESCRIPTION
Changes:
- Prior to this PR, the `<rule>` tags only redirected a few hosts to https, despite the wildcard target. They didn't cover Wire's main web app at `app.wire.com`. The new `<rule>` redirects everything to https.
- Added a target for Wire's Piwik analytics domain, `wire.innocraft.cloud`.
- Added test URLs for all subdomains I could find.
- Wildcard securecookie tag.
- Ruleset is no longer "partial".