### PR TITLE
Update Newgrounds.xml

### DIFF
--- a/src/chrome/content/rules/Newgrounds.xml
+++ b/src/chrome/content/rules/Newgrounds.xml
@@ -1,7 +1,12 @@
 <ruleset name="Newgrounds (partial, broken)" default_off="reported broken">
 
 	<target host="newgrounds.com"/>
+	
+	<!-- Wildcard needed to capture user pages, which contain a password-login widget. See tests for examples -->
 	<target host="*.newgrounds.com"/>
+		<test url="http://tomfulp.newgrounds.com"/>
+		<test url="http://johnnyutah.newgrounds.com"/>
+		<test url="http://psychogoldfish.newgrounds.com"/>
 
 	<rule from="^http:" to="https:"/>
 

--- a/src/chrome/content/rules/Newgrounds.xml
+++ b/src/chrome/content/rules/Newgrounds.xml
@@ -1,9 +1,8 @@
 <ruleset name="Newgrounds (partial, broken)" default_off="reported broken">
 
 	<target host="newgrounds.com"/>
-	<target host="www.newgrounds.com"/>
+	<target host="*.newgrounds.com"/>
 
-	<rule from="^http://(?:www\.)?newgrounds\.com/"
-		to="https://www.newgrounds.com/"/>
+	<rule from="^http:" to="https:"/>
 
 </ruleset>


### PR DESCRIPTION
Capture subdomains (like user pages: <username>.newgrounds.com)

-----------

Newgrounds has dedicated subdomains for user profile pages. These pages have the same general layout as the www site, which includes a login button with username/password fields. Without this ruleset, http links to user profile pages will remain in http, so any logins made from those pages will be unencrypted.