### PR TITLE
Create rule for pcgamer

### DIFF
--- a/src/chrome/content/rules/Pcgamer.com.xml
+++ b/src/chrome/content/rules/Pcgamer.com.xml
@@ -1,0 +1,23 @@
+<!--
+	Nonfunctional hosts in *.pcgamer.com:
+	
+	r: connection refused
+	    asus.pcgamer.com (Server not found)
+	    dl.pcgamer.com (Server not found)
+	    promo.pcgamer.com (Server not found)
+	    www.sl.pcgamer.com (Server not found)
+	
+	HTTPS connection refused:
+       	    email.pcgamer.com (HTTPS refused)
+	    media.pcgamer.com (Invalid Hostname)
+	    sl.pcgamer.com (HTTPS refused)
+	    weekender.pcgamer.com (HTTPS refused)
+-->
+<ruleset name="Pcgamer">
+
+	<target host="pcgamer.com" />
+	<target host="www.pcgamer.com" />
+
+	<rule from="^http:" to="https:" />
+
+</ruleset>


### PR DESCRIPTION
Create Pcgamer.com.xml. Apart from the two main subdomains, all other hosts seem nonfunctional. Error type indicated for each.