### PR TITLE
create a rule file for MerNetwork

### DIFF
--- a/src/chrome/content/rules/MerNetwork.xml
+++ b/src/chrome/content/rules/MerNetwork.xml
@@ -1,0 +1,6 @@
+<ruleset name="MerNetwork" default_off="firefox bug (block before changing to https) prevents site to function">
+  <!-- bug: https://bugzilla.mozilla.org/show_bug.cgi?id=878890 -->
+  <target host="mernetwork.com" />
+  <rule from="^http:" to="https:" />
+  <test url="https://mernetwork.com/index/forum.php" />
+</ruleset>

--- a/src/chrome/content/rules/MerNetwork.xml
+++ b/src/chrome/content/rules/MerNetwork.xml
@@ -1,5 +1,4 @@
-<ruleset name="MerNetwork" default_off="firefox bug (block before changing to https) prevents site to function">
-  <!-- bug: https://bugzilla.mozilla.org/show_bug.cgi?id=878890 -->
+<ruleset name="MerNetwork">
   <target host="mernetwork.com" />
   <rule from="^http:" to="https:" />
   <test url="https://mernetwork.com/index/forum.php" />

--- a/src/chrome/content/rules/MerNetwork.xml
+++ b/src/chrome/content/rules/MerNetwork.xml
@@ -1,5 +1,5 @@
 <ruleset name="MerNetwork">
   <target host="mernetwork.com" />
   <rule from="^http:" to="https:" />
-  <test url="https://mernetwork.com/index/forum.php" />
+  <test url="http://mernetwork.com/index/forum.php" />
 </ruleset>


### PR DESCRIPTION
It is working but bug in Firefox seem to break it so I have disabled it:
![spectacle k10018](https://cloud.githubusercontent.com/assets/3713914/26285503/d6eec2c2-3e51-11e7-8d89-0828058a22f4.png)

It works if `security.mixed_content.block_active_content` is `false` in `about:config`.
So it can be enabled as soon as this will work without changing this setting.