### PR TITLE
Delete Lavasoft.com.xml

### DIFF
--- a/src/chrome/content/rules/Lavasoft.com.xml
+++ b/src/chrome/content/rules/Lavasoft.com.xml
@@ -1,7 +1,0 @@
-<ruleset name="Lavasoft (broken)" default_off="https gone">
-	<target host="lavasoft.com" />
-	<target host="www.lavasoft.com" />
-	<rule from="^http://lavasoft\.com/" to="https://secure.lavasoft.com/"/>
-	<rule from="^http://www\.lavasoft\.com/" to="https://secure.lavasoft.com/"/>
-</ruleset>
-


### PR DESCRIPTION
#9906 Both `^` and `www` give incomplete certificate chain errors.