### PR TITLE
Trivialize direct rewrite rules

### DIFF
--- a/src/chrome/content/rules/254a.com.xml
+++ b/src/chrome/content/rules/254a.com.xml
@@ -6,7 +6,6 @@
 	<securecookie host="^d\.254a\.com$" name=".+" />
 
 
-	<rule from="^http://d\.254a\.com/"
-		to="https://d.254a.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/3Play-Media.xml
+++ b/src/chrome/content/rules/3Play-Media.xml
@@ -7,7 +7,6 @@
 	<target host="account.3playmedia.com" />
 
 
-	<rule from="^http://account\.3playmedia\.com/"
-		to="https://account.3playmedia.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/419_Eater.com.xml
+++ b/src/chrome/content/rules/419_Eater.com.xml
@@ -19,7 +19,6 @@
 	<securecookie host="^forum\.419eater\.com$" name=".+" />
 
 
-	<rule from="^http://forum\.419eater\.com/"
-		to="https://forum.419eater.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/AAU.at.xml
+++ b/src/chrome/content/rules/AAU.at.xml
@@ -3,7 +3,6 @@
 	<target host="pervasive.aau.at" />
 
 
-	<rule from="^http://pervasive\.aau\.at/"
-		to="https://pervasive.aau.at/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/ADCocktail.xml
+++ b/src/chrome/content/rules/ADCocktail.xml
@@ -15,7 +15,6 @@
 	<securecookie host="^track\.adcocktail\.com$" name=".+" />
 
 
-	<rule from="^http://track\.adcocktail\.com/"
-		to="https://track.adcocktail.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/ATbar.xml
+++ b/src/chrome/content/rules/ATbar.xml
@@ -13,7 +13,6 @@
 	<target host="ssl.atbar.org" />
 
 
-	<rule from="^http://ssl\.atbar\.org/"
-		to="https://ssl.atbar.org/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/AbenteuerLand.at.xml
+++ b/src/chrome/content/rules/AbenteuerLand.at.xml
@@ -9,7 +9,6 @@ Fetch error: http://psara.abenteuerland.at/ => https://psara.abenteuerland.at/: 
 	<target host="psara.abenteuerland.at" />
 
 
-	<rule from="^http://psara\.abenteuerland\.at/"
-		to="https://psara.abenteuerland.at/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Abftracker.com.xml
+++ b/src/chrome/content/rules/Abftracker.com.xml
@@ -3,7 +3,6 @@
 	<target host="affiliate.abftracker.com" />
 
 
-	<rule from="^http://affiliate\.abftracker\.com/"
-		to="https://affiliate.abftracker.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Acceptiva.com.xml
+++ b/src/chrome/content/rules/Acceptiva.com.xml
@@ -9,7 +9,6 @@
 	<target host="secure.acceptiva.com" />
 
 
-	<rule from="^http://secure\.acceptiva\.com/"
-		to="https://secure.acceptiva.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Accesstrade.net.xml
+++ b/src/chrome/content/rules/Accesstrade.net.xml
@@ -18,7 +18,6 @@
 	<securecookie host="^member\.accesstrade\.net$" name=".+" />
 
 
-	<rule from="^http://member\.accesstrade\.net/"
-		to="https://member.accesstrade.net/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Aculab.com.xml
+++ b/src/chrome/content/rules/Aculab.com.xml
@@ -12,7 +12,6 @@
 	<securecookie host="^cloud\.aculab\.com$" name=".+" />
 
 
-	<rule from="^http://cloud\.aculab\.com/"
-		to="https://cloud.aculab.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Ad-Center.com.xml
+++ b/src/chrome/content/rules/Ad-Center.com.xml
@@ -12,7 +12,6 @@
 	<securecookie host="^ads\.ad-center\.com$" name=".+" />
 
 
-	<rule from="^http://ads\.ad-center\.com/"
-		to="https://ads.ad-center.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Ad6media.xml
+++ b/src/chrome/content/rules/Ad6media.xml
@@ -19,7 +19,6 @@
 	<target host="r.ad6media.fr" />
 
 
-	<rule from="^http://r\.ad6media\.fr/"
-		to="https://r.ad6media.fr/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/AdReactor.xml
+++ b/src/chrome/content/rules/AdReactor.xml
@@ -9,7 +9,6 @@
 	<target host="adserver.adreactor.com" />
 
 
-	<rule from="^http://adserver\.adreactor\.com/"
-		to="https://adserver.adreactor.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Adify.xml
+++ b/src/chrome/content/rules/Adify.xml
@@ -3,7 +3,6 @@
 	<target host="ad.afy11.net" />
 
 
-	<rule from="^http://ad\.afy11\.net/"
-		to="https://ad.afy11.net/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Advance_Digital.xml
+++ b/src/chrome/content/rules/Advance_Digital.xml
@@ -9,7 +9,6 @@
 	<target host="blog.advance.net" />
 
 
-	<rule from="^http://blog\.advance\.net/"
-		to="https://blog.advance.net/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Advg.jp.xml
+++ b/src/chrome/content/rules/Advg.jp.xml
@@ -3,7 +3,6 @@
 	<target host="r.advg.jp" />
 
 
-	<rule from="^http://r\.advg\.jp/"
-		to="https://r.advg.jp/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Adzip.co.xml
+++ b/src/chrome/content/rules/Adzip.co.xml
@@ -3,7 +3,6 @@
 	<target host="metrics.adzip.co" />
 
 
-	<rule from="^http://metrics\.adzip\.co/"
-		to="https://metrics.adzip.co/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Amblin.io.xml
+++ b/src/chrome/content/rules/Amblin.io.xml
@@ -14,7 +14,6 @@
 	<securecookie host="^amblin\.io$" name=".+" />
 
 
-	<rule from="^http://amblin\.io/"
-		to="https://amblin.io/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Ampersandjs.com.xml
+++ b/src/chrome/content/rules/Ampersandjs.com.xml
@@ -16,7 +16,6 @@
 	<target host="ampersandjs.com" />
 
 
-	<rule from="^http://ampersandjs\.com/"
-		to="https://ampersandjs.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/ApplyYourself.xml
+++ b/src/chrome/content/rules/ApplyYourself.xml
@@ -6,7 +6,6 @@
 	<securecookie host="^app\.applyyourself\.com$" name=".+" />
 
 
-	<rule from="^http://app\.applyyourself\.com/"
-		to="https://app.applyyourself.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Arduino.cc.xml
+++ b/src/chrome/content/rules/Arduino.cc.xml
@@ -21,7 +21,6 @@
 	<target host="id.arduino.cc" />
 
 
-	<rule from="^http://id\.arduino\.cc/"
-		to="https://id.arduino.cc/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Arozus.xml
+++ b/src/chrome/content/rules/Arozus.xml
@@ -16,7 +16,6 @@
 	<target host="content.azorus.com" />
 
 
-	<rule from="^http://content\.azorus\.com/"
-		to="https://content.azorus.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Ascio.com.xml
+++ b/src/chrome/content/rules/Ascio.com.xml
@@ -12,7 +12,6 @@
 	<securecookie host="^portal\.ascio\.com$" name=".+" />
 
 
-	<rule from="^http://portal\.ascio\.com/"
-		to="https://portal.ascio.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Beagle_Street.xml
+++ b/src/chrome/content/rules/Beagle_Street.xml
@@ -13,7 +13,6 @@
 	<securecookie host="^quotes\.beaglestreet\.com$" name=".+" />
 
 
-	<rule from="^http://quotes\.beaglestreet\.com/"
-		to="https://quotes.beaglestreet.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Beanstalk_Data.xml
+++ b/src/chrome/content/rules/Beanstalk_Data.xml
@@ -13,7 +13,6 @@
 	<securecookie host="^app\.beanstalkdata\.com$" name=".+" />
 
 
-	<rule from="^http://app\.beanstalkdata\.com/"
-		to="https://app.beanstalkdata.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Belspo.be.xml
+++ b/src/chrome/content/rules/Belspo.be.xml
@@ -19,7 +19,6 @@
 	<target host="www.belspo.be" />
 
 
-	<rule from="^http://www\.belspo\.be/"
-		to="https://www.belspo.be/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Biglobe.xml
+++ b/src/chrome/content/rules/Biglobe.xml
@@ -10,7 +10,6 @@
 	<target host="api.sso.biglobe.ne.jp" />
 
 
-	<rule from="^http://api\.sso\.biglobe\.ne\.jp/"
-		to="https://api.sso.biglobe.ne.jp/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Bike24.com.xml
+++ b/src/chrome/content/rules/Bike24.com.xml
@@ -3,5 +3,5 @@
 
   <securecookie host="^\.bike24\.com$" name=".*" />
 
-  <rule from="^http://www\.bike24\.com/" to="https://www.bike24.com/" />
+  <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/BitGravity.xml
+++ b/src/chrome/content/rules/BitGravity.xml
@@ -12,7 +12,6 @@
 	<securecookie host="^dashboard\.bitgravity\.com$" name=".+" />
 
 
-	<rule from="^http://dashboard\.bitgravity\.com/"
-		to="https://dashboard.bitgravity.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Bitnodes.io.xml
+++ b/src/chrome/content/rules/Bitnodes.io.xml
@@ -3,7 +3,6 @@
 	<target host="getaddr.bitnodes.io" />
 
 
-	<rule from="^http://getaddr\.bitnodes\.io/"
-		to="https://getaddr.bitnodes.io/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Bittit.info.xml
+++ b/src/chrome/content/rules/Bittit.info.xml
@@ -1,5 +1,5 @@
 <ruleset name="Bittit.info">
   <target host="bittit.info" />
 
-  <rule from="^http://bittit\.info/" to="https://bittit.info/" />
+  <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Bouncebidder.com.xml
+++ b/src/chrome/content/rules/Bouncebidder.com.xml
@@ -7,7 +7,6 @@
 	<target host="bouncebidder.com" />
 
 
-	<rule from="^http://bouncebidder\.com/"
-		to="https://bouncebidder.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Bpaste.net.xml
+++ b/src/chrome/content/rules/Bpaste.net.xml
@@ -7,7 +7,6 @@
 	<target host="bpaste.net" />
 
 
-	<rule from="^http://bpaste\.net/"
-		to="https://bpaste.net/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/BradleyF.id.au.xml
+++ b/src/chrome/content/rules/BradleyF.id.au.xml
@@ -9,7 +9,6 @@
 	<target host="bradleyf.id.au" />
 
 
-	<rule from="^http://bradleyf\.id\.au/"
-		to="https://bradleyf.id.au/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Brands.xml
+++ b/src/chrome/content/rules/Brands.xml
@@ -10,7 +10,6 @@
 	<securecookie host="^mall\.brands\.com\.tw$" name=".+" />
 
 
-	<rule from="^http://mall\.brands\.com\.tw/"
-		to="https://mall.brands.com.tw/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Break.com.xml
+++ b/src/chrome/content/rules/Break.com.xml
@@ -3,7 +3,6 @@
 	<target host="media1.break.com" />
 
 
