### PR TITLE
Delete Gifsauce.xml

### DIFF
--- a/src/chrome/content/rules/Gifsauce.xml
+++ b/src/chrome/content/rules/Gifsauce.xml
@@ -1,9 +1,0 @@
-<ruleset name="Gifsauce" default_off="Certificate mismatch">
-
-  <target host="gifsauce.us" />
-  <target host="www.gifsauce.us" />
-
-  <rule from="^http://(?:www\.)?gifsauce\.us/"
-          to="https://gifsauce.us/" />
-
-</ruleset>


### PR DESCRIPTION
#9906 domain on sale. both `^` and `www` refuse connection over HTTPS.