### PR TITLE
[Lemde.fr] Add test urls and remove platform

### DIFF
--- a/src/chrome/content/rules/Lemde.fr.xml
+++ b/src/chrome/content/rules/Lemde.fr.xml
@@ -1,14 +1,20 @@
 <!--
+	For more Le Monde related rules, see Le_Monde.fr.xml
 
-    For more Le Monde related rules, see Le_Monde.fr.xml
-    
+	Mixed content:
+		asset.lemde.fr (www.lemonde.fr links to //asset.lmde.fr)
+
 -->
-<ruleset name="Lemde.fr (mixed content)" platform="mixedcontent">
+<ruleset name="Lemde.fr">
 
-    <target host="s1.lemde.fr" />
-    <target host="s2.lemde.fr" />
+	<target host="img.lemde.fr" />
+		<test url="http://img.lemde.fr/2017/07/05/0/0/2220/1311/534/0/60/0/8d05901_9403-7gtdra.3xsto9lik9.jpg" />
+	<target host="s1.lemde.fr" />
+		<test url="http://s1.lemde.fr/medias/web/1.2.702/img/placeholder/ratio-7.svg" />
+	<target host="s2.lemde.fr" />
+		<test url="http://s2.lemde.fr/medias/web/1.2.702/img/placeholder/ratio-7.svg" />
     
-    <rule from="^http:"
-            to="https:" />
+	<rule from="^http:"
+		to="https:" />
 
 </ruleset>


### PR DESCRIPTION
I have been thinking about it and it doesn't make sense to mark this ruleset as mixedcontent. It's related to `Le_Monde.fr.xml` which triggers MCB but this ruleset itself shouldn't.