### PR TITLE
Create AirMap.xml

### DIFF
--- a/src/chrome/content/rules/AirMap.xml
+++ b/src/chrome/content/rules/AirMap.xml
@@ -13,7 +13,7 @@
 	<test url="http://developers.airmap.com/" />
 	<test url="http://support.airmap.com/" />
 	<test url="http://www.airmap.io/" />
-	<test url="http://api.airmap.io" />
+	<test url="http://api.airmap.io/" />
 	<test url="http://app.airmap.io/" />
 	<test url="http://dashboard.airmap.io/" />
 	<test url="http://developers.airmap.com/" />

--- a/src/chrome/content/rules/AirMap.xml
+++ b/src/chrome/content/rules/AirMap.xml
@@ -1,20 +1,26 @@
+<!--
+        Time out:
+                developers.airmap.io
+                sdk.airmap.io
+
+-->
 <ruleset name="AirMap">
 	<target host="airmap.com" />
-	<target host="*.airmap.com" />
-		<test url="http://www.airmap.com/" />
-		<test url="http://cdn.airmap.com/" />
-		<test url="http://dashboard.airmap.com/" />
-		<test url="http://developers.airmap.com/" />
-		<test url="http://support.airmap.com/" />
+	<target host="www.airmap.com" />
+	<target host="api.airmap.com" />
+	<target host="app.airmap.com" />
+	<target host="cdn.airmap.com" />
+	<target host="dashboard.airmap.com" />
+	<target host="developers.airmap.com" />
+	<target host="sdk.airmap.com" />
+	<target host="support.airmap.com" />
 	<target host="airmap.io" />
-	<target host="*.airmap.io" />
-		<test url="http://www.airmap.io/" />
-		<test url="http://api.airmap.io/" />
-		<test url="http://app.airmap.io/" />
-		<test url="http://cdn.airmap.io/" />
-		<test url="http://dashboard.airmap.io/" />
-		<test url="http://developers.airmap.io/" />
-		<test url="http://sso.airmap.io/" />
+	<target host="www.airmap.io" />
+	<target host="api.airmap.io" />
+	<target host="app.airmap.io" />
+	<target host="cdn.airmap.io" />
+	<target host="dashboard.airmap.io" />
+	<target host="sso.airmap.io" />
 	
 	<securecookie host=".+" name=".+" />
 	

--- a/src/chrome/content/rules/AirMap.xml
+++ b/src/chrome/content/rules/AirMap.xml
@@ -1,22 +1,23 @@
 <ruleset name="AirMap">
 	<target host="airmap.com" />
 	<target host="*.airmap.com" />
+		<test url="http://www.airmap.com/" />
+		<test url="http://cdn.airmap.com/" />
+		<test url="http://dashboard.airmap.com/" />
+		<test url="http://developers.airmap.com/" />
+		<test url="http://support.airmap.com/" />
 	<target host="airmap.io" />
 	<target host="*.airmap.io" />
+		<test url="http://www.airmap.io/" />
+		<test url="http://api.airmap.io/" />
+		<test url="http://app.airmap.io/" />
+		<test url="http://cdn.airmap.io/" />
+		<test url="http://dashboard.airmap.io/" />
+		<test url="http://developers.airmap.io/" />
+		<test url="http://sso.airmap.io/" />
 	
 	<securecookie host=".+" name=".+" />
 	
-	<rule from="^http:" to="https:" />
-	
-	<test url="http://www.airmap.com/" />
-	<test url="http://dashboard.airmap.com/" />
-	<test url="http://developers.airmap.com/" />
-	<test url="http://support.airmap.com/" />
-	<test url="http://www.airmap.io/" />
-	<test url="http://api.airmap.io/" />
-	<test url="http://app.airmap.io/" />
-	<test url="http://dashboard.airmap.io/" />
-	<test url="http://developers.airmap.com/" />
-	<test url="http://cdn.airmap.io/" />
-	<test url="http://sso.airmap.io/" />
+	<rule from="^http:"
+			to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/AirMap.xml
+++ b/src/chrome/content/rules/AirMap.xml
@@ -1,0 +1,11 @@
+<ruleset name="AirMap">
+  <target host="*.airmap.com" />
+  <target host="*.airmap.io" />
+  
+  <rule from="^http:" to="https:" />
+
+  <test url="http://www.airmap.com/blog/" />
+  <test url="http://app.airmap.io" />
+  <test url="http://dashboard.airmap.com" />
+  <test url="http://support.airmap.com/hc/en-us" />
+</ruleset>

--- a/src/chrome/content/rules/AirMap.xml
+++ b/src/chrome/content/rules/AirMap.xml
@@ -13,9 +13,10 @@
 	<test url="http://developers.airmap.com/" />
 	<test url="http://support.airmap.com/" />
 	<test url="http://www.airmap.io/" />
+	<test url="http://api.airmap.io" />
 	<test url="http://app.airmap.io/" />
 	<test url="http://dashboard.airmap.io/" />
 	<test url="http://developers.airmap.com/" />
-	<test url="http://cdn.airmap.io/img/airmap-powered-logo.png" />
+	<test url="http://cdn.airmap.io/" />
 	<test url="http://sso.airmap.io/" />
 </ruleset>

--- a/src/chrome/content/rules/AirMap.xml
+++ b/src/chrome/content/rules/AirMap.xml
@@ -1,11 +1,21 @@
 <ruleset name="AirMap">
-  <target host="*.airmap.com" />
-  <target host="*.airmap.io" />
-  
-  <rule from="^http:" to="https:" />
-
-  <test url="http://www.airmap.com/blog/" />
-  <test url="http://app.airmap.io" />
-  <test url="http://dashboard.airmap.com" />
-  <test url="http://support.airmap.com/hc/en-us" />
+	<target host="airmap.com" />
+	<target host="*.airmap.com" />
+	<target host="airmap.io" />
+	<target host="*.airmap.io" />
+	
+	<securecookie host=".+" name=".+" />
+	
+	<rule from="^http:" to="https:" />
+	
+	<test url="http://www.airmap.com/" />
+	<test url="http://dashboard.airmap.com/" />
+	<test url="http://developers.airmap.com/" />
+	<test url="http://support.airmap.com/" />
+	<test url="http://www.airmap.io/" />
+	<test url="http://app.airmap.io/" />
+	<test url="http://dashboard.airmap.io/" />
+	<test url="http://developers.airmap.com/" />
+	<test url="http://cdn.airmap.io/img/airmap-powered-logo.png" />
+	<test url="http://sso.airmap.io/" />
 </ruleset>


### PR DESCRIPTION
Ruleset for airmap.com and airmap.io. ~~Left-wildcards were used, as all domains I found supported HTTPS.~~