### PR TITLE
Re-activate and Update Maker.tv.xml

### DIFF
--- a/src/chrome/content/rules/Maker.tv.xml
+++ b/src/chrome/content/rules/Maker.tv.xml
@@ -1,9 +1,8 @@
-<ruleset name="Maker.tv" default_off="breaks videos">
+<ruleset name="Maker.tv">
 
 	<target host="maker.tv" />
 	<target host="www.maker.tv" />
 
-	<rule from="^http:"
-		to="https:" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>


### PR DESCRIPTION
#9906 It seems that this is created with `default_off`, but `^` redirect to another domain and `www` seem to be obsolete (URLs on google all `4xx` even on HTTP) so I guess it is fine to re-activate/ remove this.