### PR TITLE
Update CNN.com related ruleset

### DIFF
--- a/src/chrome/content/rules/CNN.com.xml
+++ b/src/chrome/content/rules/CNN.com.xml
@@ -1,68 +1,55 @@
 <!--
-	CDN buckets:
+	Non-functional hosts
+		Couldn't connect to server:
+			 - money.cnn.com
+			 - cgi.money.cnn.com
+			 - jobsearch.money.cnn.com
+			 - portfolio.money.cnn.com
+			 - www.money.cnn.com
+			 - searchapp.cnn.com
+			 - transcripts.cnn.com
+			 - www.wearecnn.com
 
-		- do17qa6ql691x.cloudfront.net
+		SSL connect error:
+			 - commercial.cnn.com
+			 - rss.cnn.com
 
-		- custom.i.cnn.net.edgesuite.net
+		SSL peer certificate was not OK:
+			 - realestate.money.cnn.com
 
-			- i.a.cnn.net
+		Incomplete certificate chain error:
+			 - collection.cnn.com
+			 - static.collection.cnn.com
 
-		- cnnmoney.jobamatic.com
+		Secure connection redirects to plaintext:
+			 - www.cnn.com
+			 - cnnpressroom.blogs.cnn.com
+			 - thecnnfreedomproject.blogs.cnn.com
+			 - buzz.money.cnn.com
+			 - cnnespanol.cnn.com
+			 - edition.cnn.com
+			 - www.edition.cnn.com
 
-			- jobsearch.money.cnn.com
+		Mixed content blocking (MCB) tiggered:
+			 - go.cnn.com
+			 - www.preview.cnn.com
 
-		- s.cdn.turner.com/money/
-
-
-	Nonfunctional domains:
-
-		- cnn.com subdomains:
-
-			- ^ *	
-			- ads *
-			- edition **
-			- ireport *
-			- mexico ***
-			- (www.)?money *
-			- realestate.money *
-			- sportsillustrated **
-			- svcs *
-			- transcripts **
-			- us **
-			- www **
-
-		- i.a.cnn.net ***
-		- i.cnn.net *
-
-	* Refused
-	** Dropped
-	*** 503, akamai
-
-
-	Problematic subdomains:
-
-		- jobsearch.money	(works; mismatched, CN: *.jobamatic.com)
-
-
-	Fully covered subdomains:
-
-		- audience
-		- markets.money
-		- portfolio.money
-
+		CORS Blocking:
+			 - edition.i.cdn.cnn.com on money.cnn.com
 -->
 <ruleset name="CNN.com (partial)">
+	<target host="cnn.com" />
+	<target host="amp.cnn.com" />
+	<target host="arabic.cnn.com" />
+	<target host="i.cdn.cnn.com" />
+		<test url="http://i.cdn.cnn.com/cnn/.e/img/3.0/weather/weatherIcon_01.png" />
+		<test url="http://i.cdn.cnn.com/cnn/.e1mo/img/4.0/logos/logo_cnn_arabic.png" />
+		<test url="http://i.cdn.cnn.com/cnn/.e1mo/img/4.0/logos/logo_cnn_nav_bottom.png" />
+	<target host="i2.cdn.cnn.com" />
+		<test url="http://i2.cdn.cnn.com/cnnnext/dam/assets/170313100039-04-climate-change-impact-small-11.jpg" />
+		<test url="http://i2.cdn.cnn.com/cnnnext/dam/assets/170409024444-uss-carl-vinson-large-tease.jpg" />
+		<test url="http://i2.cdn.cnn.com/cnnnext/dam/assets/170423103501-france-election-security-eiffel-overlay-tease.jpg" />
+	<target host="markets.money.cnn.com" />
 
-	<target host="*.cnn.com" />
-
-
-	<securecookie host="^(?:audience|markets\.money)\.cnn\.com$" name=".+" />
-
-
-	<rule from="^http://(audience|(?:markets|portfolio)\.money)\.cnn\.com/"
-		to="https://$1.cnn.com/" />
-
-	<rule from="^http://jobsearch\.money\.cnn\.com/(c/|favicon\.ico)"
-		to="https://cnnmoney.jobamatic.com/$1" />
-
+	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/CNN.com.xml
+++ b/src/chrome/content/rules/CNN.com.xml
@@ -8,14 +8,23 @@
 			 - www.money.cnn.com
 			 - searchapp.cnn.com
 			 - transcripts.cnn.com
