### PR TITLE
Malwarebytes.com

### DIFF
--- a/src/chrome/content/rules/Malwarebytes.com.xml
+++ b/src/chrome/content/rules/Malwarebytes.com.xml
@@ -1,0 +1,28 @@
+<ruleset name="Malwarebytes.com">
+	<target host="my.malwarebytes.com" />
+	<target host="cloud.malwarebytes.com" />
+	<target host="buy.malwarebytes.com" />
+	<target host="shop.malwarebytes.com" />
+        <target host="malwarebytes.com" />
+        <target host="www.malwarebytes.com" />
+        <target host="downloads.malwarebytes.com" />
+        <target host="blog.malwarebytes.com" />
+        <target host="forums.malwarebytes.com" />
+        <target host="press.malwarebytes.com" />
+        <target host="support.malwarebytes.com" />
+        <target host="jobs.malwarebytes.com" />
+        <target host="store.malwarebytes.com" />
+        <target host="de.malwarebytes.com" />
+        <target host="es.malwarebytes.com" />
+        <target host="fr.malwarebytes.com" />
+        <target host="it.malwarebytes.com" />
+        <target host="pt.malwarebytes.com" />
+        <target host="br.malwarebytes.com" />
+        <target host="nl.malwarebytes.com" />
+        <target host="pl.malwarebytes.com" />
+        <target host="ru.malwarebytes.com" />
+
+        <securecookie host="^\.store\.malwarebytes\.com$" name=".+" />
+
+        <rule from="^http:" to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/Malwarebytes.com.xml
+++ b/src/chrome/content/rules/Malwarebytes.com.xml
@@ -3,26 +3,26 @@
 	<target host="cloud.malwarebytes.com" />
 	<target host="buy.malwarebytes.com" />
 	<target host="shop.malwarebytes.com" />
-        <target host="malwarebytes.com" />
-        <target host="www.malwarebytes.com" />
-        <target host="downloads.malwarebytes.com" />
-        <target host="blog.malwarebytes.com" />
-        <target host="forums.malwarebytes.com" />
-        <target host="press.malwarebytes.com" />
-        <target host="support.malwarebytes.com" />
-        <target host="jobs.malwarebytes.com" />
-        <target host="store.malwarebytes.com" />
-        <target host="de.malwarebytes.com" />
-        <target host="es.malwarebytes.com" />
-        <target host="fr.malwarebytes.com" />
-        <target host="it.malwarebytes.com" />
-        <target host="pt.malwarebytes.com" />
-        <target host="br.malwarebytes.com" />
-        <target host="nl.malwarebytes.com" />
-        <target host="pl.malwarebytes.com" />
-        <target host="ru.malwarebytes.com" />
+	<target host="malwarebytes.com" />
+	<target host="www.malwarebytes.com" />
+	<target host="downloads.malwarebytes.com" />
+	<target host="blog.malwarebytes.com" />
+	<target host="forums.malwarebytes.com" />
+	<target host="press.malwarebytes.com" />
+	<target host="support.malwarebytes.com" />
+	<target host="jobs.malwarebytes.com" />
+	<target host="store.malwarebytes.com" />
+	<target host="de.malwarebytes.com" />
+	<target host="es.malwarebytes.com" />
+	<target host="fr.malwarebytes.com" />
+	<target host="it.malwarebytes.com" />
+	<target host="pt.malwarebytes.com" />
+	<target host="br.malwarebytes.com" />
+	<target host="nl.malwarebytes.com" />
+	<target host="pl.malwarebytes.com" />
+	<target host="ru.malwarebytes.com" />
 
-        <securecookie host="^\.store\.malwarebytes\.com$" name=".+" />
+	<securecookie host="^\.store\.malwarebytes\.com$" name=".+" />
 
-        <rule from="^http:" to="https:" />
+	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Malwarebytes.com.xml
+++ b/src/chrome/content/rules/Malwarebytes.com.xml
@@ -1,26 +1,27 @@
 <ruleset name="Malwarebytes.com">
-	<target host="my.malwarebytes.com" />
-	<target host="cloud.malwarebytes.com" />
-	<target host="buy.malwarebytes.com" />
-	<target host="shop.malwarebytes.com" />
 	<target host="malwarebytes.com" />
 	<target host="www.malwarebytes.com" />
-	<target host="downloads.malwarebytes.com" />
+	<target host="block.malwarebytes.com" />
 	<target host="blog.malwarebytes.com" />
-	<target host="forums.malwarebytes.com" />
-	<target host="press.malwarebytes.com" />
-	<target host="support.malwarebytes.com" />
-	<target host="jobs.malwarebytes.com" />
-	<target host="store.malwarebytes.com" />
+	<target host="br.malwarebytes.com" />
+	<target host="buy.malwarebytes.com" />
+	<target host="cloud.malwarebytes.com" />
 	<target host="de.malwarebytes.com" />
+	<target host="downloads.malwarebytes.com" />
 	<target host="es.malwarebytes.com" />
+	<target host="forums.malwarebytes.com" />
 	<target host="fr.malwarebytes.com" />
 	<target host="it.malwarebytes.com" />
-	<target host="pt.malwarebytes.com" />
-	<target host="br.malwarebytes.com" />
+	<target host="jobs.malwarebytes.com" />
+	<target host="my.malwarebytes.com" />
 	<target host="nl.malwarebytes.com" />
 	<target host="pl.malwarebytes.com" />
+	<target host="press.malwarebytes.com" />
+	<target host="pt.malwarebytes.com" />
 	<target host="ru.malwarebytes.com" />
+	<target host="shop.malwarebytes.com" />
+	<target host="store.malwarebytes.com" />
+	<target host="support.malwarebytes.com" />
 
 	<securecookie host="^\.store\.malwarebytes\.com$" name=".+" />
 


### PR DESCRIPTION
Add rules for Malwarebytes domains.

Another PR to fix [malwarebytes.org legacy rules](https://github.com/EFForg/https-everywhere/blob/master/src/chrome/content/rules/Malwarebytes.xml) will follow.