### PR TITLE
Remove https-everywhere-checker message from activated rulesets (^A)

### DIFF
--- a/src/chrome/content/rules/A1A_Fast_Cash.xml
+++ b/src/chrome/content/rules/A1A_Fast_Cash.xml
@@ -1,9 +1,3 @@
-
-<!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://a1afastcash.com/ => https://a1afastcash.com/: Too many redirects while fetching 'https://a1afastcash.com/'
-
--->
 <ruleset name="A1A Fast Cash">
 
 	<target host="a1afastcash.com" />

--- a/src/chrome/content/rules/ACCAN.xml
+++ b/src/chrome/content/rules/ACCAN.xml
@@ -1,7 +1,3 @@
-<!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://accan.org.au/ => https://accan.org.au/: (60, 'SSL certificate problem: unable to get local issuer certificate')
--->
 <ruleset name="ACCAN">
   <target host="accan.org.au" />
 	<target host="www.accan.org.au" />

--- a/src/chrome/content/rules/ADP_VirtualEdge.xml
+++ b/src/chrome/content/rules/ADP_VirtualEdge.xml
@@ -1,6 +1,4 @@
 <!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://virtualedge.com/ => https://www.virtualedge.com/: (51, "SSL: no alternative certificate subject name matches target host name 'virtualedge.com'")
 	For other Automatic Data Processing coverage, see Automatic_Data_Processing.xml.
 
 

--- a/src/chrome/content/rules/ANB.xml
+++ b/src/chrome/content/rules/ANB.xml
@@ -1,7 +1,3 @@
-<!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://anb.com.sa/ => https://www.anb.com.sa/: (60, 'SSL certificate problem: unable to get local issuer certificate')
--->
 <ruleset name="ANB">
   <target host="anb.com.sa" />
   <target host="*.anb.com.sa" />

--- a/src/chrome/content/rules/ASADA.xml
+++ b/src/chrome/content/rules/ASADA.xml
@@ -1,7 +1,3 @@
-<!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://asada.gov.au/ => https://www.asada.gov.au/: (60, 'SSL certificate problem: certificate has expired')
--->
 <ruleset name="Australian Sports Anti-Doping Authority">
 	<target host="asada.gov.au" />
 	<target host="*.asada.gov.au" />

--- a/src/chrome/content/rules/ATBank.xml
+++ b/src/chrome/content/rules/ATBank.xml
@@ -1,10 +1,3 @@
-
-<!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://www.atbank.nl/ => https://www.atbank.nl/: (28, 'Resolving timed out after 10518 milliseconds')
-Fetch error: http://atbank.nl/ => https://atbank.nl/: (28, 'Resolving timed out after 10517 milliseconds')
-
--->
 <ruleset name="ATBank">
 	<!-- Rule created by Jeroen van der Gun -->
 

--- a/src/chrome/content/rules/AbenteuerLand.at.xml
+++ b/src/chrome/content/rules/AbenteuerLand.at.xml
@@ -1,6 +1,4 @@
 <!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://psara.abenteuerland.at/ => https://psara.abenteuerland.at/: (60, 'SSL certificate problem: self signed certificate in certificate chain')
 	(www.)?: loops
 
 -->

--- a/src/chrome/content/rules/AbleGamers.xml
+++ b/src/chrome/content/rules/AbleGamers.xml
@@ -1,8 +1,3 @@
-<!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://ablegamers.com/ => https://ablegamers.com/: (60, 'SSL certificate problem: self signed certificate')
-Fetch error: http://www.ablegamers.com/ => https://www.ablegamers.com/: (60, 'SSL certificate problem: self signed certificate')
--->
 <ruleset name="AbleGamers">
 
 	<target host="ablegamers.com" />

--- a/src/chrome/content/rules/AdXpansion.com.xml
+++ b/src/chrome/content/rules/AdXpansion.com.xml
@@ -1,6 +1,4 @@
 <!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://adxpansion.com/ => https://adxpansion.com/: (60, 'SSL certificate problem: unable to get local issuer certificate')
 	Nonfunctional subdomains:
 
 		- help		(dropped)

--- a/src/chrome/content/rules/Addison_Lee.xml
+++ b/src/chrome/content/rules/Addison_Lee.xml
@@ -1,9 +1,3 @@
-
-<!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://addisonlee.com/ => https://www.addisonlee.com/: Too many redirects while fetching 'https://www.addisonlee.com/'
-
--->
 <ruleset name="Addison Lee">
     <target host="addisonlee.com" />
     <target host="*.addisonlee.com" />