-	<rule from="^http://media1\.break\.com/"
-		to="https://media1.break.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/BroadcastJobs.co.uk.xml
+++ b/src/chrome/content/rules/BroadcastJobs.co.uk.xml
@@ -13,7 +13,6 @@
 	<securecookie host="^rs\.broadcastjobs\.co\.uk$" name=".+" />
 
 
-	<rule from="^http://rs\.broadcastjobs\.co\.uk/"
-		to="https://rs.broadcastjobs.co.uk/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/CA-Technologies.xml
+++ b/src/chrome/content/rules/CA-Technologies.xml
@@ -1,7 +1,6 @@
 <ruleset name="CA Technologies">
 	<target host="cloudmonitor.nimsoft.com" />
 
-    <rule from="^http://cloudmonitor\.nimsoft\.com/"
-        to="https://cloudmonitor.nimsoft.com/" />
+    <rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/CA-mpr.jp.xml
+++ b/src/chrome/content/rules/CA-mpr.jp.xml
@@ -9,7 +9,6 @@
 	<target host="ot.ca-mpr.jp" />
 
 
-	<rule from="^http://ot\.ca-mpr\.jp/"
-		to="https://ot.ca-mpr.jp/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/CINES.fr.xml
+++ b/src/chrome/content/rules/CINES.fr.xml
@@ -14,7 +14,6 @@
 	<target host="www.cines.fr" />
 
 
-	<rule from="^http://www\.cines\.fr/"
-		to="https://www.cines.fr/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/CNDP.fr.xml
+++ b/src/chrome/content/rules/CNDP.fr.xml
@@ -9,7 +9,6 @@
 	<target host="cas.edutheque.cndp.fr" />
 
 
-	<rule from="^http://cas\.edutheque\.cndp\.fr/"
-		to="https://cas.edutheque.cndp.fr/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Cal_State.edu.xml
+++ b/src/chrome/content/rules/Cal_State.edu.xml
@@ -7,7 +7,6 @@
 	<target host="sdsu-dspace.calstate.edu" />
 
 
-	<rule from="^http://sdsu-dspace\.calstate\.edu/"
-		to="https://sdsu-dspace.calstate.edu/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Calvin_College.xml
+++ b/src/chrome/content/rules/Calvin_College.xml
@@ -6,7 +6,6 @@
 	<securecookie host="^ulysses\.calvin\.edu$" name=".+" />
 
 
-	<rule from="^http://ulysses\.calvin\.edu/"
-		to="https://ulysses.calvin.edu/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Canadian_Light_Source.xml
+++ b/src/chrome/content/rules/Canadian_Light_Source.xml
@@ -12,7 +12,6 @@
 	<securecookie host="^user\.lightsource\.ca$" name=".+" />
 
 
-	<rule from="^http://user\.lightsource\.ca/"
-		to="https://user.lightsource.ca/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Cdnpi.pe.xml
+++ b/src/chrome/content/rules/Cdnpi.pe.xml
@@ -9,7 +9,6 @@
 	<target host="cdnpi.pe" />
 
 
-	<rule from="^http://cdnpi\.pe/"
-		to="https://cdnpi.pe/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Centmin_Mod.com.xml
+++ b/src/chrome/content/rules/Centmin_Mod.com.xml
@@ -10,7 +10,6 @@
 	<target host="community.centminmod.com" />
 
 
-	<rule from="^http://community\.centminmod\.com/"
-		to="https://community.centminmod.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Chrome.com.xml
+++ b/src/chrome/content/rules/Chrome.com.xml
@@ -3,7 +3,6 @@
 	<target host="developer.chrome.com" />
 
 
-	<rule from="^http://developer\.chrome\.com/"
-		to="https://developer.chrome.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Cinder.xml
+++ b/src/chrome/content/rules/Cinder.xml
@@ -12,7 +12,6 @@
 	<securecookie host="^forum\.libcinder\.org$" name=".+" />
 
 
-	<rule from="^http://forum\.libcinder\.org/"
-		to="https://forum.libcinder.org/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Cineclick.com.br.xml
+++ b/src/chrome/content/rules/Cineclick.com.br.xml
@@ -19,7 +19,6 @@
 	<target host="static.cineclick.com.br" />
 
 
-	<rule from="^http://static\.cineclick\.com\.br/"
-		to="https://static.cineclick.com.br/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/ClearCenter.com.xml
+++ b/src/chrome/content/rules/ClearCenter.com.xml
@@ -15,7 +15,6 @@ Fetch error: http://secure.clearcenter.com/ => https://secure.clearcenter.com/: 
 	<securecookie host="^secure\.clearcenter\.com$" name=".+" />
 
 
-	<rule from="^http://secure\.clearcenter\.com/"
-		to="https://secure.clearcenter.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Comm100.com.xml
+++ b/src/chrome/content/rules/Comm100.com.xml
@@ -3,7 +3,6 @@
 	<target host="chatserver.comm100.com" />
 
 
-	<rule from="^http://chatserver\.comm100\.com/"
-		to="https://chatserver.comm100.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Commindo-media.xml
+++ b/src/chrome/content/rules/Commindo-media.xml
@@ -11,7 +11,6 @@ Fetch error: http://auslieferung.commindo-media-ressourcen.de/ => https://auslie
 	<target host="auslieferung.commindo-media-ressourcen.de" />
 
 
-	<rule from="^http://auslieferung\.commindo-media-ressourcen\.de/"
-		to="https://auslieferung.commindo-media-ressourcen.de/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Community.elgg.org.xml
+++ b/src/chrome/content/rules/Community.elgg.org.xml
@@ -1,5 +1,5 @@
 <ruleset name="Community.elgg.org">
   <target host="community.elgg.org" />
 
-  <rule from="^http://community\.elgg\.org/" to="https://community.elgg.org/" />
+  <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Contact_At_Once.com.xml
+++ b/src/chrome/content/rules/Contact_At_Once.com.xml
@@ -9,7 +9,6 @@
 	<target host="applications.contactatonce.com" />
 
 
-	<rule from="^http://applications\.contactatonce\.com/"
-		to="https://applications.contactatonce.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Contentdn.net.xml
+++ b/src/chrome/content/rules/Contentdn.net.xml
@@ -5,7 +5,6 @@
 
 	<!--	www doesn't exist.
 					-->
-	<rule from="^http://contentdn\.net/"
-		to="https://contentdn.net/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Cookie_Reports.com.xml
+++ b/src/chrome/content/rules/Cookie_Reports.com.xml
@@ -3,7 +3,6 @@
 	<target host="policy.cookiereports.com" />
 
 
-	<rule from="^http://policy\.cookiereports\.com/"
-		to="https://policy.cookiereports.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Cooperating-Objects.eu.xml
+++ b/src/chrome/content/rules/Cooperating-Objects.eu.xml
@@ -10,7 +10,6 @@
 	<securecookie host="^www\.cooperating-objects\.eu$" name=".+" />
 
 
-	<rule from="^http://www\.cooperating-objects\.eu/"
-		to="https://www.cooperating-objects.eu/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Cope-IT.xml
+++ b/src/chrome/content/rules/Cope-IT.xml
@@ -10,7 +10,6 @@
 	<securecookie host="^www\.cope-it\.at$" name=".+" />
 
 
-	<rule from="^http://www\.cope-it\.at/"
-		to="https://www.cope-it.at/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/CoreSite.com.xml
+++ b/src/chrome/content/rules/CoreSite.com.xml
@@ -12,7 +12,6 @@
 	<securecookie host="^mycoresite\.coresite\.com$" name=".+" />
 
 
-	<rule from="^http://mycoresite\.coresite\.com/"
-		to="https://mycoresite.coresite.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Creative-serving.com.xml
+++ b/src/chrome/content/rules/Creative-serving.com.xml
@@ -12,7 +12,6 @@
 	<securecookie host="^ads\.creative-serving\.com$" name=".+" />
 
 
-	<rule from="^http://ads\.creative-serving\.com/"
-		to="https://ads.creative-serving.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Critical-Mass.xml
+++ b/src/chrome/content/rules/Critical-Mass.xml
@@ -12,7 +12,6 @@
 	<securecookie host="^cm1\.criticalmass\.com$" name=".*" />
 
 
-	<rule from="^http://cm1\.criticalmass\.com/"
-		to="https://cm1.criticalmass.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/CtsCDN.com.xml
+++ b/src/chrome/content/rules/CtsCDN.com.xml
@@ -3,7 +3,6 @@
 	<target host="jscsecmat.ctscdn.com" />
 
 
-	<rule from="^http://jscsecmat\.ctscdn\.com/"
-		to="https://jscsecmat.ctscdn.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Currys.co.uk.xml
+++ b/src/chrome/content/rules/Currys.co.uk.xml
@@ -3,7 +3,6 @@
 	<target host="secure.currys.co.uk" />
 
 
-	<rule from="^http://secure\.currys\.co\.uk/"
-		to="https://secure.currys.co.uk/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Cyberquests.org.xml
+++ b/src/chrome/content/rules/Cyberquests.org.xml
@@ -1,5 +1,5 @@
 <ruleset name="Cyberquests (Partial)">
   <target host="quiz-uscc.cyberquests.org" />
 
-  <rule from="^http://quiz-uscc\.cyberquests\.org/" to="https://quiz-uscc.cyberquests.org/" />
+  <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/DNV.com.xml
+++ b/src/chrome/content/rules/DNV.com.xml
@@ -14,7 +14,6 @@
 	<securecookie host="^exchange\.dnv\.com$" name=".+" />
 
 
-	<rule from="^http://exchange\.dnv\.com/"
-		to="https://exchange.dnv.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/DW.de.xml
+++ b/src/chrome/content/rules/DW.de.xml
@@ -29,7 +29,6 @@
 	<target host="social.dw.de" />
 
 
-	<rule from="^http://social\.dw\.de/"
-		to="https://social.dw.de/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Datemas.de.xml
+++ b/src/chrome/content/rules/Datemas.de.xml
@@ -16,7 +16,6 @@ Fetch error: http://web.datemas.de/ => https://web.datemas.de/: Too many redirec
 	<securecookie host="^web\.datemas\.de$" name=".+" />
 
 
-	<rule from="^http://web\.datemas\.de/"
-		to="https://web.datemas.de/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/DealTime.xml
+++ b/src/chrome/content/rules/DealTime.xml
@@ -3,7 +3,6 @@
 	<target host="sc.dealtime.com" />
 
 
-	<rule from="^http://sc\.dealtime\.com/"
-		to="https://sc.dealtime.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/DealerFire.xml
+++ b/src/chrome/content/rules/DealerFire.xml
@@ -9,7 +9,6 @@
 	<target host="cdn.dealerfire.com" />
 
 
