### PR TITLE
[taqun.club] Remove preloaded ruleset.

### DIFF
--- a/src/chrome/content/rules/taqun.club.xml
+++ b/src/chrome/content/rules/taqun.club.xml
@@ -1,7 +1,0 @@
-<ruleset name="taqun.club">
-	<target host="taqun.club" />
-	<target host="www.taqun.club" />
-
-	<rule from="^http:"
-		to="https:" />
-</ruleset>


### PR DESCRIPTION
This domain meets the [guideline for removal of HSTS preloaded properties](https://github.com/EFForg/https-everywhere/blob/master/CONTRIBUTING.md#hsts-preloaded-rules).