### PR TITLE
Update CNN.com.xml, Fix #9964

### DIFF
--- a/src/chrome/content/rules/CNN.com.xml
+++ b/src/chrome/content/rules/CNN.com.xml
@@ -45,6 +45,8 @@
 
 		Mixed content blocking (MCB) tiggered:
 			 - go.cnn.com
+			 - markets.money.cnn.com
+			 	+ http://money.cnn.com/data/world_markets/americas/?iid=H_MKT_QL
 			 - www.preview.cnn.com
 
 		CORS Blocking:
@@ -62,7 +64,6 @@
 		<test url="http://i2.cdn.cnn.com/cnnnext/dam/assets/170313100039-04-climate-change-impact-small-11.jpg" />
 		<test url="http://i2.cdn.cnn.com/cnnnext/dam/assets/170409024444-uss-carl-vinson-large-tease.jpg" />
 		<test url="http://i2.cdn.cnn.com/cnnnext/dam/assets/170423103501-france-election-security-eiffel-overlay-tease.jpg" />
-	<target host="markets.money.cnn.com" />
 	<target host="travel.cnn.com" />
 
 	<rule from="^http:" to="https:" />


### PR DESCRIPTION
Despite `markets.money` works perfectly on `platform="mixedcontent"`, I would like to avoid writing a `mixedcontent` rule because of https://github.com/EFForg/https-everywhere/issues/9971#issuecomment-304081854, which mentioned that 

> The platform="mixedcontent" attribute was always intended as a short-term solution, see https://bugzilla.mozilla.org/show_bug.cgi?id=878890#c20.