### PR TITLE
[peirong.me] Remove preloaded ruleset.

### DIFF
--- a/src/chrome/content/rules/peirong.me.xml
+++ b/src/chrome/content/rules/peirong.me.xml
@@ -1,7 +1,0 @@
-<ruleset name="peirong.me">
-	<target host="peirong.me" />
-	<target host="www.peirong.me" />
-
-	<rule from="^http:"
-		to="https:" />
-</ruleset>


### PR DESCRIPTION
This domain meets the [guideline for removal of HSTS preloaded properties](https://github.com/EFForg/https-everywhere/blob/master/CONTRIBUTING.md#hsts-preloaded-rules).