### PR TITLE
Update Schmidtcom.de.xml

### DIFF
--- a/src/chrome/content/rules/Schmidtcom.de.xml
+++ b/src/chrome/content/rules/Schmidtcom.de.xml
@@ -1,18 +1,50 @@
 <!--
-	All domains show config.
+	Non-functional hosts
+		Couldn't connect to server:
+			 - delva.schmidtcom.de
+			 - eglim.schmidtcom.de
+			 - ns3.schmidtcom.de
 
+		Timeout was reached:
+			 - arden.schmidtcom.de
+			 - betor.schmidtcom.de
+			 - mx1.schmidtcom.de
+			 - mx2.schmidtcom.de
+			 - ns2.schmidtcom.de
+
+		SSL peer certificate was not OK:
+			 - ns1.schmidtcom.de
 -->
-<ruleset name="Schmidtcom.de (partial)" platform="cacert">
-
-	<!--	Direct rewrites:
-				-->
+<ruleset name="Schmidtcom.de">
+	<target host="schmidtcom.de" />
+	<target host="www.schmidtcom.de" />
+	<target host="certs.schmidtcom.de" />
+	<target host="cinto.schmidtcom.de" />
+	<target host="cloud.schmidtcom.de" />
 	<target host="config.schmidtcom.de" />
+	<target host="discourse.schmidtcom.de" />
+	<target host="feedme.schmidtcom.de" />
+	<target host="git.schmidtcom.de" />
+	<target host="gitlab.schmidtcom.de" />
+	<target host="imap.schmidtcom.de" />
+	<target host="imap2.schmidtcom.de" />
+	<target host="login.schmidtcom.de" />
+	<target host="mail.schmidtcom.de" />
+	<target host="mail2.schmidtcom.de" />
+	<target host="mumble.schmidtcom.de" />
+	<target host="oc.schmidtcom.de" />
+	<target host="owncloud.schmidtcom.de" />
+	<target host="pop.schmidtcom.de" />
+	<target host="pop2.schmidtcom.de" />
+	<target host="sieve.schmidtcom.de" />
+	<target host="sieve2.schmidtcom.de" />
+	<target host="smtp.schmidtcom.de" />
+	<target host="smtp2.schmidtcom.de" />
+	<target host="ssl.schmidtcom.de" />
+	<target host="1.ssl.schmidtcom.de" />
+	<target host="2.ssl.schmidtcom.de" />
 
+	<securecookie host=".+" name=".+" />
 
-	<securecookie host="^config\.schmidtcom\.de$" name=".+" />
-
-
-	<rule from="^http:"
-		to="https:" />
-
+	<rule from="^http:" to="https:" />
 </ruleset>


### PR DESCRIPTION
According to Google Translate, the following
```
cinto.schmidtcom.de

Sie haben versucht die Webseite **cinto.schmidtcom.de** aufzurufen.
Diese Domain wird derzeit nicht für eine Webseite verwendet.
Wenn Sie der Eigentümer dieser Domain sind und eine Webseite veröffentlichen möchten, 
kontaktieren Sie uns bitte über schmidtcom.de/kontakt. 
```
is equal to 
```
You tried to access the website **git.schmidtcom.de**.
This domain is not currently used for a website.
If you are the owner of this domain and want to publish a website, 
please contact us via schmidtcom.de/kontakt.
```

Similarly,
```
config.schmidtcom.de heißt jetzt login.schmidtcom.de
```
means
```
Config.schmidtcom.de is now login.schmidtcom.de
```

I guess there is quite a lot of sub-domain not serving any content at all. The working URL are mostly `^`, `www`, `cert`, `config` and `login`. thanks.

Related: #9582 