### PR TITLE
Update OpenBSD.org.xml

### DIFF
--- a/src/chrome/content/rules/OpenBSD.org.xml
+++ b/src/chrome/content/rules/OpenBSD.org.xml
@@ -1,10 +1,6 @@
 <!--	
-	Problematic subdomains in *openbsd.org:
-		Mismatched:
-			- firmware
-		Refused:
-			- ftp2.eu
-			- man
+	Mismatched certificate:
+		- firmware.openbsd.org
 
 --><ruleset name="OpenBSD.org (partial)">
 	<target host="openbsd.org" />
@@ -12,12 +8,14 @@
 	<target host="cvsweb.openbsd.org" />
 	<target host="ftp.openbsd.org" />
 	<target host="ftp.eu.openbsd.org" />
+	<target host="ftp2.eu.openbsd.org" />
 	<target host="ftp.fr.openbsd.org" />
 	<target host="ftp.usa.openbsd.org" />
 	<target host="ftp3.usa.openbsd.org" />
 	<target host="ftp4.usa.openbsd.org" />
 	<target host="ftp5.usa.openbsd.org" />
 	<target host="lists.openbsd.org" />
+	<target host="man.openbsd.org" />
 	<target host="portroach.openbsd.org" />
 
 	<rule from="^http:"


### PR DESCRIPTION
tldr: update OpenBSD.org.xml to add rule for https://ftp2.eu.openbsd.org and https://man.openbsd.org.


Hi,

Update for OpenBSD.org.xml: man.openbsd.org and ftp2.eu.openbsd.org have been enabled for TLS, firmware.openbsd.org remains with a mismatched certificate.

Tested with ``curl --tlsv1.2 $host``, Chrome 59.0.3071.86 and Firefox 53.0.3:
General browsing and file download work fine for:
	https://man.openbsd.org
	https://ftp2.eu.openbsd.org

I have attached a pull request with the update.