### PR TITLE
Create SmackJeeves.xml

### DIFF
--- a/src/chrome/content/rules/SmackJeeves.xml
+++ b/src/chrome/content/rules/SmackJeeves.xml
@@ -1,0 +1,17 @@
+<!--
+	Smack Jeeves Webcomic Hosting (www.smackjeeves.com)
+	
+	Known non-HTTPS hosts in *.smackjeeves.com:
+	
+		- img2.smackjeeves.com (image server)
+		- *.smackjeeves.com (comic sites, except img2.smackjeeves.com
+		                     and www.smackjeeves.com)
+	
+-->
+<ruleset name="Smack Jeeves (partial)">
+	<target host="www.smackjeeves.com" />
+	<target host="smackjeeves.com" />
+	
+	<rule from="^http:"
+		to="https:" />
+</ruleset>


### PR DESCRIPTION
This pull request partially enforces HTTPS on the main domain of Smack Jeeves webcomic hosting site ([www.smackjeeves.com](https://www.smackjeeves.com/)), as it has stable TLS support with [cPanel](https://cpanel.com/) certificate for a while now.

Note: Image server ([img2.smackjeeves.com](http://img2.smackjeeves.com/)) used throughout the site is not covered by this rule as it does not support HTTPS; hence "_(partial)_" was added to the rule name.
