### PR TITLE
[Sofort.com] Remove dead target and reactivate.

### DIFF
--- a/src/chrome/content/rules/Sofort.com.xml
+++ b/src/chrome/content/rules/Sofort.com.xml
@@ -1,16 +1,8 @@
+<ruleset name="Sofort.com">
 
-<!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://documents.sofort.com/ => https://documents.sofort.com/: Too many redirects while fetching 'https://documents.sofort.com/'
-
--->
-<ruleset name="Sofort.com" default_off='failed ruleset test'>
-
-	<!--	Direct rewrites:
-				-->
 	<target host="sofort.com" />
 	<target host="api.sofort.com" />
-	<target host="documents.sofort.com" />
+	<target host="images.sofort.com" />
 	<target host="www.sofort.com" />
 
 


### PR DESCRIPTION
`documents.sofort.com` is dead.
