### PR TITLE
Add HarvardBlogs (blogs.harvard.edu)

### DIFF
--- a/src/chrome/content/rules/Blogs.harvard.edu.xml
+++ b/src/chrome/content/rules/Blogs.harvard.edu.xml
@@ -1,0 +1,14 @@
+<!--
+	Nonfunctional hosts in *.blogs.harvard.edu:
+
+	h: http redirect
+	m: certificate mismatch
+	r: connection refused
+	s: self-signed certificate
+	t: timeout on https
+-->
+<ruleset name="Harvard Blogs">
+	<target host="blogs.harvard.edu" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>


### PR DESCRIPTION
```
HarvardBlogs is a Wordpress-based blogging platform that hosted
many blogs, the server is deployed independently and support HTTPS
completely, but doesn't enforce HTTPS by default.

This commit add blogs.harvard.edu to the ruleset.

Signed-off-by: Yifeng Li <tomli@tomli.me>
```