### PR TITLE
Create forest.go.th.xml

### DIFF
--- a/src/chrome/content/rules/forest.go.th.xml
+++ b/src/chrome/content/rules/forest.go.th.xml
@@ -1,0 +1,13 @@
+<ruleset name="forest.go.th">
+  <target host="forest.go.th" />
+  <target host="*.forest.go.th" />
+
+  <test url="http://gis.forest.go.th/" />
+  <test url="http://orip.forest.go.th/" />
+  <test url="http://planbudget.forest.go.th/" />
+  <test url="http://protection.forest.go.th/" />
+	<test url="http://web1.forest.go.th/" />
+
+  <rule from="^http:"
+    to="https:" />
+</ruleset>


### PR DESCRIPTION
Allow Cloudflare to enforce Automatic HTTPS Rewrites for websites under forest.go.th so visitors could safely browse them without seeing mixed content warning.