### PR TITLE
Remove old exceptions from Phaser.io.xml.

### DIFF
--- a/src/chrome/content/rules/Phaser.io.xml
+++ b/src/chrome/content/rules/Phaser.io.xml
@@ -1,33 +1,6 @@
-<ruleset name="Phaser.io (partial)">
-
-	<!--	Direct rewrites:
-				-->
+<ruleset name="Phaser.io">
 	<target host="phaser.io" />
 	<target host="www.phaser.io" />
-
-		<!--	Redirects to http:
-						-->
-		<!--exclusion pattern="^http://phaser\.io/$" /-->
-		<!--
-			Exceptions:
-					-->
-		<exclusion pattern="^http://phaser\.io/+(?!content/|css/|favicon\.ico|images/)" />
-
-			<!--	+ve:
-					-->
-			<test url="http://phaser.io/community" />
-			<test url="http://phaser.io/download" />
-			<test url="http://phaser.io/examples" />
-			<test url="http://phaser.io/learn" />
-			<test url="http://phaser.io/news" />
-
-			<!--	-ve:
-					-->
-			<test url="http://phaser.io/content/news/2015/07/get-it-sorted-thumb.png" />
-			<test url="http://phaser.io/css/prettify.css" />
-			<test url="http://phaser.io/favicon.ico" />
-			<test url="http://phaser.io/images/img.png" />
-
 
 	<rule from="^http:"
 		to="https:" />


### PR DESCRIPTION
After manually forcing my browser to treat Phaser.io as a HSTS preloaded site, and testing all the previously affected URLs, and just wandering around the site generally, all the issues seem to be resolved. Closes #6907 (an old ticket that presumably caused the exceptions to be created, but hasn't been closed).