### PR TITLE
Delete GP2X.de.xml

### DIFF
--- a/src/chrome/content/rules/GP2X.de.xml
+++ b/src/chrome/content/rules/GP2X.de.xml
@@ -1,9 +1,0 @@
-<ruleset name="GP2X.de (partial)" default_off="Certificate mismatch">
-
-	<target host="gp2x.de" />
-	<target host="www.gp2x.de" />
-
-	<rule from="^http://(?:www\.)?gp2x\.de/shop"
-		to="https://gp2x.de/shop" />
-
-</ruleset>


### PR DESCRIPTION
#9906 Both `^` and `www` gives incomplete certificate chain errors.