### PR TITLE
Update Harvard-University related rulesets

### DIFF
--- a/src/chrome/content/rules/Harvard-University-expired.xml
+++ b/src/chrome/content/rules/Harvard-University-expired.xml
@@ -2,14 +2,12 @@
 	For rules that are on by default, see Harvard-University.xml.
 
 -->
-<ruleset name="Harvard.edu (problematic)" default_off="expired, missing certificate chain, self-signed">
+<ruleset name="Harvard.edu (problematic)" default_off="mismatches, missing certificate chain">
 
 	<!--	Direct rewrites:
 				-->
-	<target host="downloads.rc.fas.harvard.edu" />
 	<target host="pngu.mgh.harvard.edu" />
 	<target host="read.seas.harvard.edu" />
-	<target host="yuba.harvard.edu" />
 
 
 	<securecookie host="." name="." />

--- a/src/chrome/content/rules/Harvard-University.xml
+++ b/src/chrome/content/rules/Harvard-University.xml
@@ -174,7 +174,6 @@
 	<target host="blogs.law.harvard.edu" />
 	<target host="cyber.law.harvard.edu" />
 
-	<target host="oncampus.harvard.edu" />
 	<target host="www.pin1.harvard.edu" />
 	<target host="post.harvard.edu" />
 	<target host="secure.post.harvard.edu" />

--- a/src/chrome/content/rules/Harvard-University.xml
+++ b/src/chrome/content/rules/Harvard-University.xml
@@ -30,6 +30,7 @@
 		- reference.pin		(reused_issuer_and_serial)
 		- mirrors.seas ⁴
 		- people.seas ᵈ
+		- post ᵈ 
 		- thestorymap ⁴
 		- worldmap ᵈ
 		- www.wjh ⁴
@@ -174,7 +175,6 @@
 	<target host="cyber.law.harvard.edu" />
 
 	<target host="www.pin1.harvard.edu" />
-	<target host="post.harvard.edu" />
 	<target host="secure.post.harvard.edu" />
 
 	<target host="computefest.seas.harvard.edu" />

--- a/src/chrome/content/rules/Harvard-University.xml
+++ b/src/chrome/content/rules/Harvard-University.xml
@@ -139,7 +139,6 @@
 	<target host="www.cfa.harvard.edu" />
 	<target host="cqh.harvard.edu" />
 	
-	<target host="dspace.harvard.edu" />
 	<target host="economics.harvard.edu" />
 	<target host="pearson.eps.harvard.edu" />
 

--- a/src/chrome/content/rules/Harvard-University.xml
+++ b/src/chrome/content/rules/Harvard-University.xml
@@ -176,7 +176,6 @@
 	<target host="www.pin1.harvard.edu" />
 	<target host="post.harvard.edu" />
 	<target host="secure.post.harvard.edu" />
-	<target host="www.saas.harvard.edu" />
 
 	<target host="computefest.seas.harvard.edu" />
 	<target host="iacs.seas.harvard.edu" />

--- a/src/chrome/content/rules/Harvard-University.xml
+++ b/src/chrome/content/rules/Harvard-University.xml
@@ -142,7 +142,6 @@
 	<target host="economics.harvard.edu" />
 	<target host="pearson.eps.harvard.edu" />
 
-	<target host="account.fas.harvard.edu" />
 	<target host="astronomy.fas.harvard.edu" />
 	<target host="downloads.fas.harvard.edu" />
 	<target host="rc.fas.harvard.edu" />

--- a/src/chrome/content/rules/Harvard-University.xml
+++ b/src/chrome/content/rules/Harvard-University.xml
@@ -58,7 +58,6 @@
 		- pin *
 		- www.pin	($ redirects to http)
 		- pngu.mgh	(expired)
-		- saas **
 		- read.seas	(Self-signed)
 		- trademark		(Mismatched, CN: hwp.harvard.edu)
 		- yuba			(works; expired 2008-04-16, CN: localhost.localdomain)
@@ -68,7 +67,6 @@
 
 	ᶜ Server sends no certificate chain, see https://whatsmychaincert.com
 	* Mismatched
-	** Cert only matches www.saas
 
 
 	Partially covered hosts in *harvard.edu:
@@ -205,7 +203,6 @@
 
 	<target host="pin.harvard.edu" />
 	<target host="www.pin.harvard.edu" />
-	<target host="saas.harvard.edu" />
 	<target host="www.trademark.harvard.edu" />
 	<target host="media.www.harvard.edu" />
 
@@ -287,23 +284,10 @@
 
 		<!--exclusion pattern="^http://mirrors\.seas\.harvard\.edu/" /-->
 
