### PR TITLE
Fix media.idownloadblog.com rule

### DIFF
--- a/src/chrome/content/rules/IDownloadBlog.xml
+++ b/src/chrome/content/rules/IDownloadBlog.xml
@@ -1,18 +1,8 @@
-<!--
-	CDN buckets:
-
-		- idownloadblog.plssl.com
-
--->
 <ruleset name="iDownloadBlog (partial)">
 
 	<target host="media.idownloadblog.com" />
 
-
-	<!--	- Pages 404 as-is
-		- Pages 302 back from plssl
-						-->
-	<rule from="^http://media\.idownloadblog\.com/"
-		to="https://idownloadblog.plssl.com/" />
+	<rule from="^http:"
+		to="https:" />
 
 </ruleset>


### PR DESCRIPTION
All assets from *media.idownloadblog.com* (CSS, JS, images) are broken with the existing ruleset (#9412).

*idownloadblog.plssl.com* doesn't seem to exist any more, but HTTPS now works on *media.idownloadblog.com*.