-	<rule from="^http://cdn\.dealerfire\.com/"
-		to="https://cdn.dealerfire.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Denik.cz.xml
+++ b/src/chrome/content/rules/Denik.cz.xml
@@ -15,7 +15,6 @@
 	<target host="g.denik.cz" />
 
 
-	<rule from="^http://g\.denik\.cz/"
-		to="https://g.denik.cz/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Dilcdn.com.xml
+++ b/src/chrome/content/rules/Dilcdn.com.xml
@@ -17,7 +17,6 @@
 	<target host="a.dilcdn.com" />
 
 
-	<rule from="^http://a\.dilcdn\.com/"
-		to="https://a.dilcdn.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Docler.xml
+++ b/src/chrome/content/rules/Docler.xml
@@ -1,5 +1,5 @@
 <ruleset name="Docler Holding">
 	<target host="www.doclerholding.com" />
 
-	<rule from="^http://www\.doclerholding\.com/" to="https://www.doclerholding.com/" />
+	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/E-magazin.se.xml
+++ b/src/chrome/content/rules/E-magazin.se.xml
@@ -7,7 +7,6 @@
 	<target host="www.e-magin.se" />
 
 
-	<rule from="^http://www\.e-magin\.se/"
-		to="https://www.e-magin.se/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/E2E-Networks.xml
+++ b/src/chrome/content/rules/E2E-Networks.xml
@@ -12,7 +12,6 @@
 	<securecookie host="^shopping\.e2enetworks\.com$" name=".*" />
 
 
-	<rule from="^http://shopping\.e2enetworks\.com/"
-		to="https://shopping.e2enetworks.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/EBSCO-content.com.xml
+++ b/src/chrome/content/rules/EBSCO-content.com.xml
@@ -7,7 +7,6 @@ Fetch error: http://global.ebsco-content.com/ => https://global.ebsco-content.co
 	<target host="global.ebsco-content.com" />
 
 
-	<rule from="^http://global\.ebsco-content\.com/"
-		to="https://global.ebsco-content.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/EC21.xml
+++ b/src/chrome/content/rules/EC21.xml
@@ -21,7 +21,6 @@
 	<target host="login.ec21.com" />
 
 
-	<rule from="^http://login\.ec21\.com/"
-		to="https://login.ec21.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/EOReality.net.xml
+++ b/src/chrome/content/rules/EOReality.net.xml
@@ -15,7 +15,6 @@
 	<securecookie host="^billing\.eoreality\.net$" name=".+" />
 
 
-	<rule from="^http://billing\.eoreality\.net/"
-		to="https://billing.eoreality.net/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/ESupport.com.xml
+++ b/src/chrome/content/rules/ESupport.com.xml
@@ -7,7 +7,6 @@
 	<target host="secure.esupport.com" />
 
 
-	<rule from="^http://secure\.esupport\.com/"
-		to="https://secure.esupport.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Edgerunner.com.xml
+++ b/src/chrome/content/rules/Edgerunner.com.xml
@@ -12,7 +12,6 @@
 	<securecookie host="^store\.edgerunner\.com$" name=".+" />
 
 
-	<rule from="^http://store\.edgerunner\.com/"
-		to="https://store.edgerunner.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Eduroam_ES.xml
+++ b/src/chrome/content/rules/Eduroam_ES.xml
@@ -7,7 +7,6 @@
 	<target host="www.eduroam.es" />
 
 
-	<rule from="^http://www\.eduroam\.es/"
-		to="https://www.eduroam.es/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Effiliation.xml
+++ b/src/chrome/content/rules/Effiliation.xml
@@ -12,7 +12,6 @@
 	<securecookie host="^track\.effiliation\.com$" name=".+" />
 
 
-	<rule from="^http://track\.effiliation\.com/"
-		to="https://track.effiliation.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Elcomsoft.xml
+++ b/src/chrome/content/rules/Elcomsoft.xml
@@ -12,7 +12,6 @@
 	<target host="secure.elcomsoft.com" />
 
 
-	<rule from="^http://secure\.elcomsoft\.com/"
-		to="https://secure.elcomsoft.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Enlightened_Perl.org.xml
+++ b/src/chrome/content/rules/Enlightened_Perl.org.xml
@@ -8,7 +8,6 @@
 	<target host="members.enlightenedperl.org" />
 
 
-	<rule from="^http://members\.enlightenedperl\.org/"
-		to="https://members.enlightenedperl.org/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/EntheoShop.xml
+++ b/src/chrome/content/rules/EntheoShop.xml
@@ -6,7 +6,6 @@
 	<securecookie host="^shop\.entheogene\.de$" name=".*" />
 
 
-	<rule from="^http://shop\.entheogene\.de/"
-		to="https://shop.entheogene.de/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/EuroAds.se.xml
+++ b/src/chrome/content/rules/EuroAds.se.xml
@@ -3,7 +3,6 @@
 	<target host="banner.euroads.se" />
 
 
-	<rule from="^http://banner\.euroads\.se/"
-		to="https://banner.euroads.se/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Eurofurence.xml
+++ b/src/chrome/content/rules/Eurofurence.xml
@@ -3,5 +3,5 @@
 
   <securecookie host="^forum\.eurofurence\.org$" name=".+" />
 
-  <rule from="^http://forum\.eurofurence\.org/" to="https://forum.eurofurence.org/" />
+  <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/European-Bioinformatics-Institute.xml
+++ b/src/chrome/content/rules/European-Bioinformatics-Institute.xml
@@ -8,7 +8,6 @@ Fetch error: http://www.ebi.co.uk/ => https://www.ebi.co.uk/: (60, 'SSL certific
 
 
 	<!--	!www doesn't exist.	-->
-	<rule from="^http://www\.ebi\.co\.uk/"
-		to="https://www.ebi.co.uk/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Event_Booking_Online.com.xml
+++ b/src/chrome/content/rules/Event_Booking_Online.com.xml
@@ -9,7 +9,6 @@
 	<target host="eventbookingonline.com" />
 
 
-	<rule from="^http://eventbookingonline\.com/"
-		to="https://eventbookingonline.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Exede.xml
+++ b/src/chrome/content/rules/Exede.xml
@@ -12,7 +12,6 @@
 	<securecookie host="^order\.exede\.com$" name=".+" />
 
 
-	<rule from="^http://order\.exede\.com/"
-		to="https://order.exede.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Exitec.xml
+++ b/src/chrome/content/rules/Exitec.xml
@@ -9,7 +9,6 @@
 	<target host="traq.exitec.com" />
 
 
-	<rule from="^http://traq\.exitec\.com/"
-		to="https://traq.exitec.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Exmasters.com.xml
+++ b/src/chrome/content/rules/Exmasters.com.xml
@@ -20,7 +20,6 @@ Fetch error: http://admin.exmasters.com/ => https://admin.exmasters.com/: (60, '
 	<securecookie host="^admin\.exmasters\.com$" name=".+" />
 
 
-	<rule from="^http://admin\.exmasters\.com/"
-		to="https://admin.exmasters.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/FHNW.ch.xml
+++ b/src/chrome/content/rules/FHNW.ch.xml
@@ -23,7 +23,6 @@
 	<!--securecookie host="^\.fhnw\.ch$" name="^_saml_sp$" /-->
 
 
-	<rule from="^http://aai-logon\.fhnw\.ch/"
-		to="https://aai-logon.fhnw.ch/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/FeatherCoin.xml
+++ b/src/chrome/content/rules/FeatherCoin.xml
@@ -12,7 +12,6 @@
 	<securecookie host="^forum\.feathercoin\.com$" name=".+" />
 
 
-	<rule from="^http://forum\.feathercoin\.com/"
-		to="https://forum.feathercoin.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Fifthhorseman.net.xml
+++ b/src/chrome/content/rules/Fifthhorseman.net.xml
@@ -19,7 +19,6 @@
 	<target host="dkg.fifthhorseman.net" />
 
 
-	<rule from="^http://dkg\.fifthhorseman\.net/"
-		to="https://dkg.fifthhorseman.net/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Find.ly.xml
+++ b/src/chrome/content/rules/Find.ly.xml
@@ -7,7 +7,6 @@
 	<target host="connectssl.find.ly" />
 
 
-	<rule from="^http://connectssl\.find\.ly/"
-		to="https://connectssl.find.ly/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Flavors.me.xml
+++ b/src/chrome/content/rules/Flavors.me.xml
@@ -5,8 +5,7 @@
 
         <target host="flavors.me" />
 
-        <rule from="^http://flavors\.me/"
-                to="https://flavors.me/" />
+        <rule from="^http:" to="https:" />
 
 </ruleset>
 

--- a/src/chrome/content/rules/Flowplayer.org.xml
+++ b/src/chrome/content/rules/Flowplayer.org.xml
@@ -17,7 +17,6 @@
 	<target host="releases.flowplayer.org" />
 
 
-	<rule from="^http://releases\.flowplayer\.org/"
-		to="https://releases.flowplayer.org/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Fnfismd.com.xml
+++ b/src/chrome/content/rules/Fnfismd.com.xml
@@ -12,7 +12,6 @@ Fetch error: http://carenet.fnfismd.com/ => https://carenet.fnfismd.com/: (7, 'F
 	<target host="carenet.fnfismd.com" />
 
 
-	<rule from="^http://carenet\.fnfismd\.com/"
-		to="https://carenet.fnfismd.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Footprint.net.xml
+++ b/src/chrome/content/rules/Footprint.net.xml
@@ -3,7 +3,6 @@
 	<target host="secure.footprint.net" />
 
 
-	<rule from="^http://secure\.footprint\.net/"
-		to="https://secure.footprint.net/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Foreningen_for_Dansk_Internethandel.xml
+++ b/src/chrome/content/rules/Foreningen_for_Dansk_Internethandel.xml
@@ -9,7 +9,6 @@
 	<target host="cookie.fdih.dk" />
 
 
-	<rule from="^http://cookie\.fdih\.dk/"
-		to="https://cookie.fdih.dk/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Funtoo.org.xml
+++ b/src/chrome/content/rules/Funtoo.org.xml
@@ -25,7 +25,6 @@
 	<securecookie host="^bugs\.funtoo\.org$" name=".+" />
 
 
-	<rule from="^http://bugs\.funtoo\.org/"
-		to="https://bugs.funtoo.org/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Galaxy_Project.org.xml
+++ b/src/chrome/content/rules/Galaxy_Project.org.xml
@@ -3,7 +3,6 @@
 	<target host="wiki.galaxyproject.org" />
 
 
-	<rule from="^http://wiki\.galaxyproject\.org/"
-		to="https://wiki.galaxyproject.org/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Gambling_Portal_Webmasters_Association.xml
+++ b/src/chrome/content/rules/Gambling_Portal_Webmasters_Association.xml
@@ -9,7 +9,6 @@
 	<target host="certify.gpwa.org" />
 
 
-	<rule from="^http://certify\.gpwa\.org/"
-		to="https://certify.gpwa.org/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Getprice.xml
+++ b/src/chrome/content/rules/Getprice.xml
@@ -3,7 +3,6 @@
 	<target host="secure.getprice.com.au" />
 
 