-
-	<!--	Not secured by server:
-					-->
-	<!--securecookie host="^community\.alumni\.harvard\.edu$" name="^JSESSIONID$" /-->
-	<!--securecookie host="^connects\.catalyst\.harvard\.edu$" name="^ASP\.NET_SessionId$" /-->
-	<!--securecookie host="^rc\.fas\.harvard\.edu$" name="^(?:PHPSESSID|wfvt_\d+)$" /-->
-	<!--securecookie host="^account\.rc\.fas\.harvard\.edu$" name="^csrftoken$" /-->
-	<!--securecookie host="^downloads\.rc\.fas\.harvard\.edu$" name="^wordpress(?:_logged_in|_sec|user)?_[\da-f]{32}$" /-->
-	<!--securecookie host="^odybot\.rc\.fas\.harvard\.edu$" name="^PHPSESSID$" /-->
-	<!--securecookie host="^\.hul\.harvard\.edu$" name="^SESS[\da-f]{32}$" /-->
-	<!--securecookie host="^orgs\.law\.harvard\.edu$" name="^X-Mapping-" /-->
-	<!--securecookie host="^secure\.post\.harvard\.edu$" name="^TS[\da-f]+$" /-->
-
 	<securecookie host="^(?:community\.alumni|connects\.catalyst|rc\.fas|\w.*\.rc\.fas|login\.icommons|.*\.law|www\.pin1|secure\.post|www\.seas)\.harvard\.edu$" name=".+" />
 
 
-	<rule from="^http://(berkman|hsph|pin|saas)\.harvard\.edu/"
+	<rule from="^http://(berkman|hsph|pin)\.harvard\.edu/"
 		to="https://www.$1.harvard.edu/" />
 
 	<rule from="^http://media\.campaign\.harvard\.edu/"

--- a/src/chrome/content/rules/Harvard-University.xml
+++ b/src/chrome/content/rules/Harvard-University.xml
@@ -202,7 +202,6 @@
 	<target host="orgs.law.harvard.edu" />
 
 	<target host="pin.harvard.edu" />
-	<target host="www.pin.harvard.edu" />
 	<target host="www.trademark.harvard.edu" />
 	<target host="media.www.harvard.edu" />
 
@@ -287,7 +286,7 @@
 	<securecookie host="^(?:community\.alumni|connects\.catalyst|rc\.fas|\w.*\.rc\.fas|login\.icommons|.*\.law|www\.pin1|secure\.post|www\.seas)\.harvard\.edu$" name=".+" />
 
 
-	<rule from="^http://(berkman|hsph|pin)\.harvard\.edu/"
+	<rule from="^http://(berkman|hsph)\.harvard\.edu/"
 		to="https://www.$1.harvard.edu/" />
 
 	<rule from="^http://media\.campaign\.harvard\.edu/"

--- a/src/chrome/content/rules/Harvard-University.xml
+++ b/src/chrome/content/rules/Harvard-University.xml
@@ -138,7 +138,7 @@
 
 	<target host="www.cfa.harvard.edu" />
 	<target host="cqh.harvard.edu" />
-	<target host="dome.harvard.edu" />
+	
 	<target host="dspace.harvard.edu" />
 	<target host="economics.harvard.edu" />
 	<target host="pearson.eps.harvard.edu" />

--- a/src/chrome/content/rules/Harvard-University.xml
+++ b/src/chrome/content/rules/Harvard-University.xml
@@ -145,8 +145,9 @@
 
 	<target host="account.fas.harvard.edu" />
 	<target host="astronomy.fas.harvard.edu" />
-	<!--target host="downloads.fas.harvard.edu" /-->
+	<target host="downloads.fas.harvard.edu" />
 	<target host="rc.fas.harvard.edu" />
+	<target host="downloads.rc.fas.harvard.edu" />
 	<target host="static.fas.harvard.edu" />
 
 	<target host="hbdm.hbsp.harvard.edu" />


### PR DESCRIPTION
**Closing this because this domain involve much more works than I have expected.**

Minimal changes are made for the completion of #9842. NO sub-domain enumerations are done.

`downloads.rc.fas` is no longer `self-signed`,`yuba` is gone from DNS. Besides, `downloads.fas` LGTM. 

Problematic:

 - [x] dome.harvard.edu `Gone from DNS`
 - [x] dspace.harvard.edu `Gone from DNS`
 - [x] account.fas.harvard.edu `Gone from DNS`
 - [ ] hbdm.hbsp.harvard.edu `Timeout`
 - [x] oncampus.harvard.edu `Gone from DNS`
 - [ ] www.pin1.harvard.edu `Too many redirect`
 - [ ] post.harvard.edu `Timeout`
 - [ ] secure.post.harvard.edu `Timeout`
 - [x] www.saas.harvard.edu `Gone from DNS`
 - [ ] media.campaign.harvard.edu `Gone from DNS`
 - [ ] pin.harvard.edu `Mismatch`
 - [x] saas.harvard.edu `Gone from DNS`
 - [ ] media.www.harvard.edu `Mismatch`