--- a/src/chrome/content/rules/Aftonbladet-CDN.se.xml
+++ b/src/chrome/content/rules/Aftonbladet-CDN.se.xml
@@ -1,9 +1,5 @@
 
 <!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://gfx.aftonbladet-cdn.se/ => https://www.aftonbladet.se/: Too many redirects while fetching 'https://www.aftonbladet.se/'
-Fetch error: http://gfx2.aftonbladet-cdn.se/ => https://www.aftonbladet.se/: Too many redirects while fetching 'https://www.aftonbladet.se/'
-
 	For other Aftonbladet coverage, see Aftonbladet.xml.
 
 

--- a/src/chrome/content/rules/Aftonbladet.xml
+++ b/src/chrome/content/rules/Aftonbladet.xml
@@ -1,9 +1,5 @@
 
 <!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://www.aftonbladet.se/ => https://www.aftonbladet.se/: Too many redirects while fetching 'https://www.aftonbladet.se/'
-Fetch error: http://aftonbladet.se/ => https://www.aftonbladet.se/: Too many redirects while fetching 'https://www.aftonbladet.se/'
-
 	Other Aftonbladet rulesets:
 
 		- Aftonbladet-CDN.se.xml

--- a/src/chrome/content/rules/Agari.xml
+++ b/src/chrome/content/rules/Agari.xml
@@ -1,6 +1,4 @@
 <!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://agari.com/ => https://agari.com/: (51, "SSL: no alternative certificate subject name matches target host name 'agari.com'")
 	Problematic domains:
 
 		- dev	(mismatched, CN: agari.com)

--- a/src/chrome/content/rules/AkademikerForsakring.se.xml
+++ b/src/chrome/content/rules/AkademikerForsakring.se.xml
@@ -1,8 +1,3 @@
-<!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://akademikerforsakring.se/ => https://www.akademikerforsakring.se/: (28, 'Connection timed out after 10001 milliseconds')
-Fetch error: http://www.akademikerforsakring.se/ => https://www.akademikerforsakring.se/: (28, 'Connection timed out after 10001 milliseconds')
--->
 <ruleset name="AkademikerFörsäkring.se">
 	<target host="akademikerforsakring.se" />
 	<target host="www.akademikerforsakring.se" />

--- a/src/chrome/content/rules/Alfa-Media-Partner.xml
+++ b/src/chrome/content/rules/Alfa-Media-Partner.xml
@@ -1,8 +1,5 @@
 
 <!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://sso.alfa-openmedia.de/ => https://sso.alfa-openmedia.de/: (7, 'Failed to connect to sso.alfa-openmedia.de port 443: Connection refused')