-	<rule from="^http://secure\.getprice\.com\.au/"
-		to="https://secure.getprice.com.au/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/GfK_Etilize.xml
+++ b/src/chrome/content/rules/GfK_Etilize.xml
@@ -9,7 +9,6 @@
 	<target host="content.etilize.com" />
 
 
-	<rule from="^http://content\.etilize\.com/"
-		to="https://content.etilize.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Gigantti.fi.xml
+++ b/src/chrome/content/rules/Gigantti.fi.xml
@@ -3,5 +3,5 @@
 
   <securecookie host="^www\.gigantti\.fi$" name=".*" />
 
-  <rule from="^http://www\.gigantti\.fi/" to="https://www.gigantti.fi/" />
+  <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Glb_img.com.xml
+++ b/src/chrome/content/rules/Glb_img.com.xml
@@ -3,7 +3,6 @@
 	<target host="s.glbimg.com" />
 
 
-	<rule from="^http://s\.glbimg\.com/"
-		to="https://s.glbimg.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Glispa.com.xml
+++ b/src/chrome/content/rules/Glispa.com.xml
@@ -6,7 +6,6 @@
 	<securecookie host="^ads\.glispa\.com$" name=".+" />
 
 
-	<rule from="^http://ads\.glispa\.com/"
-		to="https://ads.glispa.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Global_Research.ca.xml
+++ b/src/chrome/content/rules/Global_Research.ca.xml
@@ -8,7 +8,6 @@
 		<!--exclusion pattern="http://www\.globalresearch\.ca/" /-->
 
 
-	<rule from="^http://store\.globalresearch\.ca/"
-		to="https://store.globalresearch.ca/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/HVGKonyvek.xml
+++ b/src/chrome/content/rules/HVGKonyvek.xml
@@ -2,5 +2,5 @@
 	<target host="www.hvgkonyvek.hu" />
 
 	<securecookie host="^www\.hvgkonyvek\.hu$" name=".*" />
-	<rule from="^http://www\.hvgkonyvek\.hu/" to="https://www.hvgkonyvek.hu/" />
+	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Haschek.at.xml
+++ b/src/chrome/content/rules/Haschek.at.xml
@@ -13,7 +13,6 @@
 	<target host="blog.haschek.at" />
 
 
-	<rule from="^http://blog\.haschek\.at/"
-		to="https://blog.haschek.at/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Helsinki.xml
+++ b/src/chrome/content/rules/Helsinki.xml
@@ -12,7 +12,6 @@ Fetch error: http://asiointi.hel.fi/ => https://asiointi.hel.fi/: (35, 'Unknown 
 	<target host="asiointi.hel.fi" />
 
 
-	<rule from="^http://asiointi\.hel\.fi/"
-		to="https://asiointi.hel.fi/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/HighWire.xml
+++ b/src/chrome/content/rules/HighWire.xml
@@ -12,7 +12,6 @@
 	<securecookie host="^shibboleth\.highwire\.org$" name=".+" />
 
 
-	<rule from="^http://shibboleth\.highwire\.org/"
-		to="https://shibboleth.highwire.org/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Hjv.kursuslogin.dk.xml
+++ b/src/chrome/content/rules/Hjv.kursuslogin.dk.xml
@@ -1,5 +1,5 @@
 <ruleset name="Hjv.kursuslogin.dk">
   <target host="hjv.kursuslogin.dk" />
 
-  <rule from="^http://hjv\.kursuslogin\.dk/" to="https://hjv.kursuslogin.dk/" />
+  <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/ICharts.xml
+++ b/src/chrome/content/rules/ICharts.xml
@@ -10,7 +10,6 @@
 	<securecookie host="^accounts\.icharts\.net$" name=".+" />
 
 
-	<rule from="^http://accounts\.icharts\.net/"
-		to="https://accounts.icharts.net/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/IOpus.com.xml
+++ b/src/chrome/content/rules/IOpus.com.xml
@@ -6,7 +6,6 @@
 	<securecookie host="^support\.iopus\.com$" name=".+" />
 
 
-	<rule from="^http://support\.iopus\.com/"
-		to="https://support.iopus.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/ISO.org.xml
+++ b/src/chrome/content/rules/ISO.org.xml
@@ -12,7 +12,6 @@
 	<securecookie host="^connect\.iso\.org$" name=".+" />
 
 
-	<rule from="^http://connect\.iso\.org/"
-		to="https://connect.iso.org/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/ISPsystem.xml
+++ b/src/chrome/content/rules/ISPsystem.xml
@@ -15,7 +15,6 @@ Fetch error: http://my.ispsystem.com/ => https://my.ispsystem.com/: (60, 'SSL ce
 	<target host="my.ispsystem.com" />
 
 
-	<rule from="^http://my\.ispsystem\.com/"
-		to="https://my.ispsystem.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/ISS-World.xml
+++ b/src/chrome/content/rules/ISS-World.xml
@@ -11,7 +11,6 @@
 	<target host="portal.issworld.com" />
 
 
-	<rule from="^http://portal\.issworld\.com/"
-		to="https://portal.issworld.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/ITWeb.co.za.xml
+++ b/src/chrome/content/rules/ITWeb.co.za.xml
@@ -20,7 +20,6 @@
 	<securecookie host="^secure\.itweb\.co\.za$" name=".+" />
 
 
-	<rule from="^http://secure\.itweb\.co\.za/"
-		to="https://secure.itweb.co.za/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/IVW.xml
+++ b/src/chrome/content/rules/IVW.xml
@@ -18,7 +18,6 @@
 	<securecookie host="^heft\.ivw\.eu$" name=".+" />
 
 
-	<rule from="^http://heft\.ivw\.eu/"
-		to="https://heft.ivw.eu/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Ibs.sberbank.sk.xml
+++ b/src/chrome/content/rules/Ibs.sberbank.sk.xml
@@ -5,5 +5,5 @@ Fetch error: http://ibs.sberbank.sk/ => https://ibs.sberbank.sk/: (28, 'Connecti
 <ruleset name="Ibs.sberbank.sk">
   <target host="ibs.sberbank.sk" />
 
-  <rule from="^http://ibs\.sberbank\.sk/" to="https://ibs.sberbank.sk/" />
+  <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Ikgalekkerslapen.nl.xml
+++ b/src/chrome/content/rules/Ikgalekkerslapen.nl.xml
@@ -10,7 +10,6 @@
 	<securecookie host="^www\.ikgalekkerslapen\.nl$" name=".+" />
 
 
-	<rule from="^http://www\.ikgalekkerslapen\.nl/"
-		to="https://www.ikgalekkerslapen.nl/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Iminent.com.xml
+++ b/src/chrome/content/rules/Iminent.com.xml
@@ -25,7 +25,6 @@
 	<target host="adserver.iminent.com" />
 
 
-	<rule from="^http://adserver\.iminent\.com/"
-		to="https://adserver.iminent.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/IndusGuard.xml
+++ b/src/chrome/content/rules/IndusGuard.xml
@@ -13,7 +13,6 @@
 	<securecookie host="^soc\.indusguard\.com$" name=".+" />
 
 
-	<rule from="^http://soc\.indusguard\.com/"
-		to="https://soc.indusguard.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Innocence_Project.xml
+++ b/src/chrome/content/rules/Innocence_Project.xml
@@ -12,7 +12,6 @@
 	<securecookie host="^secure\.innocenceproject\.org$" name=".+" />
 
 
-	<rule from="^http://secure\.innocenceproject\.org/"
-		to="https://secure.innocenceproject.org/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Inrialpes.fr.xml
+++ b/src/chrome/content/rules/Inrialpes.fr.xml
@@ -3,7 +3,6 @@
 	<target host="planete.inrialpes.fr" />
 
 
-	<rule from="^http://planete\.inrialpes\.fr/"
-		to="https://planete.inrialpes.fr/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Interac_PoS_Centre.ca.xml
+++ b/src/chrome/content/rules/Interac_PoS_Centre.ca.xml
@@ -7,7 +7,6 @@
 	<target host="interacposcentre.ca" />
 
 
-	<rule from="^http://interacposcentre\.ca/"
-		to="https://interacposcentre.ca/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/InvenSense.com.xml
+++ b/src/chrome/content/rules/InvenSense.com.xml
@@ -21,7 +21,6 @@
 	<securecookie host="^store\.invensense\.com$" name=".+" />
 
 
-	<rule from="^http://store\.invensense\.com/"
-		to="https://store.invensense.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Ipredictive.com.xml
+++ b/src/chrome/content/rules/Ipredictive.com.xml
@@ -10,7 +10,6 @@
 	<target host="ad.ipredictive.com" />
 
 
-	<rule from="^http://ad\.ipredictive\.com/"
-		to="https://ad.ipredictive.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Ispgateway.de.xml
+++ b/src/chrome/content/rules/Ispgateway.de.xml
@@ -7,7 +7,6 @@
 	<target host="ml01.ispgateway.de" />
 
 
-	<rule from="^http://ml01\.ispgateway\.de/"
-		to="https://ml01.ispgateway.de/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/JAMSTEC.go.jp.xml
+++ b/src/chrome/content/rules/JAMSTEC.go.jp.xml
@@ -13,7 +13,6 @@
 	<securecookie host="^www\.jamstec\.go\.jp$" name=".+" />
 
 
-	<rule from="^http://www\.jamstec\.go\.jp/"
-		to="https://www.jamstec.go.jp/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/JFK_Library.org.xml
+++ b/src/chrome/content/rules/JFK_Library.org.xml
@@ -12,7 +12,6 @@
 	<securecookie host="^store\.jfklibrary\.org$" name=".+" />
 
 
-	<rule from="^http://store\.jfklibrary\.org/"
-		to="https://store.jfklibrary.org/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/JUKI.xml
+++ b/src/chrome/content/rules/JUKI.xml
@@ -7,7 +7,6 @@
 	<target host="www.juki.co.jp" />
 
 
-	<rule from="^http://www\.juki\.co\.jp/"
-		to="https://www.juki.co.jp/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/JXT.net.au.xml
+++ b/src/chrome/content/rules/JXT.net.au.xml
@@ -7,7 +7,6 @@ Fetch error: http://images.jxt.net.au/ => https://images.jxt.net.au/: (60, 'SSL 
 	<target host="images.jxt.net.au" />
 
 
-	<rule from="^http://images\.jxt\.net\.au/"
-		to="https://images.jxt.net.au/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/JamPlay.xml
+++ b/src/chrome/content/rules/JamPlay.xml
@@ -1,5 +1,5 @@
 <ruleset name="JamPlay">
     <target host="account.jamplay.com" />
 
-    <rule from="^http://account\.jamplay\.com/" to="https://account.jamplay.com/" />
+    <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Japias.jp.xml
+++ b/src/chrome/content/rules/Japias.jp.xml
@@ -7,7 +7,6 @@
 	<target host="webcon.japias.jp" />
 
 
