### PR TITLE
disable HTTPS for tosc.iacr.org, and support of ia.cr

### DIFF
--- a/src/chrome/content/rules/International-Association-for-Cryptologic-Research.xml
+++ b/src/chrome/content/rules/International-Association-for-Cryptologic-Research.xml
@@ -9,15 +9,18 @@
 
 	<target host="iacr.org" />
 	<target host="*.iacr.org" />
+	<target host="ia.cr" />
 
-		<test url="http://eprint.iacr.org/" />
-		<test url="http://secure.iacr.org/" />
-		<test url="http://www.iacr.org/" />
-
+	<test url="http://eprint.iacr.org/" />
+	<test url="http://secure.iacr.org/" />
+	<test url="http://www.iacr.org/" />
+	<test url="http://tosc.iacr.org/" />
+	<test url="http://ia.cr/" />
 
 	<securecookie host="^\w" name="." />
 
-
+	<exclusion pattern="^http://tosc.iacr.org" />
+	
 	<rule from="^http://iacr\.org/"
 		to="https://www.iacr.org/" />
 


### PR DESCRIPTION
`tosc.iacr.org` does not support HTTPS.

IACR also uses the domain `ia.cr`.