-
 	Nonfunctional domains:
 
 		- www-ecms.alfa.de	(cert: sso.alfa-openmedia.de; shows that domain's data)

--- a/src/chrome/content/rules/Alias.io.xml
+++ b/src/chrome/content/rules/Alias.io.xml
@@ -1,8 +1,3 @@
-<!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://alias.io/ => https://alias.io/: (60, 'SSL certificate problem: unable to get local issuer certificate')
-Fetch error: http://www.alias.io/ => https://www.alias.io/: (60, 'SSL certificate problem: unable to get local issuer certificate')
--->
 <ruleset name="alias.io">
 
 	<target host="alias.io" />

--- a/src/chrome/content/rules/All_Star_Tire.xml
+++ b/src/chrome/content/rules/All_Star_Tire.xml
@@ -1,7 +1,3 @@
-<!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://allstartire.com/ => https://allstartire.com/: (60, 'SSL certificate problem: self signed certificate')
--->
 <ruleset name="All Star Tire">
 
 	<target host="allstartire.com" />

--- a/src/chrome/content/rules/Allied_Media.org.xml
+++ b/src/chrome/content/rules/Allied_Media.org.xml
@@ -1,6 +1,4 @@
 <!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://alliedmedia.org/ => https://alliedmedia.org/: (60, 'SSL certificate problem: unable to get local issuer certificate')
 	Fully covered subdomains:
 
 		- (www.)

--- a/src/chrome/content/rules/Alternatif_Bilisim.org.xml
+++ b/src/chrome/content/rules/Alternatif_Bilisim.org.xml
@@ -1,8 +1,5 @@
 
 <!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://alternatifbilisim.org/ => https://alternatifbilisim.org/: (60, 'SSL certificate problem: certificate has expired')
-
 	Mixed content:
 
 		- Images on www from $self *

--- a/src/chrome/content/rules/Alzheimers_Society.xml
+++ b/src/chrome/content/rules/Alzheimers_Society.xml
@@ -1,6 +1,4 @@
 <!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://alzheimers.org.uk/ => https://www.alzheimers.org.uk/: (60, 'SSL certificate problem: certificate has expired')
 	Nonfunctional subdomains:
 
 		- forum		(shows default plesk page)

--- a/src/chrome/content/rules/American_Future_Fund.xml
+++ b/src/chrome/content/rules/American_Future_Fund.xml
@@ -1,8 +1,3 @@
-<!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://americanfuturefund.com/ => https://americanfuturefund.com/: (60, 'SSL certificate problem: certificate has expired')
-Fetch error: http://www.americanfuturefund.com/ => https://www.americanfuturefund.com/: (60, 'SSL certificate problem: certificate has expired')
--->
 <ruleset name="American Future Fund">
 
 	<target host="americanfuturefund.com" />

--- a/src/chrome/content/rules/American_Heart.org.xml
+++ b/src/chrome/content/rules/American_Heart.org.xml
@@ -1,6 +1,4 @@
 <!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://americanheart.org/ => https://www.heart.org/: (60, 'SSL certificate problem: unable to get local issuer certificate')
 	Other American Heart Foundation rulesets:
 
 		- Heart.org.xml

--- a/src/chrome/content/rules/AppVault.xml
+++ b/src/chrome/content/rules/AppVault.xml
@@ -1,6 +1,4 @@
 <!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://skilldrum.com/ => https://skilldrum.com/: (51, "SSL: no alternative certificate subject name matches target host name 'skilldrum.com'")
 	Nonfunctional domains:
 
 		- (www.)appvaultsolutions.com

--- a/src/chrome/content/rules/Arachnys.xml
+++ b/src/chrome/content/rules/Arachnys.xml
@@ -1,9 +1,3 @@
-
-<!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://arachnys.com/ => https://arachnys.com/: (35, 'Unknown SSL protocol error in connection to arachnys.com:443 ')
-
--->
 <ruleset name="Arachnys">
 
 	<target host="arachnys.com" />

--- a/src/chrome/content/rules/Argus_Leader.xml
+++ b/src/chrome/content/rules/Argus_Leader.xml
@@ -1,6 +1,4 @@
 <!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://argusleader.com/ => http://argusleader.com/: (51, "SSL: no alternative certificate subject name matches target host name 'www.argusleader.com'")
 	For other Gannett Company coverage, see Gannet-Company.xml.
 
 

--- a/src/chrome/content/rules/Asbury_Park_Press.xml
+++ b/src/chrome/content/rules/Asbury_Park_Press.xml
@@ -1,6 +1,4 @@
 <!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://app.com/ => https://www.app.com/: (51, "SSL: no alternative certificate subject name matches target host name 'www.app.com'")
 	For other Gannett Company coverage, see Gannett-Company.xml.
 
 

--- a/src/chrome/content/rules/Asheville_Citizen-Times.xml
+++ b/src/chrome/content/rules/Asheville_Citizen-Times.xml
@@ -1,6 +1,4 @@
 <!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://citizen-times.com/ => https://www.citizen-times.com/: (51, "SSL: no alternative certificate subject name matches target host name 'www.citizen-times.com'")
 	For other Gannett Company coverage, see Gannet-Company.xml.
 
 

--- a/src/chrome/content/rules/Ashford.com.xml
+++ b/src/chrome/content/rules/Ashford.com.xml
@@ -1,6 +1,4 @@
 <!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://www.ashford.com/ => http://www.ashford.com/: (28, 'Operation timed out after 15001 milliseconds with 0 bytes received')
 	At least some pages redirect to http
 
 

--- a/src/chrome/content/rules/Aspect-Security.xml
+++ b/src/chrome/content/rules/Aspect-Security.xml
@@ -1,6 +1,4 @@
 <!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://aspectsecurity.com/ => https://www.aspectsecurity.com/: Cycle detected - URL already encountered: http://aspectsecurity.com/
 	^: Refused
 
 -->

--- a/src/chrome/content/rules/Atipso.com.xml
+++ b/src/chrome/content/rules/Atipso.com.xml
@@ -1,6 +1,4 @@
 <!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://atipso.com/ => https://atipso.com/: (60, 'SSL certificate problem: unable to get local issuer certificate')
 	Mixed content:
 
 		- css on www from fonts.googleapis.com *

--- a/src/chrome/content/rules/Auctionthing.net.xml
+++ b/src/chrome/content/rules/Auctionthing.net.xml
@@ -1,7 +1,3 @@
-<!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://www.auctionthing.net/ => https://www.auctionthing.net/: (60, 'SSL certificate problem: unable to get local issuer certificate')
--->
 <ruleset name="auctionthing.net">
 
 	<target host="auctionthing.net" />

--- a/src/chrome/content/rules/Audemars_Piguet.com.xml
+++ b/src/chrome/content/rules/Audemars_Piguet.com.xml
@@ -1,6 +1,4 @@
 <!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://audemarspiguet.com/ => https://www.audemarspiguet.com/: (6, 'Could not resolve host: audemarspiguet.com')
 	Problematic subdomains:
 
 		- ^	(dropped)

--- a/src/chrome/content/rules/Audible.de.xml
+++ b/src/chrome/content/rules/Audible.de.xml
@@ -1,7 +1,3 @@
-<!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://audible.de/ => https://www.audible.de/: Cycle detected - URL already encountered: https://www.audible.de/
--->
 <ruleset name="Audible.de" platform="mixedcontent">
   <target host="audible.de"/>
   <target host="*.audible.de"/>

--- a/src/chrome/content/rules/Aufbix.org.xml
+++ b/src/chrome/content/rules/Aufbix.org.xml
@@ -1,6 +1,4 @@
 <!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://hydra.aufbix.org/ => https://hydra.aufbix.org/: (60, 'SSL certificate problem: unable to get local issuer certificate')
 	For problematic rules, see Aufbix.org-problematic.xml.
 
 

--- a/src/chrome/content/rules/AustralianAntarcticDataCentre.xml
+++ b/src/chrome/content/rules/AustralianAntarcticDataCentre.xml
@@ -1,7 +1,3 @@
-<!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://data.aad.gov.au/ => https://data.aad.gov.au/: (60, 'SSL certificate problem: self signed certificate in certificate chain')
--->
 <ruleset name="Australian Antarctic Data Centre">
 	<target host="data.aad.gov.au" />
 	<target host="*.data.aad.gov.au" />

--- a/src/chrome/content/rules/AustralianWarMemorial.xml
+++ b/src/chrome/content/rules/AustralianWarMemorial.xml
@@ -1,7 +1,3 @@
-<!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://awm.gov.au/ => https://www.awm.gov.au/: (6, 'Could not resolve host: awm.gov.au')
--->
 <ruleset name="Australian War Memorial">
 	<target host="awm.gov.au" />
 	<target host="*.awm.gov.au" />

--- a/src/chrome/content/rules/Authorize.net.xml
+++ b/src/chrome/content/rules/Authorize.net.xml
@@ -1,6 +1,4 @@
 <!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://fuzeqna.com/ => https://www.fuzeqna.com/: (6, 'Could not resolve host: fuzeqna.com')
 	Nonfunctional domains:
 
 		- welcome.authorize.net		(no https)

--- a/src/chrome/content/rules/AutoTrader.com.xml
+++ b/src/chrome/content/rules/AutoTrader.com.xml
@@ -1,7 +1,3 @@
-<!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://autotraderstatic.com/ => https://www.autotraderstatic.com/: (6, 'Could not resolve host: autotraderstatic.com')
--->
 <ruleset name="AutoTrader.com (partial)">
 
 	<target host="autotrader.com" />

--- a/src/chrome/content/rules/Auto_Rims_and_Accessories.xml
+++ b/src/chrome/content/rules/Auto_Rims_and_Accessories.xml
@@ -1,7 +1,3 @@
-<!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://autorimsandaccessories.com/ => https://autorimsandaccessories.com/: (60, 'SSL certificate problem: self signed certificate')
--->
 <ruleset name="Auto Rims &amp; Accessories">
 
 	<target host="autorimsandaccessories.com" />

--- a/src/chrome/content/rules/Automatic_Data_Processing.xml
+++ b/src/chrome/content/rules/Automatic_Data_Processing.xml
@@ -1,6 +1,4 @@
 <!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://adp.com/ => https://www.adp.com/: (28, 'Operation timed out after 0 milliseconds with 0 out of 0 bytes received')
 	Other Automatic Data Processing rulesets:
 
 		- ADP_Retirement_Services.xml

--- a/src/chrome/content/rules/Aviris-naonvalineet.xml
+++ b/src/chrome/content/rules/Aviris-naonvalineet.xml
@@ -1,7 +1,3 @@
-<!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://www.aviris.nkl.fi/ => https://aviris.nkl.fi/: (6, 'Could not resolve host: www.aviris.nkl.fi')
--->
 <ruleset name="Aviris n&#228;&#246;nv&#228;lineet">
 	<target host="aviris.fi"/>
 	<target host="www.aviris.fi"/>

--- a/src/chrome/content/rules/Axis_Bank.xml
+++ b/src/chrome/content/rules/Axis_Bank.xml
@@ -1,6 +1,4 @@
 <!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://www.axisbank.co.in/ => https://www.axisbank.co.in/: (28, 'Connection timed out after 10000 milliseconds')
 	Nonfunctional domains:
 
 		- home.axisdirect.co.in		(times out)


### PR DESCRIPTION
splitting the rewrite process to a manageable size.