### PR TITLE
 	Update Fr33tux.org.xml 

### DIFF
--- a/src/chrome/content/rules/Fr33tux.org.xml
+++ b/src/chrome/content/rules/Fr33tux.org.xml
@@ -3,6 +3,8 @@
 	<target host="fr33tux.org" />
 	<target host="www.fr33tux.org" />
 	<target host="p.fr33tux.org" />
+	<target host="tor.fr33tux.org" />
+	<target host="wp.fr33tux.org" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Fr33tux.org.xml
+++ b/src/chrome/content/rules/Fr33tux.org.xml
@@ -1,13 +1,7 @@
-
-<!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://git.fr33tux.org/ => https://git.fr33tux.org/: (6, 'Could not resolve host: git.fr33tux.org')
-
--->
-<ruleset name="fr33tux.org" platform="cacert mixedcontent" default_off='failed ruleset test'>
+<ruleset name="fr33tux.org">
 
 	<target host="fr33tux.org" />
-	<target host="git.fr33tux.org" />
+	<target host="www.fr33tux.org" />
 	<target host="p.fr33tux.org" />
 
 


### PR DESCRIPTION
Delete `Fr33tux.org.xml` since it is currently preloaded, for completion of #9582. See https://hstspreload.org/?domain=fr33tux.org Related: #10056 