### PR TITLE
Update rules/make-trivial-rule to perform basic SSL verifications

### DIFF
--- a/src/chrome/content/rules/make-trivial-rule
+++ b/src/chrome/content/rules/make-trivial-rule
@@ -67,4 +67,25 @@ cat > "$dest" <<END
 </ruleset>
 END
 
-echo "$0: created $dest; please examine it." >&2
+# check $lower
+wget "https://$lower/" -O /dev/null -o /dev/null
+if [ "$?" -eq 5 ]; then
+  sed -i "/<target host=\"$lower\" \/>/d" "$dest"
+  echo "error: $lower: SSL verification failure" >&2
+fi
+
+# check www.$lower
+wget "https://www.$lower/" -O /dev/null -o /dev/null
+if [ "$?" -eq 5 ]; then
+  sed -i "/<target host=\"www.$lower\" \/>/d" "$dest"
+  echo "error: www.$lower: SSL verification failure" >&2
+fi
+
+target_count=$(grep -F '<target host=' "$dest" | wc -l)
+if [ "$target_count" -gt 0 ]; then 
+  echo "$0: created $dest; please examine it." >&2
+else
+  rm "$dest"
+  echo "error: neither $lower nor www.$lower support https" >&2
+  exit 1
+fi


### PR DESCRIPTION
A problem is that I have difficulty update the comment despite SSL verification results are available. Feel free to close this if this modification is not desirable. Thanks.

P.S. `wget` is used to avoid external dependencies like `curl`

P.S.2 The checking can be stricter if `"$?" -ne 0` is used instead of [`rules/make-trivial-rule#79`](https://github.com/EFForg/https-everywhere/pull/10267/files#diff-4ac8b1e3c56b32aa60f09b3f22046008R79)