### PR TITLE
Delete Cannagraphic.xml

### DIFF
--- a/src/chrome/content/rules/Cannagraphic.xml
+++ b/src/chrome/content/rules/Cannagraphic.xml
@@ -1,8 +1,0 @@
-<!-- ICMag SSL cert is valid for www domains; https://icmag.com/* gives invalid cert warning -->
-<ruleset name="Intl Cannagraphic Magazine">
-  <target host="www.icmag.*" />
-  <target host="icmag.*" />
-  
-  <rule from="^http://(?:www\.)?icmag\.com/" to="https://www.icmag.com/"/>
-  <rule from="^http://(?:www\.)?icmag\.com/ic/" to="https://www.icmag.com/ic/"/>
-</ruleset>


### PR DESCRIPTION
**Note to reviewers: this is a website about cannabis consumption and growth. I am guessing depending on your country, you might get in trouble for checking this website (???).**

I don't know what the right wildcard was for.

`Sublist3r` found 3 subdomains for `icmag.com`

- https://icmag.com redirects to http://mag.icmag.com
- https://www.icmag.com redirects to http://mag.icmag.com
- https://mag.icmag.com is mismatched

so this ruleset isn't protecting anything.