### PR TITLE
update rules for tocco.ch

### DIFF
--- a/src/chrome/content/rules/Tocco.ch.xml
+++ b/src/chrome/content/rules/Tocco.ch.xml
@@ -1,13 +1,17 @@
 <!--
-	Invalid certificate:
-		juventus.tocco.ch
-		sfb.tocco.ch
-		sfbtest.tocco.ch
-		sfbv.tocco.ch
-		uzhmels.tocco.ch
-		uzhmelstest.tocco.ch
-		zb.tocco.ch
-		zbtest.tocco.ch
+	Non-functional hosts:
+		Certificate mismatch:
+			- juventus.tocco.ch
+			- sfb.tocco.ch
+			- sfbtest.tocco.ch
+			- sfbv.tocco.ch
+			- uzhmels.tocco.ch
+			- uzhmelstest.tocco.ch
+			- zb.tocco.ch
+			- zbtest.tocco.ch
+		Connection refused:
+			- santesuisse.tocco.ch
+			- santesuissetest.tocco.ch
 -->
 <ruleset name="Tocco AG">
 	<target host="tocco.ch" />
@@ -19,6 +23,7 @@
 	<target host="agogistest.tocco.ch" />
 	<target host="arge.tocco.ch" />
 	<target host="argetest.tocco.ch" />
+	<target host="artifactory01.tocco.ch" />
 	<target host="avanti.tocco.ch" />
 	<target host="avantitest.tocco.ch" />
 	<target host="awpf.tocco.ch" />
@@ -41,8 +46,6 @@
 	<target host="dghtest.tocco.ch" />
 	<target host="dls.tocco.ch" />
 	<target host="dlstest.tocco.ch" />
-	<target host="docker.tocco.ch" />
-	<target host="dockertest.tocco.ch" />
 	<target host="documentation.tocco.ch" />
 	<target host="ecap.tocco.ch" />
 	<target host="ecaptest.tocco.ch" />
@@ -50,7 +53,6 @@
 	<target host="elk01.tocco.ch" />
 	<target host="enga.tocco.ch" />
 	<target host="extranet.tocco.ch" />
-	<target host="feusi.tocco.ch" />
 	<target host="ffgs.tocco.ch" />
 	<target host="ffgstest.tocco.ch" />
 	<target host="fsn.tocco.ch" />
@@ -58,25 +60,37 @@
 	<target host="gerrit.tocco.ch" />
 	<target host="git.tocco.ch" />
 	<target host="graphite.tocco.ch" />
+	<target host="gst.tocco.ch" />
 	<target host="gvz.tocco.ch" />
 	<target host="gvztest.tocco.ch" />
 	<target host="hftm.tocco.ch" />
+	<target host="hftmtest.tocco.ch" />
+	<target host="hrswiss.tocco.ch" />
 	<target host="icfo.tocco.ch" />
 	<target host="ief.tocco.ch" />
 	<target host="iffp.tocco.ch" />
+	<target host="iffp1.tocco.ch" />
+	<target host="iffp2.tocco.ch" />
 	<target host="iffptest.tocco.ch" />
 	<target host="inlingua.tocco.ch" />
 	<target host="inlinguatest.tocco.ch" />
 	<target host="juventustest.tocco.ch" />
+	<target host="k5bs.tocco.ch" />
 	<target host="kinderaerzte.tocco.ch" />
+	<target host="kinderaerztetest.tocco.ch" />
 	<target host="koshiatsu.tocco.ch" />
 	<target host="koshiatsutest.tocco.ch" />
 	<target host="lakesideschool.tocco.ch" />
 	<target host="lmb.tocco.ch" />
 	<target host="magenta.tocco.ch" />
+	<target host="maltech.tocco.ch" />
+	<target host="maltechtest.tocco.ch" />
 	<target host="manual.tocco.ch" />
 	<target host="master.tocco.ch" />
+	<target host="master2.tocco.ch" />
+	<target host="master3.tocco.ch" />
 	<target host="mvn.tocco.ch" />
+	<target host="newplacement.tocco.ch" />
 	<target host="nhk.tocco.ch" />
 	<target host="nhktest.tocco.ch" />
 	<target host="nose.tocco.ch" />
