### PR TITLE
Create rule for siliconera

### DIFF
--- a/src/chrome/content/rules/Siliconera.com.xml
+++ b/src/chrome/content/rules/Siliconera.com.xml
@@ -1,0 +1,21 @@
+<!--
+	Nonfunctional hosts in *.siliconera.com:
+
+	h: http redirect
+	m: certificate mismatch
+	r: connection refused
+	s: self-signed certificate
+	t: timeout on https
+-->
+<ruleset name="Siliconera" platform="mixedcontent">
+
+	<target host="siliconera.com" />
+	<target host="www.siliconera.com" />
+	<target host="mobile.siliconera.com" />
+	<target host="storage.siliconera.com" />
+
+	<rule from="^http:" to="https:" />
+	
+	<test url="http://www.siliconera.com/wordpress/wp-content/themes/siliconera/imgs/siliconera_logo.gif" />
+
+</ruleset>

--- a/src/chrome/content/rules/Siliconera.com.xml
+++ b/src/chrome/content/rules/Siliconera.com.xml
@@ -1,12 +1,3 @@
-<!--
-	Nonfunctional hosts in *.siliconera.com:
-
-	h: http redirect
-	m: certificate mismatch
-	r: connection refused
-	s: self-signed certificate
-	t: timeout on https
--->
 <ruleset name="Siliconera" platform="mixedcontent">
 
 	<target host="siliconera.com" />


### PR DESCRIPTION
Create Siliconera.com.xml. The media subdomain contains mixed content blocking, so mixedcontent platform is added. Test url to check the main website image logo loads on HTTPS version.