### PR TITLE
[Uni-Muenchen.de] Remove wildcard (fix #10161)

### DIFF
--- a/src/chrome/content/rules/LMU-Muenchen.xml
+++ b/src/chrome/content/rules/LMU-Muenchen.xml
@@ -20,8 +20,11 @@
 -->
 <ruleset name="LM Uni Muenchen">
 
-	<target host="*.uni-muenchen.de" />
-
+	<target host="www.uni-muenchen.de" />
+	<target host="cms-static.uni-muenchen.de" />
+	<target host="www.en.uni-muenchen.de" />
+	<target host="www.portal.uni-muenchen.de" />
+	<target host="login.portal.uni-muenchen.de" />
 
 	<!--	Secured by server:
 					-->
@@ -33,10 +36,9 @@
 	<!--securecookie host="^www.portal.uni-muenchen.de$" name="^_shibstate_\d{10}_\w{4}$" /-->
 	<!--securecookie host="^www\.uni-muenchen\.de$" name="^JSESSIONID$" /-->
 
-	<securecookie host=".*\.uni-muenchen\.de$" name=".+" />
+	<securecookie host=".+" name=".+" />
 
-
-	<rule from="^http://(cms-static|www\.en|(?:login|www)\.portal|www)\.uni-muenchen\.de/"
-		to="https://$1.uni-muenchen.de/" />
+	<rule from="^http:"
+		to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/LMU-Muenchen.xml
+++ b/src/chrome/content/rules/LMU-Muenchen.xml
@@ -36,6 +36,7 @@
 	<!--securecookie host="^www.portal.uni-muenchen.de$" name="^_shibstate_\d{10}_\w{4}$" /-->
 	<!--securecookie host="^www\.uni-muenchen\.de$" name="^JSESSIONID$" /-->
 
+	<!-- see https://github.com/EFForg/https-everywhere/issues/10161 -->
 	<securecookie host=".+" name=".+" />
 
 	<rule from="^http:"


### PR DESCRIPTION
Attempt at fixing #10161.

I purposely did not add any new subdomain but simply kept the previous coverage after fixing the securecookie.