### PR TITLE
Ignore "rules" directory itself changes when build

### DIFF
--- a/makecrx.sh
+++ b/makecrx.sh
@@ -44,7 +44,7 @@ rm -f src/chrome/content/rules/default.rulesets src/defaults/rulesets.sqlite
 # Only generate the ruleset database if any rulesets have changed. Tried
 # implementing this with make, but make is very slow with 15k+ input files.
 needs_update() {
-  find src/chrome/content/rules/ -newer $RULESETS_JSON |\
+  find src/chrome/content/rules/* -newer $RULESETS_JSON |\
     grep -q .
 }
 if [ ! -f "$RULESETS_JSON" ] || needs_update ; then

--- a/makexpi.sh
+++ b/makexpi.sh
@@ -60,7 +60,7 @@ rm -f src/chrome/content/rules/default.rulesets src/defaults/rulesets.sqlite
 # Only generate the ruleset database if any rulesets have changed. Tried
 # implementing this with make, but make is very slow with 15k+ input files.
 needs_update() {
-  find src/chrome/content/rules/ -newer $RULESETS_JSON |\
+  find src/chrome/content/rules/* -newer $RULESETS_JSON |\
     grep -q .
 }
 if [ ! -f "$RULESETS_JSON" ] || needs_update ; then


### PR DESCRIPTION
needs_update always be true for me, perhaps because of "Clean up obsolete ruleset databases" or anything else. This causes "Generating ruleset DB" to always be used when build.