### PR TITLE
Remove support for downgrade rules.

### DIFF
--- a/src/chrome/content/code/HTTPS.js
+++ b/src/chrome/content/code/HTTPS.js
@@ -264,8 +264,6 @@ const HTTPS = {
   
   
   cookiesCleanup: function(refCookie) {
-    var downgraded = [];
-
     var ignored = this.secureCookiesExceptions;
     var disabled = !this.secureCookies;
     var bi = DOM.createBrowserIterator();

--- a/utils/relaxng.xml
+++ b/utils/relaxng.xml
@@ -75,9 +75,6 @@
             <param name="pattern">(https?://[^ \\]*/[^ \\]*|https:)</param>
           </data>
         </attribute>
-        <optional>
-            <attribute name="downgrade" />
-        </optional>
       </element>
     </oneOrMore>
 

--- a/utils/simple.py
+++ b/utils/simple.py
@@ -27,8 +27,6 @@ def simple(f):
     not tree.xpath("/ruleset/exclusion"),
     # targets must not contain any wildcards
     not any("*" in target for target in targets),
-    # ruleset must not contain any downgrade rules
-    not any("downgrade" in rule.attrib for rule in tree.xpath("/ruleset/rule")),
     # and every rule must itself be simple according to the criteria below
     all(simple_rule(rule, targets) for rule in tree.xpath("/ruleset/rule"))
     ])

--- a/utils/single_rule_response.py
+++ b/utils/single_rule_response.py
@@ -89,8 +89,6 @@ if __name__ == "__main__":
     seen = []
     for rule in tree.xpath('/ruleset/rule'):
         to = rule.get('to')
-        if rule.get('downgrade') or to in seen:
-            continue
         if back_ref.search(to):
             continue
         if not test_response_no_redirect(to):

--- a/utils/trivial-validate.py
+++ b/utils/trivial-validate.py
@@ -32,10 +32,8 @@ xpath_exclusion_pattern = etree.XPath("/ruleset/exclusion/@pattern")
 xpath_cookie_host_pattern = etree.XPath("/ruleset/securecookie/@host")
 xpath_cookie_name_pattern = etree.XPath("/ruleset/securecookie/@name")
 
-# Load lists of ruleset names whitelisted for downgrade & duplicate rules
+# Load lists of ruleset names whitelisted for duplicate rules
 thispath = os.path.dirname(os.path.realpath(__file__))
-with open(thispath + '/downgrade-whitelist.txt') as downgrade_fh:
-    downgrade_allowed_list = [x.rstrip('\n') for x in downgrade_fh.readlines()]
 with open(thispath + '/duplicate-whitelist.txt') as duplicate_fh:
     duplicate_allowed_list = [x.rstrip('\n') for x in duplicate_fh.readlines()]
 
@@ -96,21 +94,10 @@ def test_unencrypted_to(tree, rulename, from_attrib, to):
     # Rules that redirect to something other than https or http.
     # This used to test for http: but testing for lack of https: will
     # catch more kinds of mistakes.
-    # Now warn if the rule author indicates they intended it, with the
-    # downgrade attribute.  Error if this attribute is not present.
     """Rule redirects to something other than https."""
     for rule in xpath_rule(tree):
-        to, downgrade = rule.get("to"), rule.get("downgrade")
-        if to[:6] != "https:" and to[:5] != "http:":
-            return False
-        elif to[:5] == "http:" and downgrade:
-            if rulename in downgrade_allowed_list:
-                warn("whitelisted downgrade rule in %s redirects to http." % rulename)
-            else:
-                fail("non-whitelisted downgrade rule in %s redirects to http." % rulename)
-                return False
-        elif to[:5] == "http:":
-            fail("non-downgrade rule in %s redirects to http." % rulename)
+        to = rule.get("to")
+        if to[:6] != "https:":
             return False
     return True
 


### PR DESCRIPTION
Downgrades to HTTP are detected and rejected in trivial-validate.py. We
used to have a handful of exemptions, but the list of exemptions has
become empty, so we are removing this function forever.

Relates to #1327.

/cc @ivysrono @semenko @Hainish 