### PR TITLE
LinuxFoundation Pardot bugfixes and updates

### DIFF
--- a/src/chrome/content/rules/LinuxFoundation.xml
+++ b/src/chrome/content/rules/LinuxFoundation.xml
@@ -24,17 +24,9 @@ Fetch error: http://eventsstg.linuxfoundation.org/sites/all/themes/lfevents/css/
 
 	Partially covered hosts in *linuxfoundation.org:
 
-		- collabprojects ʰ
 		- events ʰ
-		- eventsstg ʰ
-		- www ʰ
 
 	ʰ Some pages redirect to http
-
-
-	Insecure cookies are set for these domains:
-
-		- developerbugs.linuxfoundation.org
 
 -->
 <ruleset name="Linux Foundation.org (partial)" default_off='failed ruleset test'>
@@ -49,7 +41,6 @@ Fetch error: http://eventsstg.linuxfoundation.org/sites/all/themes/lfevents/css/
 	<target host="collabprojects.linuxfoundation.org" />
 	<target host="developerbugs.linuxfoundation.org" />
 	<target host="events.linuxfoundation.org" />
-	<target host="eventsstg.linuxfoundation.org" />
 	<target host="identity.linuxfoundation.org" />
 	<target host="ldn.linuxfoundation.org" />
 	<target host="lists.linuxfoundation.org" />
@@ -61,69 +52,34 @@ Fetch error: http://eventsstg.linuxfoundation.org/sites/all/themes/lfevents/css/
 				-->
 	<target host="go.linuxfoundation.org" />
 
-		<!--	Redirects to http:
-						-->
-		<!--exclusion pattern="^http://collabprojects\.linuxfoundation\.org/$" /-->
-		<!--exclusion pattern="^http://events\.linuxfoundation\.org/(contact-us|events(/|[\w/-]+/*)?)?(\?.*)?$" /-->
-		<!--exclusion pattern="^http://eventstg\.linuxfoundation\.org/$" /-->
-		<!--exclusion pattern="^http://www\.linuxfoundation\.org/$" /-->
-
 		<!--	Exceptions:
 					-->
-		<exclusion pattern="^http://collabprojects\.linuxfoundation\.org/+(?!sites/)" />
+		<exclusion pattern="^http://events\.linuxfoundation\.org/((events/|\?).*)?$" />
 
 			<!--	+ve:
 					-->
-			<test url="http://collabprojects.linuxfoundation.org/" />
-			<test url="http://collabprojects.linuxfoundation.org//" />
-
-			<!--	-ve:
-					-->
-			<test url="http://collabprojects.linuxfoundation.org/sites/all/modules/custom/lf_assets/includes/img/di_blue.png" />
-
-		<exclusion pattern="^http://events(?:stg)?\.linuxfoundation\.org/+(?!sites/)" />
-
-			<!--	+ve:
-					-->
-			<test url="http://events.linuxfoundation.org/contact-us" />
-			<test url="http://events.linuxfoundation.org/events" />
 			<test url="http://events.linuxfoundation.org/events/embedded-linux-conference-europe/attend/register" />
 			<test url="http://events.linuxfoundation.org/events/linuxcon-europe/program/cfp" />
-			<test url="http://events.linuxfoundation.org/events/mesoscon/attend/register" />
+			<test url="http://events.linuxfoundation.org/events/mesoscon/attend/register?utm_source=lf" />
+			<test url="http://events.linuxfoundation.org/?" />
+			<test url="http://events.linuxfoundation.org/?utm_source=lf" />
 
 			<!--	-ve:
 					-->
+			<test url="http://events.linuxfoundation.org/sponsor" />
 			<test url="http://events.linuxfoundation.org/sites/events/files/styles/events_listing_192x192/public/ccc_eu_color.png" />
-			<test url="http://eventsstg.linuxfoundation.org/sites/all/themes/lfevents/css/homepage-pardot_new.css" />
 
