### PR TITLE
Fix Argument list too long error

### DIFF
--- a/src/chrome/content/rules/make-trivial-rule
+++ b/src/chrome/content/rules/make-trivial-rule
@@ -35,7 +35,7 @@ fi
 lower=$(echo "$1" | tr A-Z a-z)
 escaped=$(echo "$lower" | sed 's/\./\\./g' )
 
-duplicate=$(grep -EHin '<target\s+host="(w+\.)?'$escaped'"\s*/>' *.xml)
+duplicate=$(find . -name '*.xml' -exec grep -EHin '<target\s+host="(w+\.)?'$escaped'"\s*/>' -- {} +)
 if [ -n "$duplicate" ]
 then
   echo "error: $lower already exists:" >&2


### PR DESCRIPTION
22,000 files was too many to handle as a glob when checking whether an existing rule matches a new one. This addresses the issue by using `find -exec` instead of a glob.

Manually tested on macOS Sierra. I'm assuming the syntax will likely be the same, but not aware of the cross platform requirements of this project enough to make a call.