-	<rule from="^http://webcon\.japias\.jp/"
-		to="https://webcon.japias.jp/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/JoeyH.name.xml
+++ b/src/chrome/content/rules/JoeyH.name.xml
@@ -10,7 +10,6 @@
 	<securecookie host="^joeyh\.name$" name=".+" />
 
 
-	<rule from="^http://joeyh\.name/"
-		to="https://joeyh.name/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Kaufdown.de.xml
+++ b/src/chrome/content/rules/Kaufdown.de.xml
@@ -3,7 +3,6 @@
 	<target host="sueddeutsche.kaufdown.de" />
 
 
-	<rule from="^http://sueddeutsche\.kaufdown\.de/"
-		to="https://sueddeutsche.kaufdown.de/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/KeyGhost.com.xml
+++ b/src/chrome/content/rules/KeyGhost.com.xml
@@ -15,7 +15,6 @@
 	<target host="secure.keyghost.com" />
 
 
-	<rule from="^http://secure\.keyghost\.com/"
-		to="https://secure.keyghost.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Kitenet.net.xml
+++ b/src/chrome/content/rules/Kitenet.net.xml
@@ -14,7 +14,6 @@
 	<target host="kitenet.net" />
 
 
-	<rule from="^http://kitenet\.net/"
-		to="https://kitenet.net/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Kreativ_Media.xml
+++ b/src/chrome/content/rules/Kreativ_Media.xml
@@ -13,7 +13,6 @@
 	<securecookie host="^secure\.kreativmedia\.ch$" name=".+" />
 
 
-	<rule from="^http://secure\.kreativmedia\.ch/"
-		to="https://secure.kreativmedia.ch/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Kreativvonalak.xml
+++ b/src/chrome/content/rules/Kreativvonalak.xml
@@ -1,5 +1,5 @@
 <ruleset name="Kreat&#237;v Vonalak">
 	<target host="www.kreativvonalak.hu" />
 
-	<rule from="^http://www\.kreativvonalak\.hu/" to="https://www.kreativvonalak.hu/" />
+	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Libsodium.org.xml
+++ b/src/chrome/content/rules/Libsodium.org.xml
@@ -13,7 +13,6 @@
 	<target host="download.libsodium.org" />
 
 
-	<rule from="^http://download\.libsodium\.org/"
-		to="https://download.libsodium.org/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Live_Business_Chat.com.xml
+++ b/src/chrome/content/rules/Live_Business_Chat.com.xml
@@ -19,7 +19,6 @@
 	<target host="www.livebusinesschat.com" />
 
 
-	<rule from="^http://www\.livebusinesschat\.com/"
-		to="https://www.livebusinesschat.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Liveclicker.net.xml
+++ b/src/chrome/content/rules/Liveclicker.net.xml
@@ -3,7 +3,6 @@
 	<target host="ecdn.liveclicker.net" />
 
 
-	<rule from="^http://ecdn\.liveclicker\.net/"
-		to="https://ecdn.liveclicker.net/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Londit.com.xml
+++ b/src/chrome/content/rules/Londit.com.xml
@@ -27,7 +27,6 @@
 	<securecookie host="^manager\.londit\.com$" name=".+" />
 
 
-	<rule from="^http://manager\.londit\.com/"
-		to="https://manager.londit.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/MDTS.xml
+++ b/src/chrome/content/rules/MDTS.xml
@@ -6,7 +6,6 @@
 	<securecookie host="^mdts\.uk\.com$" name=".*" />
 
 
-	<rule from="^http://mdts\.uk\.com/"
-		to="https://mdts.uk.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Malvern_Diabetic_Foot.org.xml
+++ b/src/chrome/content/rules/Malvern_Diabetic_Foot.org.xml
@@ -16,7 +16,6 @@ Fetch error: http://www.malverndiabeticfoot.org/ => https://www.malverndiabeticf
 	<securecookie host="^www\.malverndiabeticfoot\.org$" name=".+" />
 
 
-	<rule from="^http://www\.malverndiabeticfoot\.org/"
-		to="https://www.malverndiabeticfoot.org/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Malwr.com.xml
+++ b/src/chrome/content/rules/Malwr.com.xml
@@ -14,7 +14,6 @@
 	<target host="malwr.com" />
 
 
-	<rule from="^http://malwr\.com/"
-		to="https://malwr.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/McClatchy_Interactive.com.xml
+++ b/src/chrome/content/rules/McClatchy_Interactive.com.xml
@@ -18,7 +18,6 @@ Non-2xx HTTP code: http://media.mcclatchyinteractive.com/ (200) => https://media
 	<target host="media.mcclatchyinteractive.com" />
 
 
-	<rule from="^http://media\.mcclatchyinteractive\.com/"
-		to="https://media.mcclatchyinteractive.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Mer-Project.xml
+++ b/src/chrome/content/rules/Mer-Project.xml
@@ -3,7 +3,6 @@
 	<target host="bugs.merproject.org" />
 
 
-	<rule from="^http://bugs\.merproject\.org/"
-		to="https://bugs.merproject.org/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Metrics34.com.xml
+++ b/src/chrome/content/rules/Metrics34.com.xml
@@ -7,7 +7,6 @@
 	<target host="ctrack.metrics34.com" />
 
 
-	<rule from="^http://ctrack\.metrics34\.com/"
-		to="https://ctrack.metrics34.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Miaozhen.com.xml
+++ b/src/chrome/content/rules/Miaozhen.com.xml
@@ -3,7 +3,6 @@
 	<target host="collect.cn.miaozhen.com" />
 
 
-	<rule from="^http://collect\.cn\.miaozhen\.com/"
-		to="https://collect.cn.miaozhen.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Microgaming.xml
+++ b/src/chrome/content/rules/Microgaming.xml
@@ -10,7 +10,6 @@
 	<securecookie host="^www\.tickerassist\.co\.uk$" name=".+" />
 
 
-	<rule from="^http://www\.tickerassist\.co\.uk/"
-		to="https://www.tickerassist.co.uk/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Minacs.com.xml
+++ b/src/chrome/content/rules/Minacs.com.xml
@@ -8,7 +8,6 @@
 	<securecookie host="^clientchat\.minacs\.com$" name=".+" />
 
 
-	<rule from="^http://clientchat\.minacs\.com/"
-		to="https://clientchat.minacs.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Moja.tatrabanka.sk.xml
+++ b/src/chrome/content/rules/Moja.tatrabanka.sk.xml
@@ -1,5 +1,5 @@
 <ruleset name="Moja.tatrabanka.sk">
   <target host="moja.tatrabanka.sk" />
 
-  <rule from="^http://moja\.tatrabanka\.sk/" to="https://moja.tatrabanka.sk/" />
+  <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/MyPreferences.com.xml
+++ b/src/chrome/content/rules/MyPreferences.com.xml
@@ -19,7 +19,6 @@
 	<securecookie host="^pc2\.mypreferences\.com$" name=".+" />
 
 
-	<rule from="^http://pc2\.mypreferences\.com/"
-		to="https://pc2.mypreferences.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/My_Virtual_Paper.xml
+++ b/src/chrome/content/rules/My_Virtual_Paper.xml
@@ -24,7 +24,6 @@
 	<securecookie host="^secure\.admin\.myvirtualpaper\.com$" name=".+" />
 
 
-	<rule from="^http://secure\.admin\.myvirtualpaper\.com/"
-		to="https://secure.admin.myvirtualpaper.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Mycliplister.com.xml
+++ b/src/chrome/content/rules/Mycliplister.com.xml
@@ -7,7 +7,6 @@
 	<target host="mycliplister.com" />
 
 
-	<rule from="^http://mycliplister\.com/"
-		to="https://mycliplister.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/N-able.com.xml
+++ b/src/chrome/content/rules/N-able.com.xml
@@ -15,7 +15,6 @@
 	<securecookie host="^secure\.n-able\.com$" name=".+" />
 
 
-	<rule from="^http://secure\.n-able\.com/"
-		to="https://secure.n-able.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/NPTEd.org.xml
+++ b/src/chrome/content/rules/NPTEd.org.xml
@@ -7,7 +7,6 @@
 	<target host="www.npted.org" />
 
 
-	<rule from="^http://www\.npted\.org/"
-		to="https://www.npted.org/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/National-Arbitration-Forum.xml
+++ b/src/chrome/content/rules/National-Arbitration-Forum.xml
@@ -6,7 +6,6 @@
 	<securecookie host="^secure\.arb-forum\.com$" name=".*" />
 
 
-	<rule from="^http://secure\.arb-forum\.com/"
-		to="https://secure.arb-forum.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Nessus.org.xml
+++ b/src/chrome/content/rules/Nessus.org.xml
@@ -14,7 +14,6 @@
 	<securecookie host="^discussions\.nessus\.org$" name=".+" />
 
 
-	<rule from="^http://discussions\.nessus\.org/"
-		to="https://discussions.nessus.org/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/NetGo.hu.xml
+++ b/src/chrome/content/rules/NetGo.hu.xml
@@ -2,5 +2,5 @@
 	<target host="www.netgo.hu" />
 
 	<securecookie host="^www\.netgo\.hu$" name=".+" />
-	<rule from="^http://www\.netgo\.hu/" to="https://www.netgo.hu/" />
+	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Net_Mobile.xml
+++ b/src/chrome/content/rules/Net_Mobile.xml
@@ -3,7 +3,6 @@
 	<target host="ssl.net-m.net" />
 
 
-	<rule from="^http://ssl\.net-m\.net/"
-		to="https://ssl.net-m.net/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Network_Maker.xml
+++ b/src/chrome/content/rules/Network_Maker.xml
@@ -13,7 +13,6 @@
 	<securecookie host="^signup\.network-maker\.com$" name=".+" />
 
 
-	<rule from="^http://signup\.network-maker\.com/"
-		to="https://signup.network-maker.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/NewsNow.xml
+++ b/src/chrome/content/rules/NewsNow.xml
@@ -13,7 +13,6 @@
 	<securecookie host="^delivery\.ad\.newsnow\.net$" name=".+" />
 
 
-	<rule from="^http://delivery\.ad\.newsnow\.net/"
-		to="https://delivery.ad.newsnow.net/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/NoHold.xml
+++ b/src/chrome/content/rules/NoHold.xml
@@ -10,7 +10,6 @@
 	<target host="sw.nohold.net" />
 
 
-	<rule from="^http://sw\.nohold\.net/"
-		to="https://sw.nohold.net/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Nxtck.com.xml
+++ b/src/chrome/content/rules/Nxtck.com.xml
@@ -10,7 +10,6 @@
 	<securecookie host="^nxtck\.com$" name=".+" />
 
 
-	<rule from="^http://nxtck\.com/"
-		to="https://nxtck.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/OECD.xml
+++ b/src/chrome/content/rules/OECD.xml
@@ -5,7 +5,6 @@
 
 	<!--	!www doesn't exist.
 					-->
