### PR TITLE
[ICIJ] Cleanup and reactivate.

### DIFF
--- a/src/chrome/content/rules/ICIJ.xml
+++ b/src/chrome/content/rules/ICIJ.xml
@@ -1,15 +1,6 @@
-
-<!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://4r7hcmz0uv8fsq5a6zp9cozerpu80vf.icij.org/ => https://4r7hcmz0uv8fsq5a6zp9cozerpu80vf.icij.org/: (6, 'Could not resolve host: 4r7hcmz0uv8fsq5a6zp9cozerpu80vf.icij.org')
-
-	Mismatch:
-		- offshoreleaksmap.icij.org
--->
-<ruleset name="ICIJ" default_off='failed ruleset test'>
+<ruleset name="ICIJ">
 	<target host="icij.org" />
 	<target host="www.icij.org" />
-	<target host="4r7hcmz0uv8fsq5a6zp9cozerpu80vf.icij.org" />
 	<target host="donate.icij.org" />
 	<target host="linkurious.icij.org" />
 	<target host="offshoreleaks.icij.org" />
@@ -21,7 +12,7 @@ Fetch error: http://4r7hcmz0uv8fsq5a6zp9cozerpu80vf.icij.org/ => https://4r7hcmz
 	<target host="static-01-www.icij.org" />
 	<target host="static-02-www.icij.org" />
 
-	<securecookie host="^\.icij\.org$" name=".+" />
+	<securecookie host=".+" name=".+" />
 
 
 	<rule from="^http:"


### PR DESCRIPTION
`4r7hcmz0uv8fsq5a6zp9cozerpu80vf.icij.org` is dead.