### PR TITLE
[Express-VPN.com] Remove preloaded ruleset.

### DIFF
--- a/src/chrome/content/rules/Express-VPN.xml
+++ b/src/chrome/content/rules/Express-VPN.xml
@@ -1,7 +1,0 @@
-<ruleset name="Express-VPN.com">
-  <target host="express-vpn.com" />
-  <target host="www.express-vpn.com" />
-
-  <rule from="^http://(?:www\.)express-vpn\.com/"
-          to="https://www.express-vpn.com/" />
-</ruleset>


### PR DESCRIPTION
This domain meets the [guideline for removal of HSTS preloaded properties](https://github.com/EFForg/https-everywhere/blob/master/CONTRIBUTING.md#hsts-preloaded-rules).