### PR TITLE
[eggplant.today] Remove preloaded ruleset.

### DIFF
--- a/src/chrome/content/rules/eggplant.today.xml
+++ b/src/chrome/content/rules/eggplant.today.xml
@@ -1,7 +1,0 @@
-<ruleset name="eggplant.today">
-	<target host="eggplant.today" />
-	<target host="www.eggplant.today" />
-
-	<rule from="^http:"
-		to="https:" />
-</ruleset>


### PR DESCRIPTION
This domain meets the [guideline for removal of HSTS preloaded properties](https://github.com/EFForg/https-everywhere/blob/master/CONTRIBUTING.md#hsts-preloaded-rules).