### PR TITLE
Pro-Linux.de

### DIFF
--- a/src/chrome/content/rules/Pro-Linux.de.xml
+++ b/src/chrome/content/rules/Pro-Linux.de.xml
@@ -1,5 +1,18 @@
 <!--
 	Non-functional hosts
+
+		4XX:
+			- ca.pro-linux.de
+			- dns.pro-linux.de
+
+		Cert mismatch:
+			- new.pro-linux.de
+			- test.pro-linux.de
+
+		Connection refused:
+			- localhost.pro-linux.de
+			- loopback.pro-linux.de
+
 		Incomplete certificate chain error:
 			 - mail.pro-linux.de
 			 - samael.pro-linux.de
@@ -7,10 +20,22 @@
 		Mixed content blocking (MCB) tiggered:
 			 - pro-linux.de
 			 - www.pro-linux.de
+			 
+		Timeout: 
+		-	 demon.pro-linux.de
+
 -->
-<ruleset name="Pro-Linux.de" platform="mixedcontent">
+<ruleset name="Pro-Linux.de" >
 	<target host="pro-linux.de" />
 	<target host="www.pro-linux.de" />
+
+	<target host="admin.pro-linux.de" />
+	<target host="alpha.pro-linux.de" />
+	<target host="beta.pro-linux.de" />
+	<target host="dev.pro-linux.de" />
+	<target host="tools.pro-linux.de" />
+	<target host="users.pro-linux.de" />
+	<target host="webmail.pro-linux.de" />
 
 	<securecookie host="^(www\.)?pro-linux\.de$" name=".+" />
 


### PR DESCRIPTION
The mixed-content is just a bad google inclusion. The website doesn't break.
Therefore we should remove this platform and enable the rule by default