### PR TITLE
Delete Gnosis-Software.xml

### DIFF
--- a/src/chrome/content/rules/Gnosis-Software.xml
+++ b/src/chrome/content/rules/Gnosis-Software.xml
@@ -1,9 +1,0 @@
-<ruleset name="Gnosis Software" default_off="Certificate mismatch">
-
-	<target host="gnosis.cx" />
-	<target host="www.gnosis.cx" />
-
-	<rule from="^http://(?:www\.)?gnosis\.cx/"
-		to="https://gnosis.cx/" />
-
-</ruleset>


### PR DESCRIPTION
#9906 none of `^` and `www` works over HTTPS. 