-			 - www.wearecnn.com
+			 - tours.cnn.com
+			 - weather.cnn.com
 
 		SSL connect error:
 			 - commercial.cnn.com
 			 - rss.cnn.com
 
 		SSL peer certificate was not OK:
+			 - debates.cnn.com
+			 - finance.fortune.cnn.com
+			 - management.fortune.cnn.com
+			 - tech.fortune.cnn.com
+			 - lending.cnn.com
+			 - mexico.cnn.com
 			 - realestate.money.cnn.com
+			 - podcast.cnn.com
+			 - smartlink.cnn.com
 
 		Incomplete certificate chain error:
 			 - collection.cnn.com
@@ -25,10 +34,11 @@
 			 - www.cnn.com
 			 - cnnpressroom.blogs.cnn.com
 			 - thecnnfreedomproject.blogs.cnn.com
-			 - buzz.money.cnn.com
 			 - cnnespanol.cnn.com
+			 - buzz.money.cnn.com
 			 - edition.cnn.com
 			 - www.edition.cnn.com
+			 - us.cnn.com
 
 		Mixed content blocking (MCB) tiggered:
 			 - go.cnn.com
@@ -50,6 +60,7 @@
 		<test url="http://i2.cdn.cnn.com/cnnnext/dam/assets/170409024444-uss-carl-vinson-large-tease.jpg" />
 		<test url="http://i2.cdn.cnn.com/cnnnext/dam/assets/170423103501-france-election-security-eiffel-overlay-tease.jpg" />
 	<target host="markets.money.cnn.com" />
+	<target host="travel.cnn.com" />
 
 	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/CNN.com.xml
+++ b/src/chrome/content/rules/CNN.com.xml
@@ -1,4 +1,7 @@
 <!--
+	CNN.com related ruleset:
+		- CNN.net.xml
+
 	Non-functional hosts
 		Couldn't connect to server:
 			 - money.cnn.com

--- a/src/chrome/content/rules/CNN.net.xml
+++ b/src/chrome/content/rules/CNN.net.xml
@@ -1,0 +1,31 @@
+<!--
+	For more CNN.com related ruleset, see CNN.com.xml
+
+	Non-functional hosts
+		Couldn't connect to server:
+			 - cnn.net
+			 - www.cnn.net
+			 - a.cnn.net
+
+		Timeout was reached:
+			 - i1.cnn.net
+			 - i4.cnn.net
+
+		SSL peer certificate was not OK:
+			 - e.a.cnn.net
+			 - i.a.cnn.net
+			 - m.a.cnn.net
+			 - s.a.cnn.net
+			 - i.cnn.net
+			 - i.l.cnn.net
+
+		Mixed Content Blocking (MCB) tiggered:
+			 - podcasts.cnn.net
+-->
+<ruleset name="CNN.net (partial)">
+	<target host="io.cnn.net" />
+		<test url="http://io.cnn.net/nba/nba/.element/media/2.0/teamsites/knicks/media/account-manager/Print.pdf" />
+	<target host="s.cnn.net" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>


### PR DESCRIPTION
 - [x] cnn.com
 - [x] amp.cnn.com
 - [x] cnnpressroom.blogs.cnn.com
 - [x] i.cdn.cnn.com
 - [x] i2.cdn.cnn.com
 - [x] commercial.cnn.com
 - [x] edition.cnn.com
 - [x] go.cnn.com
 - [x] money.cnn.com
 - [x] buzz.money.cnn.com
 - [x] cgi.money.cnn.com
 - [x] jobsearch.money.cnn.com
 - [x] markets.money.cnn.com
 - [x] portfolio.money.cnn.com
 - [x] realestate.money.cnn.com
 - [x] www.money.cnn.com
 - [x] rss.cnn.com
 - [x] searchapp.cnn.com
 - [x] www.cnn.com
