### PR TITLE
Delete Blosxom.com.xml

### DIFF
--- a/src/chrome/content/rules/Blosxom.com.xml
+++ b/src/chrome/content/rules/Blosxom.com.xml
@@ -1,9 +1,0 @@
-<ruleset name="blosxom.com" default_off="Certificate mismatch">
-
-	<target host="blosxom.com" />
-	<target host="www.blosxom.com" />
-
-	<rule from="^http://(?:www\.)?blosxom\.com/"
-		to="https://blosxom.com/" />
-
-</ruleset>


### PR DESCRIPTION
#9906 both `^` and `www` do not work over HTTPS.