### PR TITLE
[AmericasLongestWar.com] Update default_off reason

### DIFF
--- a/src/chrome/content/rules/Americas_Longest_War.xml
+++ b/src/chrome/content/rules/Americas_Longest_War.xml
@@ -1,4 +1,4 @@
-<ruleset name="America's Longest War" default_off="400">
+<ruleset name="America's Longest War" default_off="mismatched">
 
 	<target host="americaslongestwar.com" />
 	<target host="www.americaslongestwar.com" />


### PR DESCRIPTION
It's probably safer to wait until #9906 is settled before merging. I can update the `default_off` reason to `invalid-certificate` if needed.