### PR TITLE
[conflux.tw] Remove preloaded ruleset.

### DIFF
--- a/src/chrome/content/rules/conflux.tw.xml
+++ b/src/chrome/content/rules/conflux.tw.xml
@@ -1,7 +1,0 @@
-<ruleset name="conflux.tw">
-	<target host="conflux.tw" />
-	<target host="www.conflux.tw" />
-
-	<rule from="^http:"
-		to="https:" />
-</ruleset>


### PR DESCRIPTION
This domain meets the [guideline for removal of HSTS preloaded properties](https://github.com/EFForg/https-everywhere/blob/master/CONTRIBUTING.md#hsts-preloaded-rules).