### PR TITLE
Create rule for gamecritics

### DIFF
--- a/src/chrome/content/rules/Gamecritics.com.xml
+++ b/src/chrome/content/rules/Gamecritics.com.xml
@@ -1,0 +1,14 @@
+<!--
+	Nonfunctional hosts in *.gamecritics.com:
+
+	r: connection refused:
+	   rocket.gamecritics.com (Server not found)
+-->
+<ruleset name="Gamecritics">
+
+	<target host="gamecritics.com" />
+	<target host="www.gamecritics.com" />
+
+	<rule from="^http:" to="https:" />
+
+</ruleset>


### PR DESCRIPTION
Create Gamecritics.com.xml. Connection is refused for "rocket.gamecritics.com".