### PR TITLE
add rule for Magictail

### DIFF
--- a/src/chrome/content/rules/Magictail.net.xml
+++ b/src/chrome/content/rules/Magictail.net.xml
@@ -1,4 +1,4 @@
-<ruleset name="Magictail">
+<ruleset name="magictail.net">
 	<target host="magictail.net" />
 	<target host="www.magictail.net" />
 

--- a/src/chrome/content/rules/Magictail.xml
+++ b/src/chrome/content/rules/Magictail.xml
@@ -1,0 +1,9 @@
+<ruleset name="Magictail">
+	<target host="www.magictail.net" />
+	<target host="magictail.net" />
+
+	<rule from="^http:" to="https:" />
+
+	<test url="http://www.magictail.net/" />
+	<test url="http://magictail.net/" />
+</ruleset>

--- a/src/chrome/content/rules/Magictail.xml
+++ b/src/chrome/content/rules/Magictail.xml
@@ -1,9 +1,6 @@
 <ruleset name="Magictail">
-	<target host="www.magictail.net" />
 	<target host="magictail.net" />
+	<target host="www.magictail.net" />
 
 	<rule from="^http:" to="https:" />
-
-	<test url="http://www.magictail.net/" />
-	<test url="http://magictail.net/" />
 </ruleset>


### PR DESCRIPTION
Probably low priority but it's better if it exists ;)

Page has very good HTTPS support (green lock so no 3rd party content is loaded via HTTP).