@@ -84,15 +98,19 @@
 	<target host="nvstest.tocco.ch" />
 	<target host="odags.tocco.ch" />
 	<target host="odagstest.tocco.ch" />
+	<target host="odaszh.tocco.ch" />
 	<target host="phsg.tocco.ch" />
+	<target host="pkp-reports.tocco.ch
 	<target host="redcross.tocco.ch" />
 	<target host="redcrosstest.tocco.ch" />
 	<target host="rss.tocco.ch" />
 	<target host="rsstest.tocco.ch" />
+	<target host="sah.tocco.ch" />
 	<target host="saz.tocco.ch" />
 	<target host="saztest.tocco.ch" />
 	<target host="sgd.tocco.ch" />
 	<target host="sgdtest.tocco.ch" />
+	<target host="shl.tocco.ch" />
 	<target host="siu.tocco.ch" />
 	<target host="siutest.tocco.ch" />
 	<target host="sjv.tocco.ch" />
@@ -104,8 +122,10 @@
 	<target host="sonar.tocco.ch" />
 	<target host="sorbetto.tocco.ch" />
 	<target host="spedlogswiss.tocco.ch" />
+	<target host="spedlogswisstest.tocco.ch" />
 	<target host="spi.tocco.ch" />
 	<target host="spitest.tocco.ch" />
+	<target host="sps.tocco.ch" />
 	<target host="spv.tocco.ch" />
 	<target host="spvtest.tocco.ch" />
 	<target host="srksg.tocco.ch" />
@@ -116,20 +136,28 @@
 	<target host="tc.tocco.ch" />
 	<target host="teamcity.tocco.ch" />
 	<target host="test.tocco.ch" />
+	<target host="test1.tocco.ch" />
+	<target host="test2.tocco.ch" />
 	<target host="tgv.tocco.ch" />
 	<target host="tgvtest.tocco.ch" />
+	<target host="tlc.tocco.ch" />
 	<target host="tocco.tocco.ch" />
+	<target host="tocco1.tocco.ch" />
+	<target host="tocco2.tocco.ch" />
 	<target host="toccotest.tocco.ch" />
 	<target host="toz.tocco.ch" />
 	<target host="toztest.tocco.ch" />
 	<target host="usic.tocco.ch" />
 	<target host="usictest.tocco.ch" />
+	<target host="uzhavinventar.tocco.ch" />
+	<target host="uzhavinventartest.tocco.ch" />
 	<target host="visana.tocco.ch" />
 	<target host="visanatest.tocco.ch" />
 	<target host="wiki.tocco.ch" />
+	<target host="zbrest.tocco.ch" />
 	<target host="zewo.tocco.ch" />
+	<target host="zewotest.tocco.ch" />
 	<target host="zgp.tocco.ch" />
-	<target host="zgppilot.tocco.ch" />
 	<target host="zgptest.tocco.ch" />
 
 	<securecookie host=".+" name=".+" />

--- a/src/chrome/content/rules/Tocco.ch.xml
+++ b/src/chrome/content/rules/Tocco.ch.xml
@@ -100,7 +100,7 @@
 	<target host="odagstest.tocco.ch" />
 	<target host="odaszh.tocco.ch" />
 	<target host="phsg.tocco.ch" />
-	<target host="pkp-reports.tocco.ch
+	<target host="pkp-reports.tocco.ch" />
 	<target host="redcross.tocco.ch" />
 	<target host="redcrosstest.tocco.ch" />
 	<target host="rss.tocco.ch" />

--- a/src/chrome/content/rules/Tocco.ch.xml
+++ b/src/chrome/content/rules/Tocco.ch.xml
@@ -100,7 +100,6 @@
 	<target host="odagstest.tocco.ch" />
 	<target host="odaszh.tocco.ch" />
 	<target host="phsg.tocco.ch" />
-	<target host="pkp-reports.tocco.ch" />
 	<target host="redcross.tocco.ch" />
 	<target host="redcrosstest.tocco.ch" />
 	<target host="rss.tocco.ch" />


### PR DESCRIPTION
The content has been generated directly from the DNS zone file
using #7706. Host names used for non-HTTP purposes, proxying, etc.
I left out intentionally.