### PR TITLE
[Irccloud.com] Cleanup and reactivate.

### DIFF
--- a/src/chrome/content/rules/Irccloud.com.xml
+++ b/src/chrome/content/rules/Irccloud.com.xml
@@ -1,22 +1,11 @@
-
-<!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://alpha.irccloud.com/ => https://alpha.irccloud.com/: (6, 'Could not resolve host: alpha.irccloud.com')
-
--->
-<ruleset name="IRCCloud" default_off='failed ruleset test'>
+<ruleset name="IRCCloud">
 	<target host="irccloud.com" />
 	<target host="www.irccloud.com" />
-	<target host="alpha.irccloud.com" />
 	<target host="api.irccloud.com" />
 	<target host="blog.irccloud.com" />
 
-	<securecookie host="^irccloud\.com$" name=".+" />
-	<securecookie host="^www\.irccloud\.com$" name=".+" />
-	<securecookie host="^alpha\.irccloud\.com$" name=".+" />
-	<securecookie host="^api\.irccloud\.com$" name=".+" />
-	<securecookie host="^blog\.irccloud\.com$" name=".+" />
+	<securecookie host=".+" name=".+" />
 
 	<rule from="^http:"
-			to="https:" />
+		to="https:" />
 </ruleset>


### PR DESCRIPTION
`alpha.irccloud.com` is dead.