-	<rule from="^http://www\.oecd\.org/"
-		to="https://www.oecd.org/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/OS_Systems.xml
+++ b/src/chrome/content/rules/OS_Systems.xml
@@ -12,7 +12,6 @@
 	<securecookie host="^projetos\.ossystems\.com\.br$" name=".+" />
 
 
-	<rule from="^http://projetos\.ossystems\.com\.br/"
-		to="https://projetos.ossystems.com.br/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Object-Management-Group.xml
+++ b/src/chrome/content/rules/Object-Management-Group.xml
@@ -9,7 +9,6 @@
 	<target host="secure.omg.org" />
 
 
-	<rule from="^http://secure\.omg\.org/"
-		to="https://secure.omg.org/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Onefeed.co.uk.xml
+++ b/src/chrome/content/rules/Onefeed.co.uk.xml
@@ -13,7 +13,6 @@
 	<target host="tracking.onefeed.co.uk" />
 
 
-	<rule from="^http://tracking\.onefeed\.co\.uk/"
-		to="https://tracking.onefeed.co.uk/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Onion.xml
+++ b/src/chrome/content/rules/Onion.xml
@@ -22,7 +22,6 @@
 	<securecookie host="^store\.theonion\.com$" name=".+" />
 
 
-	<rule from="^http://store\.theonion\.com/"
-		to="https://store.theonion.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/OptMD.com.xml
+++ b/src/chrome/content/rules/OptMD.com.xml
@@ -7,7 +7,6 @@
 	<target host="cdn-sec.optmd.com" />
 
 
-	<rule from="^http://cdn-sec\.optmd\.com/"
-		to="https://cdn-sec.optmd.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Orxrdr.com.xml
+++ b/src/chrome/content/rules/Orxrdr.com.xml
@@ -7,7 +7,6 @@
 	<target host="www.orxrdr.com" />
 
 
-	<rule from="^http://www\.orxrdr\.com/"
-		to="https://www.orxrdr.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Over-yonder.net.xml
+++ b/src/chrome/content/rules/Over-yonder.net.xml
@@ -7,7 +7,6 @@
 	<target host="www.over-yonder.net" />
 
 
-	<rule from="^http://www\.over-yonder\.net/"
-		to="https://www.over-yonder.net/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/P2P_Foundation.net.xml
+++ b/src/chrome/content/rules/P2P_Foundation.net.xml
@@ -20,7 +20,6 @@
 	<target host="blog.p2pfoundation.net" />
 
 
-	<rule from="^http://blog\.p2pfoundation\.net/"
-		to="https://blog.p2pfoundation.net/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/PTE.xml
+++ b/src/chrome/content/rules/PTE.xml
@@ -5,5 +5,5 @@ Fetch error: http://www.pte.hu/ => https://www.pte.hu/: (60, 'SSL certificate pr
 <ruleset name="P&#233;csi Tudom&#225;nyegyetem">
 	<target host="www.pte.hu" />
 	
-	<rule from="^http://www\.pte\.hu/" to="https://www.pte.hu/" />
+	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Pachube.com.xml
+++ b/src/chrome/content/rules/Pachube.com.xml
@@ -3,7 +3,6 @@
 	<target host="api.pachube.com" />
 
 
-	<rule from="^http://api\.pachube\.com/"
-		to="https://api.pachube.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Pacnet.xml
+++ b/src/chrome/content/rules/Pacnet.xml
@@ -6,7 +6,6 @@
 	<securecookie host="^wm4\.pacific\.net\.au$" name=".+" />
 
 
-	<rule from="^http://wm4\.pacific\.net\.au/"
-		to="https://wm4.pacific.net.au/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Palantir.com.xml
+++ b/src/chrome/content/rules/Palantir.com.xml
@@ -7,7 +7,6 @@
 	<target host="www.palantir.com" />
 
 
-	<rule from="^http://www\.palantir\.com/"
-		to="https://www.palantir.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Pangora.xml
+++ b/src/chrome/content/rules/Pangora.xml
@@ -3,7 +3,6 @@
 	<target host="images.pangora.com" />
 
 
-	<rule from="^http://images\.pangora\.com/"
-		to="https://images.pangora.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Paris_Diderot_University.xml
+++ b/src/chrome/content/rules/Paris_Diderot_University.xml
@@ -18,7 +18,6 @@
 	<securecookie host="^auth\.univ-paris-diderot\.fr$" name=".+" />
 
 
-	<rule from="^http://auth\.univ-paris-diderot\.fr/"
-		to="https://auth.univ-paris-diderot.fr/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Pegaz_Hosting.com.xml
+++ b/src/chrome/content/rules/Pegaz_Hosting.com.xml
@@ -12,7 +12,6 @@
 	<securecookie host="^secure\.pegazhosting\.com$" name=".+" />
 
 
-	<rule from="^http://secure\.pegazhosting\.com/"
-		to="https://secure.pegazhosting.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Pform.net.xml
+++ b/src/chrome/content/rules/Pform.net.xml
@@ -9,7 +9,6 @@
 	<target host="pform.net" />
 
 
-	<rule from="^http://pform\.net/"
-		to="https://pform.net/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Piatnik.de.xml
+++ b/src/chrome/content/rules/Piatnik.de.xml
@@ -1,5 +1,5 @@
 <ruleset name="Piatnik Deutschland">
 	<target host="piatnik.de" />
 
-	<rule from="^http://piatnik\.de/" to="https://piatnik.de/" />
+	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Ping.gg.xml
+++ b/src/chrome/content/rules/Ping.gg.xml
@@ -7,7 +7,6 @@
 	<target host="ping.gg" />
 
 
-	<rule from="^http://ping\.gg/"
-		to="https://ping.gg/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Progressive.hu.xml
+++ b/src/chrome/content/rules/Progressive.hu.xml
@@ -5,5 +5,5 @@
 	<target host="www.progressive.hu" />
 
 	<securecookie host="^www\.progressive\.hu$" name=".+" />
-	<rule from="^http://www\.progressive\.hu/" to="https://www.progressive.hu/" />
+	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Pt_engine.jp.xml
+++ b/src/chrome/content/rules/Pt_engine.jp.xml
@@ -9,7 +9,6 @@
 	<target host="js.ptengine.jp" />
 
 
-	<rule from="^http://js\.ptengine\.jp/"
-		to="https://js.ptengine.jp/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/PubGears.com.xml
+++ b/src/chrome/content/rules/PubGears.com.xml
@@ -15,7 +15,6 @@
 	<securecookie host="^ox-d\.pubgears\.com$" name=".+" />
 
 
-	<rule from="^http://ox-d\.pubgears\.com/"
-		to="https://ox-d.pubgears.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/PubNXT.net.xml
+++ b/src/chrome/content/rules/PubNXT.net.xml
@@ -13,7 +13,6 @@
 		<!--exclusion pattern="^http://(www\.analytics|www)\.pubnxt\.net/" /-->
 
 
-	<rule from="^http://analytics\.pubnxt\.net/"
-		to="https://analytics.pubnxt.net/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/R7.com.xml
+++ b/src/chrome/content/rules/R7.com.xml
@@ -32,7 +32,6 @@
 	<target host="barra.r7.com" />
 
 
-	<rule from="^http://barra\.r7\.com/"
-		to="https://barra.r7.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/ROI_Solutions.xml
+++ b/src/chrome/content/rules/ROI_Solutions.xml
@@ -6,7 +6,6 @@
 	<securecookie host="^secure2\.roisolutions\.net$" name=".+" />
 
 
-	<rule from="^http://secure2\.roisolutions\.net/"
-		to="https://secure2.roisolutions.net/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/RSA-Security.xml
+++ b/src/chrome/content/rules/RSA-Security.xml
@@ -12,7 +12,6 @@ Fetch error: http://www.securesuite.co.uk/ => https://www.securesuite.co.uk/: (2
 	<securecookie host="^www\.securesuite\.co\.uk$" name=".+" /-->
 
 
-	<rule from="^http://www\.securesuite\.co\.uk/"
-		to="https://www.securesuite.co.uk/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Radford.edu.xml
+++ b/src/chrome/content/rules/Radford.edu.xml
@@ -9,7 +9,6 @@
 	<target host="php.radford.edu" />
 
 
-	<rule from="^http://php\.radford\.edu/"
-		to="https://php.radford.edu/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Radius_Networks.com.xml
+++ b/src/chrome/content/rules/Radius_Networks.com.xml
@@ -10,7 +10,6 @@
 	<securecookie host="^account\.radiusnetworks\.com$" name=".+" />
 
 
-	<rule from="^http://account\.radiusnetworks\.com/"
-		to="https://account.radiusnetworks.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Regit.org.xml
+++ b/src/chrome/content/rules/Regit.org.xml
@@ -12,7 +12,6 @@
 	<target host="home.regit.org" />
 
 
-	<rule from="^http://home\.regit\.org/"
-		to="https://home.regit.org/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Remedy_Entertainment.xml
+++ b/src/chrome/content/rules/Remedy_Entertainment.xml
@@ -12,7 +12,6 @@
 	<securecookie host="^community\.remedygames\.com$" name=".+" />
 
 
-	<rule from="^http://community\.remedygames\.com/"
-		to="https://community.remedygames.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Richard_and_Judy_Book_Club.xml
+++ b/src/chrome/content/rules/Richard_and_Judy_Book_Club.xml
@@ -7,7 +7,6 @@
 	<target host="www.richardandjudy.co.uk" />
 
 
-	<rule from="^http://www\.richardandjudy\.co\.uk/"
-		to="https://www.richardandjudy.co.uk/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/SEC-Consult.com.xml
+++ b/src/chrome/content/rules/SEC-Consult.com.xml
@@ -14,7 +14,6 @@
 	<target host="www.sec-consult.com" />
 
 
-	<rule from="^http://www\.sec-consult\.com/"
-		to="https://www.sec-consult.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/ST.com.xml
+++ b/src/chrome/content/rules/ST.com.xml
@@ -15,7 +15,6 @@
 	<securecookie host="^my\.st\.com$" name=".+" />
 
 
-	<rule from="^http://my\.st\.com/"
-		to="https://my.st.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/SVT.se.xml
+++ b/src/chrome/content/rules/SVT.se.xml
@@ -21,8 +21,7 @@
 	<securecookie host="^ld\.svt\.se$" name=".*" />
 
 
-	<rule from="^http://ld\.svt\.se/"
-		to="https://ld.svt.se/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>
 

--- a/src/chrome/content/rules/Salvation_Army_USA.org.xml
+++ b/src/chrome/content/rules/Salvation_Army_USA.org.xml
@@ -15,7 +15,6 @@
 	<securecookie host="^donate\.salvationarmyusa\.org$" name=".+" />
 
 
