### PR TITLE
Update Amd.com.xml

### DIFF
--- a/src/chrome/content/rules/Amd.com.xml
+++ b/src/chrome/content/rules/Amd.com.xml
@@ -29,6 +29,10 @@
 <ruleset name="Amd.com">
 	<target host="amd.com" />
 	<target host="www.amd.com" />
+		<!-- 30X with plain HTTP, 404 with HTTPS -->
+		<exclusion pattern="http://(www\.)?amd.com/featuredetails" />
+		<test url="http://amd.com/featuredetails" />
+		<test url="http://www.amd.com/featuredetails" />
 	<target host="atlsso.amd.com" />
 	<target host="community.amd.com" />
 	<target host="federation.amd.com" />

--- a/src/chrome/content/rules/Amd.com.xml
+++ b/src/chrome/content/rules/Amd.com.xml
@@ -21,8 +21,11 @@
 		amdsnv.amd.com
 		ati.amd.com
 		products.amd.com
--->
 
+	Weak security algorithm (invalid certificate):
+		amd.com
+
+-->
 <ruleset name="Amd.com">
 	<target host="amd.com" />
 	<target host="www.amd.com" />
@@ -33,6 +36,7 @@
 	<target host="sso.amd.com" />
 	<target host="support.amd.com" />
 	<target host="wwwd.amd.com" />
-	
+
+	<rule from="^http://amd\.com/" to="https://www.amd.com/" />
 	<rule from="^http:" to="https:" />
 </ruleset>


### PR DESCRIPTION
This fixes issue https://github.com/EFForg/https-everywhere/issues/9890.

The `exclusion` for `http://(www\.)?amd.com/featuredetails` is unrelated but I happened to notice it so I'm sneaking it in here. It's probably best not to squash-and-merge because the two changes are unrelated.