### PR TITLE
[Lemde.fr] Default_off ruleset (fix #10962)

### DIFF
--- a/src/chrome/content/rules/Lemde.fr.xml
+++ b/src/chrome/content/rules/Lemde.fr.xml
@@ -1,5 +1,5 @@
 <!--
-	For more Le Monde related rules, see Le_Monde.fr.xml
+	For more Le Monde related rules, see LeMonde.fr.xml
 
 	Invalid certificate:
 

--- a/src/chrome/content/rules/Lemde.fr.xml
+++ b/src/chrome/content/rules/Lemde.fr.xml
@@ -1,11 +1,18 @@
 <!--
 	For more Le Monde related rules, see Le_Monde.fr.xml
 
-	Mixed content:
-		asset.lemde.fr (www.lemonde.fr links to //asset.lmde.fr)
+	Invalid certificate:
+
+		asset.lemde.fr (www.lemonde.fr and s1.lemde.fr link to //asset.lmde.fr)
+			<test url="http://asset.lemde.fr/data/0.14.2/css/cadre-page.css" />
+
+			see https://github.com/EFForg/https-everywhere/issues/10962
+
+		live.lemde.fr
+			<test url="http://live.lemde.fr/mux.json" />
 
 -->
-<ruleset name="Lemde.fr">
+<ruleset name="Lemde.fr" default_off="other">
 
 	<target host="img.lemde.fr" />
 		<test url="http://img.lemde.fr/2017/07/05/0/0/2220/1311/534/0/60/0/8d05901_9403-7gtdra.3xsto9lik9.jpg" />


### PR DESCRIPTION
Related: https://github.com/EFForg/https-everywhere/pull/10876 and https://github.com/EFForg/https-everywhere/issues/10962.

Another option would have been to remove the broken subdomain `s1.lemde.fr` but we would need to remove `s2.lemde.fr` as well because it looks like they are used as mirrors.

Also, because lemonde.fr has broken protocol-relative URL in many places in its source code, I would rather not take any chances.