-	<rule from="^http://donate\.salvationarmyusa\.org/"
-		to="https://donate.salvationarmyusa.org/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Schottenland.xml
+++ b/src/chrome/content/rules/Schottenland.xml
@@ -19,7 +19,6 @@
 	<target host="na.schottenland.de" />
 
 
-	<rule from="^http://na\.schottenland\.de/"
-		to="https://na.schottenland.de/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Scoop.co.nz.xml
+++ b/src/chrome/content/rules/Scoop.co.nz.xml
@@ -13,7 +13,6 @@
 	<target host="newsagent.scoop.co.nz" />
 
 
-	<rule from="^http://newsagent\.scoop\.co\.nz/"
-		to="https://newsagent.scoop.co.nz/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/SendYourFiles.com.xml
+++ b/src/chrome/content/rules/SendYourFiles.com.xml
@@ -12,7 +12,6 @@
 	<securecookie host="^secure\.sendyourfiles\.com$" name=".+" />
 
 
-	<rule from="^http://secure\.sendyourfiles\.com/"
-		to="https://secure.sendyourfiles.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Sesek.com.xml
+++ b/src/chrome/content/rules/Sesek.com.xml
@@ -12,7 +12,6 @@
 	<target host="robert.sesek.com" />
 
 
-	<rule from="^http://robert\.sesek\.com/"
-		to="https://robert.sesek.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Skeptic.xml
+++ b/src/chrome/content/rules/Skeptic.xml
@@ -3,7 +3,6 @@
 	<target host="shop.skeptic.com" />
 
 
-	<rule from="^http://shop\.skeptic\.com/"
-		to="https://shop.skeptic.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Small_World_Labs.com.xml
+++ b/src/chrome/content/rules/Small_World_Labs.com.xml
@@ -7,7 +7,6 @@
 	<target host="static.smallworldlabs.com" />
 
 
-	<rule from="^http://static\.smallworldlabs\.com/"
-		to="https://static.smallworldlabs.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Smoothwall.org.xml
+++ b/src/chrome/content/rules/Smoothwall.org.xml
@@ -10,7 +10,6 @@
 	<target host="my.smoothwall.org" />
 
 
-	<rule from="^http://my\.smoothwall\.org/"
-		to="https://my.smoothwall.org/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Socialtext.net.xml
+++ b/src/chrome/content/rules/Socialtext.net.xml
@@ -14,7 +14,6 @@ Fetch error: http://saml.socialtext.net/ => https://saml.socialtext.net/: (7, 'F
 	<securecookie host="^saml\.socialtext\.net$" name=".+" />
 
 
-	<rule from="^http://saml\.socialtext\.net/"
-		to="https://saml.socialtext.net/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Soufun.com.tw.xml
+++ b/src/chrome/content/rules/Soufun.com.tw.xml
@@ -17,7 +17,6 @@
 	<target host="ssl.soufun.com.tw" />
 
 
-	<rule from="^http://ssl\.soufun\.com\.tw/"
-		to="https://ssl.soufun.com.tw/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/South-by-Southwest.xml
+++ b/src/chrome/content/rules/South-by-Southwest.xml
@@ -12,7 +12,6 @@
 	<securecookie host="^cart\.sxsw\.com$" name=".*" />
 
 
-	<rule from="^http://cart\.sxsw\.com/"
-		to="https://cart.sxsw.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Space_Telescope_Science_Institute.xml
+++ b/src/chrome/content/rules/Space_Telescope_Science_Institute.xml
@@ -13,7 +13,6 @@
 	<securecookie host="^archive\.stsci\.edu$" name=".+" />
 
 
-	<rule from="^http://archive\.stsci\.edu/"
-		to="https://archive.stsci.edu/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Sploder.com.xml
+++ b/src/chrome/content/rules/Sploder.com.xml
@@ -13,7 +13,6 @@
 	<target host="cdn.sploder.com" />
 
 
-	<rule from="^http://cdn\.sploder\.com/"
-		to="https://cdn.sploder.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Squid_Solutions.xml
+++ b/src/chrome/content/rules/Squid_Solutions.xml
@@ -9,7 +9,6 @@
 	<target host="aws.tracker.squidanalytics.com" />
 
 
-	<rule from="^http://aws\.tracker\.squidanalytics\.com/"
-		to="https://aws.tracker.squidanalytics.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Staticmy.com.xml
+++ b/src/chrome/content/rules/Staticmy.com.xml
@@ -3,7 +3,6 @@
 	<target host="img.staticmy.com" />
 
 
-	<rule from="^http://img\.staticmy\.com/"
-		to="https://img.staticmy.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Steeleye.com.xml
+++ b/src/chrome/content/rules/Steeleye.com.xml
@@ -12,7 +12,6 @@
 	<securecookie host="^license\.steeleye\.com$" name=".+" />
 
 
-	<rule from="^http://license\.steeleye\.com/"
-		to="https://license.steeleye.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Stgbssint.com.xml
+++ b/src/chrome/content/rules/Stgbssint.com.xml
@@ -7,7 +7,6 @@ Fetch error: http://storage.stgbssint.com/ => https://storage.stgbssint.com/: No
 	<target host="storage.stgbssint.com" />
 
 
-	<rule from="^http://storage\.stgbssint\.com/"
-		to="https://storage.stgbssint.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/StudiesAbroad.com.xml
+++ b/src/chrome/content/rules/StudiesAbroad.com.xml
@@ -3,7 +3,6 @@
 	<target host="secure.studiesabroad.com" />
 
 
-	<rule from="^http://secure\.studiesabroad\.com/"
-		to="https://secure.studiesabroad.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Survey-Analytics.xml
+++ b/src/chrome/content/rules/Survey-Analytics.xml
@@ -2,7 +2,6 @@
 
 	<target host="popup.questionpro.com" />
 
-	<rule from="^http://popup\.questionpro\.com/"
-		to="https://popup.questionpro.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/SvD.se.xml
+++ b/src/chrome/content/rules/SvD.se.xml
@@ -18,7 +18,6 @@
 	<target host="kundservice.svd.se" />
 
 
-	<rule from="^http://kundservice\.svd\.se/"
-		to="https://kundservice.svd.se/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Synch.hu.xml
+++ b/src/chrome/content/rules/Synch.hu.xml
@@ -3,7 +3,6 @@
 	<target host="web.synch.hu" />
 
 
-	<rule from="^http://web\.synch\.hu/"
-		to="https://web.synch.hu/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Synovite-scripts.com.xml
+++ b/src/chrome/content/rules/Synovite-scripts.com.xml
@@ -3,7 +3,6 @@
 	<target host="ssl.synovite-scripts.com" />
 
 
-	<rule from="^http://ssl\.synovite-scripts\.com/"
-		to="https://ssl.synovite-scripts.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Syracuse_University.xml
+++ b/src/chrome/content/rules/Syracuse_University.xml
@@ -3,7 +3,6 @@
 	<target host="faculty.ischool.syr.edu" />
 
 
-	<rule from="^http://faculty\.ischool\.syr\.edu/"
-		to="https://faculty.ischool.syr.edu/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/TDBank.xml
+++ b/src/chrome/content/rules/TDBank.xml
@@ -1,6 +1,5 @@
 <ruleset name="TD Bank (partial)">
   <target host="onlinebanking.tdbank.com" />
 
-  <rule from="^http://onlinebanking\.tdbank\.com/"
-          to="https://onlinebanking.tdbank.com/" />
+  <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/TauCeti.org.au.xml
+++ b/src/chrome/content/rules/TauCeti.org.au.xml
@@ -7,7 +7,6 @@
 	<target host="www.tauceti.org.au" />
 
 
-	<rule from="^http://www\.tauceti\.org\.au/"
-		to="https://www.tauceti.org.au/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Tequipment.NET.xml
+++ b/src/chrome/content/rules/Tequipment.NET.xml
@@ -12,7 +12,6 @@
 	<securecookie host="^store\.tequipment\.net$" name=".+" />
 
 
-	<rule from="^http://store\.tequipment\.net/"
-		to="https://store.tequipment.net/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/The-Teaching-Company.xml
+++ b/src/chrome/content/rules/The-Teaching-Company.xml
@@ -3,7 +3,6 @@
 	<target host="secureimages.teach12.com" />
 
 
-	<rule from="^http://secureimages\.teach12\.com/"
-		to="https://secureimages.teach12.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Thehabbos.org.xml
+++ b/src/chrome/content/rules/Thehabbos.org.xml
@@ -7,7 +7,6 @@
 	<target host="thehabbos.org" />
 
 
-	<rule from="^http://thehabbos\.org/"
-		to="https://thehabbos.org/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Tigase.org.xml
+++ b/src/chrome/content/rules/Tigase.org.xml
@@ -21,7 +21,6 @@
 	<securecookie host="^projects\.tigase\.org$" name=".+" />
 
 
-	<rule from="^http://projects\.tigase\.org/"
-		to="https://projects.tigase.org/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Toke.dk.xml
+++ b/src/chrome/content/rules/Toke.dk.xml
@@ -7,7 +7,6 @@
 	<target host="kau.toke.dk" />
 
 
-	<rule from="^http://kau\.toke\.dk/"
-		to="https://kau.toke.dk/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Tokyo_University_of_Science.xml
+++ b/src/chrome/content/rules/Tokyo_University_of_Science.xml
@@ -5,7 +5,6 @@
 
 	<!--	^tus.ac.jp doesn't exist.
 						-->
-	<rule from="^http://www\.tus\.ac\.jp/"
-		to="https://www.tus.ac.jp/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/TouchNet_Information_Systems.xml
+++ b/src/chrome/content/rules/TouchNet_Information_Systems.xml
@@ -6,7 +6,6 @@
 	<securecookie host="^secure\.touchnet\.com$" name=".+" />
 
 
-	<rule from="^http://secure\.touchnet\.com/"
-		to="https://secure.touchnet.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Toyota.es.xml
+++ b/src/chrome/content/rules/Toyota.es.xml
@@ -9,7 +9,6 @@
 	<target host="www2.toyota.es" />
 
 
-	<rule from="^http://www2\.toyota\.es/"
-		to="https://www2.toyota.es/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Trace_Register.xml
+++ b/src/chrome/content/rules/Trace_Register.xml
@@ -9,7 +9,6 @@
 	<target host="cdn.traceregister.com" />
 
 
-	<rule from="^http://cdn\.traceregister\.com/"
-		to="https://cdn.traceregister.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Twingly.xml
+++ b/src/chrome/content/rules/Twingly.xml
@@ -12,7 +12,6 @@
 	<securecookie host="^api\.twingly\.com$" name=".+" />
 
 
-	<rule from="^http://api\.twingly\.com/"
-		to="https://api.twingly.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Twistage.xml
+++ b/src/chrome/content/rules/Twistage.xml
@@ -24,7 +24,6 @@
 	<securecookie host="^console\.twistage\.com$" name=".+" />
 
 
