### PR TITLE
[skyline.link] Remove preloaded ruleset.

### DIFF
--- a/src/chrome/content/rules/skyline.link.xml
+++ b/src/chrome/content/rules/skyline.link.xml
@@ -1,7 +1,0 @@
-<ruleset name="skyline.link">
-	<target host="skyline.link" />
-	<target host="www.skyline.link" />
-
-	<rule from="^http:"
-		to="https:" />
-</ruleset>


### PR DESCRIPTION
This domain meets the [guideline for removal of HSTS preloaded properties](https://github.com/EFForg/https-everywhere/blob/master/CONTRIBUTING.md#hsts-preloaded-rules).