### PR TITLE
Update APA.org.xml

### DIFF
--- a/src/chrome/content/rules/APA.org.xml
+++ b/src/chrome/content/rules/APA.org.xml
@@ -14,7 +14,6 @@
 	<target host="apa.org" />
 	<target host="www.apa.org" />
 	<target host="books.apa.org" />
-	<target host="cesaoas.apa.org" />
 	<target host="coaportal.apa.org" />
 	<target host="fs.apa.org" />
 	<target host="join.apa.org" />

--- a/src/chrome/content/rules/APA.org.xml
+++ b/src/chrome/content/rules/APA.org.xml
@@ -11,7 +11,7 @@
 			* Redirects to mytest.apa.org
 -->
 <ruleset name="APA.org (partial)">
-	<taget host="apa.org" />
+	<target host="apa.org" />
 	<target host="www.apa.org" />
 	<target host="books.apa.org" />
 	<target host="cesaoas.apa.org" />

--- a/src/chrome/content/rules/APA.org.xml
+++ b/src/chrome/content/rules/APA.org.xml
@@ -1,20 +1,34 @@
 <!--
-	Nonfunctional hosts in *apa.org:
-
-		- doi ʳ
-		- psycnet ʰ
-
-	ʰ Redirects to http
-	ʳ Refused
-
+	Numerous nonfunctional subdomains for *.apa.org (141 found with Sublist3r)	
+	
+	Redirects:
+		* on.apa.org
+			* bit.ly vanity domain
+			* target located in Bitly_branded_short_domains.xml
+		* staging.psyctherapy.apa.org
+			* Redirects to mytest.apa.org
+		* psyctherapyalpha.apa.org
+			* Redirects to mytest.apa.org
 -->
-<ruleset name="APA.org (partial)" platform="mixedcontent">
+<ruleset name="APA.org (partial)">
 
+	<taget host="apa.org" />
+	<target host="www.apa.org" />
+	<target host="books.apa.org" />
+	<target host="cesaoas.apa.org" />
+	<target host="coaportal.apa.org" />
+	<target host="fs.apa.org" />
+	<target host="join.apa.org" />
+	<target host="memforms.apa.org" />
+	<target host="mfpapp.apa.org" />
 	<target host="my.apa.org" />
-
+	<target host="mytest.apa.org" />
+	<target host="myweb.apa.org" />
+	<target host="pages.apa.org" />
+	<target host="securenet.apa.org" />
+	<target host="www2.apa.org" />
 
 	<securecookie host="^\w" name="." />
-
 
 	<rule from="^http:"
 		to="https:" />

--- a/src/chrome/content/rules/APA.org.xml
+++ b/src/chrome/content/rules/APA.org.xml
@@ -11,7 +11,6 @@
 			* Redirects to mytest.apa.org
 -->
 <ruleset name="APA.org (partial)">
-
 	<taget host="apa.org" />
 	<target host="www.apa.org" />
 	<target host="books.apa.org" />

--- a/src/chrome/content/rules/APA.org.xml
+++ b/src/chrome/content/rules/APA.org.xml
@@ -5,6 +5,8 @@
 			- psycnet
 		Refused:
 			- doi
+		Unable to get local issuer certificate (Travis error):
+			- join
 		Numerous other nonfunctional subdomains (~140 found with Sublist3r)
 
 	Redirects:
@@ -22,7 +24,6 @@
 	<target host="books.apa.org" />
 	<target host="coaportal.apa.org" />
 	<target host="fs.apa.org" />
-	<target host="join.apa.org" />
 	<target host="memforms.apa.org" />
 	<target host="mfpapp.apa.org" />
 	<target host="my.apa.org" />

--- a/src/chrome/content/rules/APA.org.xml
+++ b/src/chrome/content/rules/APA.org.xml
@@ -1,6 +1,12 @@
 <!--
-	Numerous nonfunctional subdomains for *.apa.org (141 found with Sublist3r)	
-	
+
+	Nonfunctional hosts in *apa.org:
+		Redirects to http:
+			- psycnet
+		Refused:
+			- doi
+		Numerous other nonfunctional subdomains (~140 found with Sublist3r)
+
 	Redirects:
 		* on.apa.org
 			* bit.ly vanity domain


### PR DESCRIPTION
Loading the site's main page and some other pages on the subdomains https://www.apa.org, https://www2.apa.org and https://books.apa.org over https triggers a JavaScript alert that complains that "An error occurred while loading the featured jobs.". But it doesn't seem to affect functionality at all so I think the benefits outweigh the side-effects.