-	<rule from="^http://console\.twistage\.com/"
-		to="https://console.twistage.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/UK-Access-Management-Federation.xml
+++ b/src/chrome/content/rules/UK-Access-Management-Federation.xml
@@ -10,7 +10,6 @@ Fetch error: http://wayf.ukfederation.org.uk/ => https://wayf.ukfederation.org.u
 	<securecookie host="^wayf\.ukfederation\.org\.uk$" name=".*" />
 
 
-	<rule from="^http://wayf\.ukfederation\.org\.uk/"
-		to="https://wayf.ukfederation.org.uk/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/UKFur.xml
+++ b/src/chrome/content/rules/UKFur.xml
@@ -3,5 +3,5 @@
 
   <securecookie host="^forum\.ukfur\.org$" name=".+" />
 
-  <rule from="^http://forum\.ukfur\.org/" to="https://forum.ukfur.org/" />
+  <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/USP.br.xml
+++ b/src/chrome/content/rules/USP.br.xml
@@ -14,7 +14,6 @@
 	<target host="mail.usp.br" />
 
 
-	<rule from="^http://mail\.usp\.br/"
-		to="https://mail.usp.br/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Unblu.com.xml
+++ b/src/chrome/content/rules/Unblu.com.xml
@@ -14,7 +14,6 @@
 	<target host="start.unblu.com" />
 
 
-	<rule from="^http://start\.unblu\.com/"
-		to="https://start.unblu.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Univ-SMB.fr.xml
+++ b/src/chrome/content/rules/Univ-SMB.fr.xml
@@ -7,7 +7,6 @@
 	<target host="www.univ-smb.fr" />
 
 
-	<rule from="^http://www\.univ-smb\.fr/"
-		to="https://www.univ-smb.fr/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/University-of-Western-Australia.xml
+++ b/src/chrome/content/rules/University-of-Western-Australia.xml
@@ -15,7 +15,6 @@
 	<securecookie host="^static\.weboffice\.uwa\.edu\.au$" name=".*" />
 
 
-	<rule from="^http://static\.weboffice\.uwa\.edu\.au/"
-		to="https://static.weboffice.uwa.edu.au/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/University_Computer_Club.xml
+++ b/src/chrome/content/rules/University_Computer_Club.xml
@@ -12,7 +12,6 @@
 	<target host="matt.ucc.asn.au" />
 
 
-	<rule from="^http://matt\.ucc\.asn\.au/"
-		to="https://matt.ucc.asn.au/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/University_of_York.xml
+++ b/src/chrome/content/rules/University_of_York.xml
@@ -2,6 +2,6 @@
 
   <target host="www.york.ac.uk" />
 
-  <rule from="^http://www\.york\.ac\.uk/" to="https://www.york.ac.uk/" />
+  <rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/UnlimitedHost.xml
+++ b/src/chrome/content/rules/UnlimitedHost.xml
@@ -14,7 +14,6 @@ Fetch error: http://apollo.unlimitedhost.asia/ => https://apollo.unlimitedhost.a
 	<target host="apollo.unlimitedhost.asia" />
 
 
-	<rule from="^http://apollo\.unlimitedhost\.asia/"
-		to="https://apollo.unlimitedhost.asia/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Vanco.co.uk.xml
+++ b/src/chrome/content/rules/Vanco.co.uk.xml
@@ -16,7 +16,6 @@ Fetch error: http://o-zone.vanco.co.uk/ => https://o-zone.vanco.co.uk/: (28, 'Co
 	<securecookie host="^o-zone\.vanco\.co\.uk$" name=".+" />
 
 
-	<rule from="^http://o-zone\.vanco\.co\.uk/"
-		to="https://o-zone.vanco.co.uk/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Varusteleka.fi.xml
+++ b/src/chrome/content/rules/Varusteleka.fi.xml
@@ -9,5 +9,5 @@
 	<securecookie host="^www\.varusteleka\.fi$" name=".+" />
 
 
-  <rule from="^http://www\.varusteleka\.fi/" to="https://www.varusteleka.fi/" />
+  <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Vexxhost.com.xml
+++ b/src/chrome/content/rules/Vexxhost.com.xml
@@ -21,7 +21,6 @@
 	<securecookie host="^secure\.vexxhost\.com$" name=".+" />
 
 
-	<rule from="^http://secure\.vexxhost\.com/"
-		to="https://secure.vexxhost.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/VidStore.xml
+++ b/src/chrome/content/rules/VidStore.xml
@@ -12,7 +12,6 @@
 	<securecookie host="^ads\.vidstore\.com$" name=".+" />
 
 
-	<rule from="^http://ads\.vidstore\.com/"
-		to="https://ads.vidstore.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/VideoBloom.com.xml
+++ b/src/chrome/content/rules/VideoBloom.com.xml
@@ -19,7 +19,6 @@
 	<!--securecookie host="^\.videobloom\.com$" name="SESS\w{32}" /-->
 
 
-	<rule from="^http://my\.videobloom\.com/"
-		to="https://my.videobloom.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Vitelity.xml
+++ b/src/chrome/content/rules/Vitelity.xml
@@ -1,5 +1,5 @@
 <ruleset name="Vitelity">
   <target host="portal.vitelity.net" />
 
-  <rule from="^http://portal\.vitelity\.net/" to="https://portal.vitelity.net/" />
+  <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/W-x.co.xml
+++ b/src/chrome/content/rules/W-x.co.xml
@@ -3,7 +3,6 @@
 	<target host="s.w-x.co" />
 
 
-	<rule from="^http://s\.w-x\.co/"
-		to="https://s.w-x.co/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Web_Service_Award.xml
+++ b/src/chrome/content/rules/Web_Service_Award.xml
@@ -11,7 +11,6 @@ Fetch error: http://ssl.webserviceaward.com/ => https://ssl.webserviceaward.com/
 	<target host="ssl.webserviceaward.com" />
 
 
-	<rule from="^http://ssl\.webserviceaward\.com/"
-		to="https://ssl.webserviceaward.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Webmail-Loxinfo.xml
+++ b/src/chrome/content/rules/Webmail-Loxinfo.xml
@@ -1,5 +1,5 @@
 <ruleset name="Webmail.loxinfo.co.th">
   <target host="webmail.loxinfo.co.th" />
 
-  <rule from="^http://webmail\.loxinfo\.co\.th/" to="https://webmail.loxinfo.co.th/" />
+  <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Wemakeprice.com.xml
+++ b/src/chrome/content/rules/Wemakeprice.com.xml
@@ -9,7 +9,6 @@
 	<target host="image.wemakeprice.com" />
 
 
-	<rule from="^http://image\.wemakeprice\.com/"
-		to="https://image.wemakeprice.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Willhaben.at.xml
+++ b/src/chrome/content/rules/Willhaben.at.xml
@@ -25,7 +25,6 @@
 	<securecookie host="^mobile\.willhaben\.at$" name=".+" />
 
 
-	<rule from="^http://mobile\.willhaben\.at/"
-		to="https://mobile.willhaben.at/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Wippies.xml
+++ b/src/chrome/content/rules/Wippies.xml
@@ -5,5 +5,5 @@ Fetch error: http://webmail.wippies.com/ => https://webmail.wippies.com/: (28, '
 <ruleset name="Wippies Webmail">
   <target host="webmail.wippies.com" />
 
-  <rule from="^http://webmail\.wippies\.com/" to="https://webmail.wippies.com/" />
+  <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Wk3.org.xml
+++ b/src/chrome/content/rules/Wk3.org.xml
@@ -10,7 +10,6 @@
 	<securecookie host="^wk3\.org$" name=".+" />
 
 
-	<rule from="^http://wk3\.org/"
-		to="https://wk3.org/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Workforce_Hosting.com.xml
+++ b/src/chrome/content/rules/Workforce_Hosting.com.xml
@@ -14,7 +14,6 @@
 	<securecookie host="^sdsurf\.workforcehosting\.com$" name=".+" />
 
 
-	<rule from="^http://sdsurf\.workforcehosting\.com/"
-		to="https://sdsurf.workforcehosting.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Yospace.com.xml
+++ b/src/chrome/content/rules/Yospace.com.xml
@@ -15,7 +15,6 @@
 	<securecookie host="^cds1\.yospace\.com$" name=".+" />
 
 
-	<rule from="^http://cds1\.yospace\.com/"
-		to="https://cds1.yospace.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Yuri.org.uk.xml
+++ b/src/chrome/content/rules/Yuri.org.uk.xml
@@ -7,7 +7,6 @@
 	<target host="www.yuri.org.uk" />
 
 
-	<rule from="^http://www\.yuri\.org\.uk/"
-		to="https://www.yuri.org.uk/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/eon.xml
+++ b/src/chrome/content/rules/eon.xml
@@ -2,5 +2,5 @@
 	<target host="www.eon-hungaria.com" />
 
 	<securecookie host="^www\.eon-hungaria\.com$" name=".*" />
-	<rule from="^http://www\.eon-hungaria\.com/" to="https://www.eon-hungaria.com/" />
+	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/mail.yaziba.net.xml
+++ b/src/chrome/content/rules/mail.yaziba.net.xml
@@ -2,6 +2,6 @@
 
        <target host="mail.yaziba.net" />
 
-       <rule from="^http://mail\.yaziba\.net/" to="https://mail.yaziba.net/" />
+       <rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/speech.leseweb.dk.xml
+++ b/src/chrome/content/rules/speech.leseweb.dk.xml
@@ -1,5 +1,5 @@
 <ruleset name="speech.leseweb.dk">
   <target host="speech.leseweb.dk" />
 
-  <rule from="^http://speech\.leseweb\.dk/" to="https://speech.leseweb.dk/" />
+  <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/wbond.xml
+++ b/src/chrome/content/rules/wbond.xml
@@ -1,6 +1,5 @@
 <ruleset name="Will Bond">
 	<target host="sublime.wbond.net" />
 
-	<rule from="^http://sublime\.wbond\.net/"
-		to="https://sublime.wbond.net/" />
+	<rule from="^http:" to="https:" />
 </ruleset>


### PR DESCRIPTION
A list of candidates is generated such that

 - Neither `default_off` nor `platform`
 - No linked rulesets (no occurrence of the string `.xml`)
 - Exclude all rulesets (8) failing Travis
   * 3dglassesfree.com.xml
   * Ebi.ac.uk.xml
   * RoboForm.com.xml
   * UpsideOut.com.xml
   * CounterPunch.org.xml
   * Kursbuero.de.xml
   * Toshiba.co.jp.xml
   * xServers.xml
 - `#rule` == `#target` == `#non-wildcard target` == 1

Note: The following ruleset from the PR require might some attention (non effective rewrite)
 - E-rewards.com.xml
 - Myftp.utechsoft.com.xml
 - Owl.English.Purdue.edu.xml

Remark: The number of rulesets satisfying these conditions is much lesser than my expectation. IMHO, this is not urgent at all. 

Remark: The code I used is written in Go, I might provide the code to reproduce this change if necessary.