### PR TITLE
Delete arma2.com.xml

### DIFF
--- a/src/chrome/content/rules/arma2.com.xml
+++ b/src/chrome/content/rules/arma2.com.xml
@@ -1,6 +1,0 @@
-<ruleset name="ArmA 2 (Partial)" default_off="Bad Cert">
-  <target host="arma2.com" />
-  <target host="www.arma2.com" />
-
-  <rule from="^http://(?:www\.)?arma2\.com/" to="https://www.arma2.com/" />
-</ruleset>


### PR DESCRIPTION
Delete `arma2.com.xml` because all sub-domains of `*.arma2.com` serves `mismatched` certificates. See https://gist.github.com/cschanaj/588d38dbffdc8346588331addc916709