-		<exclusion pattern="^http://www\.linuxfoundation\.org/(?!about/join/individual(?:$|[?/])|cas\?|misc/|sites/|user(?:$|\?))" />
+		<!-- Exclude Pardot paths other than /, /e/*, /l/*, and /?* -->
+		<!-- As of Sept 2016, most Pardot vanity URLs do NOT work on go.pardot.com,
+		     only on the vanity domain (go.linuxfoundation.org) which does not
+		     support SSL. Embedded forms (/l/*) and non-vanity tracker URLs (/e/*)
+		     are the only paths confirmed to work on https://go.pardot.com. -->
+		<!-- http://help.pardot.com/customer/portal/articles/2126757-using-vanity-urls -->
+		<exclusion pattern="^http://go\.linuxfoundation\.org/(?![el]/)[^?]" />
 
 			<!--	+ve:
 					-->
-			<test url="http://www.linuxfoundation.org/about" />
-			<test url="http://www.linuxfoundation.org/about/faq" />
-			<test url="http://www.linuxfoundation.org/about/members" />
-			<test url="http://www.linuxfoundation.org/collaborate" />
-			<test url="http://www.linuxfoundation.org/news-media/blogs" />
-			<test url="http://www.linuxfoundation.org/og" />
-			<test url="http://www.linuxfoundation.org/privacy" />
-			<test url="http://www.linuxfoundation.org/programs" />
-			<test url="http://www.linuxfoundation.org/publications" />
-			<test url="http://www.linuxfoundation.org/search" />
-
-			<!--	-ve:
-					-->
-			<test url="http://www.linuxfoundation.org/about/join/individual" />
-			<test url="http://www.linuxfoundation.org/cas?destination=homepage" />
-			<test url="http://www.linuxfoundation.org/sites/all/modules/custom/lf_assets/includes/img/di_blue.png" />
-			<test url="http://www.linuxfoundation.org/user" />
-
-
-	<!--	Not secured by server:
-					-->
-	<!--securecookie host="^developerbugs\.linuxfoundation\.org$" name="^(BUGLIST|LASTORDER)$" /-->
-
-	<securecookie host="^(?!collabprojects\.|events\.)." name="." />
+			<test url="http://go.linuxfoundation.org/sysadminday2016" />
 
 
 	<rule from="^http://go\.linuxfoundation\.org/+(?:\?.*)?$"
@@ -134,10 +90,11 @@ Fetch error: http://eventsstg.linuxfoundation.org/sites/all/themes/lfevents/css/
 		<test url="http://go.linuxfoundation.org//" />
 		<test url="http://go.linuxfoundation.org//?" />
 
-	<rule from="^http://go\.linuxfoundation\.org/"
-		to="https://pi.pardot.com/" />
+	<rule from="^http://go\.linuxfoundation\.org/([el])/"
+		to="https://pi.pardot.com/$1/" />
 
 		<test url="http://go.linuxfoundation.org/e/6342/TheLinuxFoundation/ymc8q/578968329" />
+		<test url="http://go.linuxfoundation.org/l/6342/2016-03-23/33c3kc" />
 
 	<rule from="^http:"
 		to="https:" />

--- a/src/chrome/content/rules/LinuxFoundation.xml
+++ b/src/chrome/content/rules/LinuxFoundation.xml
@@ -1,7 +1,6 @@
 
 <!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://eventsstg.linuxfoundation.org/sites/all/themes/lfevents/css/homepage-pardot_new.css => https://eventsstg.linuxfoundation.org/sites/all/themes/lfevents/css/homepage-pardot_new.css: (6, 'Could not resolve host: eventsstg.linuxfoundation.org')
+	go.linuxfoundation.org is handled in Pardot_vanity_domains.xml.
 
 	Other Linux Foundation rulesets:
 
@@ -36,6 +35,7 @@ Fetch error: http://eventsstg.linuxfoundation.org/sites/all/themes/lfevents/css/
 	<target host="lists.linux-foundation.org" />
 
 	<target host="linuxfoundation.org" />
+	<target host="www.linuxfoundation.org" />
 	<target host="admin.linuxfoundation.org" />
 	<target host="automotive.linuxfoundation.org" />
 	<target host="collabprojects.linuxfoundation.org" />
@@ -46,11 +46,6 @@ Fetch error: http://eventsstg.linuxfoundation.org/sites/all/themes/lfevents/css/
 	<target host="lists.linuxfoundation.org" />
 	<target host="lsbbugs.linuxfoundation.org" />
 	<target host="training.linuxfoundation.org" />
-	<target host="www.linuxfoundation.org" />
-
-	<!--	Complications:
-				-->
-	<target host="go.linuxfoundation.org" />
 
 		<!--	Exceptions:
 					-->
@@ -68,33 +63,6 @@ Fetch error: http://eventsstg.linuxfoundation.org/sites/all/themes/lfevents/css/
 					-->
 			<test url="http://events.linuxfoundation.org/sponsor" />
 			<test url="http://events.linuxfoundation.org/sites/events/files/styles/events_listing_192x192/public/ccc_eu_color.png" />
-
-		<!-- Exclude Pardot paths other than /, /e/*, /l/*, and /?* -->
-		<!-- As of Sept 2016, most Pardot vanity URLs do NOT work on go.pardot.com,
-		     only on the vanity domain (go.linuxfoundation.org) which does not
-		     support SSL. Embedded forms (/l/*) and non-vanity tracker URLs (/e/*)
-		     are the only paths confirmed to work on https://go.pardot.com. -->
-		<!-- http://help.pardot.com/customer/portal/articles/2126757-using-vanity-urls -->
-		<exclusion pattern="^http://go\.linuxfoundation\.org/(?![el]/)[^?]" />
-
-			<!--	+ve:
-					-->
-			<test url="http://go.linuxfoundation.org/sysadminday2016" />
-
-
-	<rule from="^http://go\.linuxfoundation\.org/+(?:\?.*)?$"
-		to="https://www.linuxfoundation.org/" />
-
-		<test url="http://go.linuxfoundation.org/?" />
-		<test url="http://go.linuxfoundation.org/?f" />
-		<test url="http://go.linuxfoundation.org//" />
-		<test url="http://go.linuxfoundation.org//?" />
-
-	<rule from="^http://go\.linuxfoundation\.org/([el])/"
-		to="https://pi.pardot.com/$1/" />
-
-		<test url="http://go.linuxfoundation.org/e/6342/TheLinuxFoundation/ymc8q/578968329" />
-		<test url="http://go.linuxfoundation.org/l/6342/2016-03-23/33c3kc" />
 
 	<rule from="^http:"
 		to="https:" />

--- a/src/chrome/content/rules/LinuxFoundation.xml
+++ b/src/chrome/content/rules/LinuxFoundation.xml
@@ -23,16 +23,10 @@
 
 	Partially covered hosts in *linuxfoundation.org:
 
-		- events ʰ
-
-	ʰ Some pages redirect to http
+		- events (root domain and /events/* redirect to http)
 
 -->
 <ruleset name="Linux Foundation.org (partial)" default_off='failed ruleset test'>
-
-	<!--	Direct rewrites:
-				-->
-	<target host="lists.linux-foundation.org" />
 
 	<target host="linuxfoundation.org" />
 	<target host="www.linuxfoundation.org" />
@@ -41,28 +35,21 @@
 	<target host="collabprojects.linuxfoundation.org" />
 	<target host="developerbugs.linuxfoundation.org" />
 	<target host="events.linuxfoundation.org" />
+		<exclusion pattern="^http://events\.linuxfoundation\.org/((events/|\?).*)?$" />
+		<!-- Secured -->
+		<test url="http://events.linuxfoundation.org/sponsor" />
+		<test url="http://events.linuxfoundation.org/sites/events/files/styles/events_listing_192x192/public/ccc_eu_color.png" />
+		<!-- Excluded -->
+		<test url="http://events.linuxfoundation.org/events/embedded-linux-conference-europe/attend/register" />
+		<test url="http://events.linuxfoundation.org/events/linuxcon-europe/program/cfp" />
+		<test url="http://events.linuxfoundation.org/events/mesoscon/attend/register?utm_source=lf" />
+		<test url="http://events.linuxfoundation.org/" />
+		<test url="http://events.linuxfoundation.org/?utm_source=lf" />
 	<target host="identity.linuxfoundation.org" />
 	<target host="ldn.linuxfoundation.org" />
 	<target host="lists.linuxfoundation.org" />
 	<target host="lsbbugs.linuxfoundation.org" />
 	<target host="training.linuxfoundation.org" />
-
-		<!--	Exceptions:
-					-->
-		<exclusion pattern="^http://events\.linuxfoundation\.org/((events/|\?).*)?$" />
-
-			<!--	+ve:
-					-->
-			<test url="http://events.linuxfoundation.org/events/embedded-linux-conference-europe/attend/register" />
-			<test url="http://events.linuxfoundation.org/events/linuxcon-europe/program/cfp" />
-			<test url="http://events.linuxfoundation.org/events/mesoscon/attend/register?utm_source=lf" />
-			<test url="http://events.linuxfoundation.org/?" />
-			<test url="http://events.linuxfoundation.org/?utm_source=lf" />
-
-			<!--	-ve:
-					-->
-			<test url="http://events.linuxfoundation.org/sponsor" />
-			<test url="http://events.linuxfoundation.org/sites/events/files/styles/events_listing_192x192/public/ccc_eu_color.png" />
 
 	<rule from="^http:"
 		to="https:" />

--- a/src/chrome/content/rules/Pardot_vanity_domains.xml
+++ b/src/chrome/content/rules/Pardot_vanity_domains.xml
@@ -1,0 +1,24 @@
+<!--
+
+For other Pardot coverage, see Pardot.xml.
+
+-->
+<ruleset name="Pardot vanity domains (partial)">
+
+	<!-- Many Pardot tracker URLs that work on a vanity CNAME do *NOT* work on
+	     the SSL-enabled domain "go.pardot.com". Embedded forms (/l/*) and
+	     non-vanity tracker URLs (/e/*) ARE confirmed to work. -->
+	<!-- http://help.pardot.com/customer/portal/articles/2126757-using-vanity-urls -->
+	<!-- http://help.pardot.com/customer/portal/articles/2126640-how-to-ssl-enable-http-secure-pardot-urls -->
+	<rule from="^http://([\w.-]+)/([el])/"
+		to="https://go.pardot.com/$2/" />
+
+	<!-- Exclude top domain to disable implicit test -->
+	<exclusion pattern="^http://([\w.-]+)/$" />
+
+	<target host="go.linuxfoundation.org" />
+		<test url="http://go.linuxfoundation.org/" />
+		<test url="http://go.linuxfoundation.org/e/6342/TheLinuxFoundation/ymc8q/578968329" />
+		<test url="http://go.linuxfoundation.org/l/6342/2016-03-23/33c3kc" />
+
+</ruleset>


### PR DESCRIPTION
An updated copy of #6035 since the thread got too convoluted.

Commit 7e99e2bf8 includes several fixes to Linux Foundation domains, the most important of which is a broken "vanity URL" tracker domain for Pardot.

Due to a concern about the negative lookahead syntax, the next commit fb64b5f00 creates a new  standalone Pardot domain xml, similar to bitly, which allows us to avoid the negative lookahead.

29970 contains style updates I learned about in the course of contributing this change.