### PR TITLE
Delete TV.com.xml

### DIFF
--- a/src/chrome/content/rules/TV.com.xml
+++ b/src/chrome/content/rules/TV.com.xml
@@ -1,9 +1,0 @@
-<!-- tv.com includes stuff from .com.com. which do NOT allow https :( -->
-<ruleset name="TV.com (broken)" default_off="JS redirects back to HTTP">
-	<target host="tv.com" />
-	<target host="www.tv.com" />
-
-	<rule from="^http://tv\.com/" to="https://www.tv.com/"/>
-	<rule from="^http://www\.tv\.com/" to="https://www.tv.com/"/>
-</ruleset>
-


### PR DESCRIPTION
#9906 None of its sub-domains works over HTTPS.
```xml
<!--
	Non-functional hosts
		Couldn't connect to server:
			 - tv.com
			 - gallery.tv.com
			 - get.tv.com
			 - socialize.tv.com

		Timeout was reached:
			 - authorize.tv.com
			 - ct.tv.com
			 - mads.tv.com

		SSL peer certificate was not OK:
			 - www.tv.com
			 - abc.tv.com
			 - assets.tv.com
			 - au.tv.com
			 - beta.tv.com
			 - blog.tv.com
			 - bravo.tv.com
			 - dw.tv.com
			 - google.tv.com
			 - li.tv.com
			 - uk.tv.com
			 - us.tv.com
			 - userimg.tv.com
			 - origin.www.tv.com

		4xx client error:
			 - urs.tv.com

		5xx server error:
			 - secure.tv.com
-->
<ruleset name="TV.com">

	<rule from="^http:" to="https:" />
</ruleset>

```