### PR TITLE
makecrx.sh: improve support for macOS

### DIFF
--- a/makecrx.sh
+++ b/makecrx.sh
@@ -98,7 +98,7 @@ trap 'rm -f "$pub" "$sig" "$zip"' EXIT
 # zip up the crx dir
 cwd=$(pwd -P)
 (cd "$dir" && ../../utils/create_xpi.py -n "$cwd/$zip" -x "../../.build_exclusions" .)
-echo >&2 "Unsigned package has sha1sum: `sha1sum "$cwd/$zip"`"
+echo >&2 "Unsigned package has sha1sum: $(openssl dgst -sha1 "$cwd/$zip" | awk '{print $2}')"
 
 # signature
 openssl sha1 -sha1 -binary -sign "$key" < "$zip" > "$sig"

--- a/makecrx.sh
+++ b/makecrx.sh
@@ -115,8 +115,16 @@ crmagic_hex="4372 3234" # Cr24
 version_hex="0200 0000" # 2
 pub_len_hex=$(byte_swap $(printf '%08x\n' $(ls -l "$pub" | awk '{print $5}')))
 sig_len_hex=$(byte_swap $(printf '%08x\n' $(ls -l "$sig" | awk '{print $5}')))
+
+# Case-insensitive matching is a GNU extension unavailable when using BSD sed.
+if [[ "$(sed --version 2>&1)" =~ "GNU" ]]; then
+  sed="sed"
+elif [[ "$(gsed --version 2>&1)" =~ "GNU" ]]; then
+  sed="gsed"
+fi
+
 (
-  echo "$crmagic_hex $version_hex $pub_len_hex $sig_len_hex" | sed -e 's/\s//g' -e 's/\([0-9A-F]\{2\}\)/\\\\\\x\1/gI' | xargs printf
+  echo "$crmagic_hex $version_hex $pub_len_hex $sig_len_hex" | $sed -e 's/\s//g' -e 's/\([0-9A-F]\{2\}\)/\\\\\\x\1/gI' | xargs printf
   cat "$pub" "$sig" "$zip"
 ) > "$crx"
 #rm -rf pkg/crx


### PR DESCRIPTION
An attempt to handle a couple of issues with this script when using macOS, stumbled across in https://github.com/EFForg/https-everywhere/pull/10072#issuecomment-305370157.

It's written in such a way that it shouldn't mess with anything on the Linux side of development but I will spin up a VM a little later today to triple check that.

Locally after this change:
```
~> PYTHONPATH="/private/tmp/https-venv/lib/python2.7/site-packages" makecrx.sh
Building chrome version 2017.6.5
Generating ruleset DB
Validation of included rulesets completed.

Validation of rulesets against relaxng.xml succeeded.
Creating ruleset library...
Removing whitespaces and comments...
chrome/content/rules/default.rulesets passed XML validity test.
Unsigned package has sha1sum: 2386676cfd3157dcb3592697748439866238e909
Total included rules:    22831
Rules disabled by default:     3811
Created pkg/https-everywhere-2017.6.5~pre.crx
```

Or if you don't have a GNU `sed` available:
```
~> PYTHONPATH="/private/tmp/https-venv/lib/python2.7/site-packages" makecrx.sh
Building chrome version 2017.6.5
Generating ruleset DB
Validation of included rulesets completed.

Validation of rulesets against relaxng.xml succeeded.
Creating ruleset library...
Removing whitespaces and comments...
chrome/content/rules/default.rulesets passed XML validity test.
Unsigned package has sha1sum: 2386676cfd3157dcb3592697748439866238e909
Cannot find a GNU sed. Please install one!
```

Theoretically anyone who has run the `install-dev-dependencies.sh` script shouldn't be in a situation where they don't have a GNU `sed` installed, but it's perfectly possible for GNU `sed` to be either `sed` or `gsed` on macOS hence the name logic.