### PR TITLE
Update and reactivate ThePirateBay.xml

### DIFF
--- a/src/chrome/content/rules/ThePirateBay.xml
+++ b/src/chrome/content/rules/ThePirateBay.xml
@@ -1,44 +1,32 @@
-
 <!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://kanyebay.com/ => https://kanyebay.com/: (28, 'Connection timed out after 20000 milliseconds')
-Fetch error: http://www.kanyebay.com/ => https://www.kanyebay.com/: (28, 'Connection timed out after 20000 milliseconds')
+	Other The Pirate Bay rulesets:
+		thepiratebay-legacy.xml
+		proxybay.one.xml
+		thepiratebay-proxylist.org.xml
+		thepirateportal.org.xml
+		thephoenixbay.com.xml
+		proxyportal.org.xml
+		tpblist.xyz.xml
+		proxybay.pl.xml
 
-Other The Pirate Bay rulesets:
-thepiratebay-legacy.xml
-proxybay.one.xml
-thepiratebay-proxylist.org.xml
-thepirateportal.org.xml
-thephoenixbay.com.xml
-proxyportal.org.xml
-tpblist.xyz.xml
-proxybay.pl.xml
-
-www.proxybay.la timed out
-promobay.org nonexist
-www.promobay.org nonexist
-oldpiratebay.org timed out
-www.oldpiratebay.org timed out
 -->
 
-<ruleset name="The Pirate Bay" default_off='failed ruleset test'>
+<ruleset name="The Pirate Bay">
 
 	<target host="thepiratebay.se" />
 	<target host="www.thepiratebay.se" />
+
 	<target host="thepiratebay.org" />
 	<target host="www.thepiratebay.org" />
+
 	<target host="pirates-forum.org" />
 	<target host="www.pirates-forum.org" />
-	<target host="kanyebay.com" />
-	<target host="www.kanyebay.com" />
 
 	<target host="proxybay.la" />
 	<target host="www.proxybay.la" />
+
 	<target host="tpb.run" />
 	<target host="www.tpb.run" />
-	
-	<rule from="^http://www\.proxybay\.la/"
-		to="https://proxybay.la/" />
 
 	<target host="thepiratebay-proxylist.org" />
 	<target host="www.thepiratebay-proxylist.org" />


### PR DESCRIPTION
I would like to use this PR to discuss the case of thepiratebay. Currently, the numerous mirrors are secured across 9 rulesets, without any apparent logic behind it.

First of all, we should stop redirecting dead mirrors to working ones, as in [`thepiratebay-legacy.xml`](https://github.com/EFForg/https-everywhere/blob/master/src/chrome/content/rules/thepiratebay-legacy.xml). It is not this extension job to track the current working mirror. It is very time consuming and it could introduce a security risk (some mirrors may be compromised and we don't want to be responsible for sending users on them). This point was already discussed in https://github.com/EFForg/https-everywhere/pull/8561.

Also, in this case, I am not sure if it would better to group all domain in a single ruleset, that would require frequent but somewhat easy updates or split them in a myriad of smaller rulesets, which would have to be updated less frequently.