### PR TITLE
Trivialize capturing direct rewrite rules

### DIFF
--- a/src/chrome/content/rules/Abuse.ch.xml
+++ b/src/chrome/content/rules/Abuse.ch.xml
@@ -1,12 +1,14 @@
 <ruleset name="Abuse.ch">
 
-	<target host="*.abuse.ch" />
+	<target host="spyeyetracker.abuse.ch" />
+	<target host="sslbl.abuse.ch" />
+	<target host="www.abuse.ch" />
+	<target host="zeustracker.abuse.ch" />
 
 
 	<securecookie host=".*\.abuse\.ch$" name=".+" />
 
 
-	<rule from="^http://(sslbl|spyeyetracker|www|zeustracker)\.abuse\.ch/"
-		to="https://$1.abuse.ch/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/AdHands.ru.xml
+++ b/src/chrome/content/rules/AdHands.ru.xml
@@ -16,10 +16,10 @@
 -->
 <ruleset name="AdHands.ru (partial)">
 
-	<target host="*.adhands.ru" />
+	<target host="api.adhands.ru" />
+	<target host="sedu.adhands.ru" />
 
 
-	<rule from="^http://(api|sedu)\.adhands\.ru/"
-		to="https://$1.adhands.ru/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Adjust-net.jp.xml
+++ b/src/chrome/content/rules/Adjust-net.jp.xml
@@ -1,9 +1,9 @@
 <ruleset name="adjust-net.jp">
 
-	<target host="*.adjust-net.jp" />
+	<target host="ads.adjust-net.jp" />
+	<target host="ifr.adjust-net.jp" />
 
 
-	<rule from="^http://(ads|ifr)\.adjust-net\.jp/"
-		to="https://$1.adjust-net.jp/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Admitad.com.xml
+++ b/src/chrome/content/rules/Admitad.com.xml
@@ -7,10 +7,10 @@
 -->
 <ruleset name="admitad.com">
 
-	<target host="*.admitad.com" />
+	<target host="ad.admitad.com" />
+	<target host="cdn.admitad.com" />
 
 
-	<rule from="^http://(ad|cdn)\.admitad\.com/"
-		to="https://$1.admitad.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Babylon.xml
+++ b/src/chrome/content/rules/Babylon.xml
@@ -9,13 +9,14 @@
 -->
 <ruleset name="Babylon (partial)">
 
-	<target host="*.babylon.com" />
+	<target host="img.babylon.com" />
+	<target host="store.babylon.com" />
+	<target host="utils.babylon.com" />
 
 
 	<securecookie host="^store\.babylon\.com$" name=".*" />
 
 
-	<rule from="^http://(img|store|utils)\.babylon\.com/"
-		to="https://$1.babylon.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Cihar.com.xml
+++ b/src/chrome/content/rules/Cihar.com.xml
@@ -10,10 +10,10 @@
 -->
 <ruleset name="Cihar.com (partial)">
 
-	<target host="*.cihar.com" />
+	<target host="blog.cihar.com" />
+	<target host="stats.cihar.com" />
 
 
-	<rule from="^http://(blog|stats)\.cihar\.com/"
-		to="https://$1.cihar.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Cirrus_Media.com.au.xml
+++ b/src/chrome/content/rules/Cirrus_Media.com.au.xml
@@ -6,10 +6,10 @@
 -->
 <ruleset name="Cirrus Media.com.au (partial)">
 
-	<target host="*.cirrusmedia.com.au" />
+	<target host="ccbnstatic.cirrusmedia.com.au" />
+	<target host="media.cirrusmedia.com.au" />
 
 
-	<rule from="^http://(ccbnstatic|media)\.cirrusmedia\.com\.au/"
-		to="https://$1.cirrusmedia.com.au/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Codefuel.xml
+++ b/src/chrome/content/rules/Codefuel.xml
@@ -24,7 +24,8 @@
 -->
 <ruleset name="Codefuel.com (partial)">
 
-	<target host="*.codefuel.com" />
+	<target host="accounts.codefuel.com" />
+	<target host="sso.codefuel.com" />
 
 
 	<!--	Not secured by server:
@@ -37,7 +38,6 @@
 	<securecookie host="^(?:accounts|sso)\.codefuel.com$" name=".+" />
 
 
-	<rule from="^http://(accounts|sso)\.codefuel\.com/"
-		to="https://$1.codefuel.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Comenity.net.xml
+++ b/src/chrome/content/rules/Comenity.net.xml
@@ -1,9 +1,9 @@
 <ruleset name="Comenity.net (partial)">
 
-	<target host="*.comenity.net" />
+	<target host="c.comenity.net" />
+	<target host="d.comenity.net" />
 
 
-	<rule from="^http://(c|d)\.comenity\.net/"
-		to="https://$1.comenity.net/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Comm100.cn.xml
+++ b/src/chrome/content/rules/Comm100.cn.xml
@@ -1,12 +1,12 @@
 <ruleset name="com100.cn">
 
-	<target host="*.comm100.cn" />
+	<target host="chatserver.comm100.cn" />
+	<target host="hosted.comm100.cn" />
 
 
 	<securecookie host="^chatserver\.comm100\.cn$" name=".+" />
 
 
-	<rule from="^http://(chatserver|hosted)\.comm100\.cn/"
-		to="https://$1.comm100.cn/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Customer.io.xml
+++ b/src/chrome/content/rules/Customer.io.xml
@@ -6,10 +6,11 @@
 -->
 <ruleset name="Customer.io (partial)">
 
-	<target host="*.customer.io" />
+	<target host="assets.customer.io" />
+	<target host="manage.customer.io" />
+	<target host="track.customer.io" />
 
 
-	<rule from="^http://(assets|manage|track)\.customer\.io/"
-		to="https://$1.customer.io/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Dancing_Astronaut.xml
+++ b/src/chrome/content/rules/Dancing_Astronaut.xml
@@ -6,10 +6,10 @@
 -->
 <ruleset name="Dancing Astronaut (partial)">
 
-	<target host="*.dancingastronaut.com" />
+	<target host="static.dancingastronaut.com" />
+	<target host="uploads.dancingastronaut.com" />
 
 
-	<rule from="^http://(static|uploads)\.dancingastronaut\.com/"
-		to="https://$1.dancingastronaut.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/DataHC.com.xml
+++ b/src/chrome/content/rules/DataHC.com.xml
@@ -1,9 +1,9 @@
 <ruleset name="dataHC.com">
 
-	<target host="*.datahc.com" />
+	<target host="cdn.datahc.com" />
+	<target host="media.datahc.com" />
 
 
-	<rule from="^http://(cdn|media)\.datahc\.com/"
-		to="https://$1.datahc.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/DigiBib.net.xml
+++ b/src/chrome/content/rules/DigiBib.net.xml
@@ -9,10 +9,10 @@
 -->
 <ruleset name="DigiBib.net">
 
-	<target host="*.digibib.net" />
+	<target host="m.digibib.net" />
+	<target host="www.digibib.net" />
 
 
-	<rule from="^http://(m|www)\.digibib\.net/"
-		to="https://$1.digibib.net/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Domena.pl.xml
+++ b/src/chrome/content/rules/Domena.pl.xml
@@ -13,13 +13,14 @@
 -->
 <ruleset name="Domena.pl (partial)">
 
-	<target host="*.domena.pl" />
+	<target host="domeny.domena.pl" />
+	<target host="hosting.domena.pl" />
+	<target host="poczta.domena.pl" />
 
 
 	<securecookie host="^(?:domeny|hosting|poczta)\.domena\.pl$" name=".+" />
 
 
-	<rule from="^http://(domeny|hosting|poczta)\.domena\.pl/"
-		to="https://$1.domena.pl/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Electric_Embers.xml
+++ b/src/chrome/content/rules/Electric_Embers.xml
@@ -7,13 +7,13 @@
 -->
 <ruleset name="Electric Embers (partial)">
 
-	<target host="*.electricembers.net" />
+	<target host="internal.electricembers.net" />
+	<target host="mail.electricembers.net" />
 
 
 	<securecookie host="^mail\.electricembers\.net$" name=".+" />
 
 
-	<rule from="^http://(internal|mail)\.electricembers\.net/"
-		to="https://$1.electricembers.net/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Ensimag.fr.xml
+++ b/src/chrome/content/rules/Ensimag.fr.xml
@@ -32,10 +32,13 @@
 -->
 <ruleset name="Ensimag.fr (partial)">
 
-	<target host="*.ensimag.fr" />
+	<target host="ensiwiki.ensimag.fr" />
+	<target host="inside.ensimag.fr" />
+	<target host="intranet.ensimag.fr" />
+	<target host="relint.ensimag.fr" />
+	<target host="webmail.ensimag.fr" />
 
 
-	<rule from="^http://(ensiwiki|inside|intranet|relint|webmail)\.ensimag\.fr/"
-		to="https://$1.ensimag.fr/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Florida-Center-for-Library-Automation.xml
+++ b/src/chrome/content/rules/Florida-Center-for-Library-Automation.xml
@@ -6,10 +6,10 @@
 -->
 <ruleset name="Florida Center for Library Automation (partial)">
 
-	<target host="*.fcla.edu" />
+	<target host="fclaweb.fcla.edu" />
+	<target host="metalib.fcla.edu" />
 
 
-	<rule from="^http://(fclaweb|metalib)\.fcla\.edu/"
-		to="https://$1.fcla.edu/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Fout.jp.xml
+++ b/src/chrome/content/rules/Fout.jp.xml
@@ -17,7 +17,9 @@
 -->
 <ruleset name="Fout.jp (partial)">
 
-	<target host="*.fout.jp" />
+	<target host="cnt.fout.jp" />
+	<target host="dsp.fout.jp" />
+	<target host="js.fout.jp" />
 
 
 	<!--	Set by cnt:
@@ -25,7 +27,6 @@
 	<securecookie host="^\.fout\.jp$" name="^uid$" />
 
 
-	<rule from="^http://(cnt|dsp|js)\.fout\.jp/"
-		to="https://$1.fout.jp/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Frooition_Software.xml
+++ b/src/chrome/content/rules/Frooition_Software.xml
@@ -7,10 +7,11 @@
 -->
 <ruleset name="Frooition Software (partial)">
 
-	<target host="*.frooition.com" />
+	<target host="freedom.frooition.com" />
+	<target host="my.frooition.com" />
+	<target host="secure.frooition.com" />
 
 
-	<rule from="^http://(freedom|my|secure)\.frooition\.com/"
-		to="https://$1.frooition.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/GPShopper.com.xml
+++ b/src/chrome/content/rules/GPShopper.com.xml
@@ -7,10 +7,11 @@
 -->
 <ruleset name="GPShopper.com (partial)">
 
-	<target host="*.gpshopper.com" />
+	<target host="analytics.gpshopper.com" />
+	<target host="cdn.gpshopper.com" />
+	<target host="static.gpshopper.com" />
 
 
-	<rule from="^http://(analytics|cdn|static)\.gpshopper\.com/"
-		to="https://$1.gpshopper.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Grid5000.fr.xml
+++ b/src/chrome/content/rules/Grid5000.fr.xml
@@ -4,10 +4,10 @@
 -->
 <ruleset name="Grid5000.fr">
 
-	<target host="*.grid5000.fr" />
+	<target host="api.grid5000.fr" />
+	<target host="www.grid5000.fr" />
 
 
-	<rule from="^http://(api|www)\.grid5000\.fr/"
-		to="https://$1.grid5000.fr/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/HITBSecConf.xml
+++ b/src/chrome/content/rules/HITBSecConf.xml
@@ -13,13 +13,13 @@
 -->
 <ruleset name="HITBSecConf">
 
-	<target host="*.hitb.org" />
+	<target host="conference.hitb.org" />
+	<target host="news.hitb.org" />
 
 
 	<securecookie host="^(?:conference|news)\.hitb\.org$" name=".+" />
 
 
-	<rule from="^http://(conference|news)\.hitb\.org/"
-		to="https://$1.hitb.org/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Helmet.fi.xml
+++ b/src/chrome/content/rules/Helmet.fi.xml
@@ -1,5 +1,7 @@
 <ruleset name="Helmet.fi">
-  <target host="*.helmet.fi" />
+  <target host="haku.helmet.fi" />
+	<target host="luettelo.helmet.fi" />
+	<target host="www.helmet.fi" />
 
 
 	<!--	Not secured by server:
@@ -12,5 +14,5 @@
 	<securecookie host="^(?:haku|luettelo|www)?\.helmet\.fi$" name=".+" />
 
 
-  <rule from="^http://(www|luettelo|haku)\.helmet\.fi/" to="https://$1.helmet.fi/" />
+  <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/JAMF_Software.com.xml
+++ b/src/chrome/content/rules/JAMF_Software.com.xml
@@ -1,6 +1,9 @@
 <ruleset name="JAMF Software.com (partial)">
 
-	<target host="*.jamfsoftware.com" />
+	<target host="jamfnation.jamfsoftware.com" />
+	<target host="my.jamfsoftware.com" />
+	<target host="store.jamfsoftware.com" />
+	<target host="support.jamfsoftware.com" />
 		<!--
 			Dropped:
 					-->
@@ -12,7 +15,6 @@
 	<!--securecookie host="^\.jamfsoftware\.com$" name="^JSESSIONID$" /-->
 
 
-	<rule from="^http://(jamfnation|my|support|store)\.jamfsoftware\.com/"
-		to="https://$1.jamfsoftware.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Law_School_Admission_Council.xml
+++ b/src/chrome/content/rules/Law_School_Admission_Council.xml
@@ -13,13 +13,14 @@
 -->
 <ruleset name="Law School Admission Council (partial)">
 
-	<target host="*.lsac.org" />
+	<target host="llm.lsac.org" />
+	<target host="lsaclookup.lsac.org" />
+	<target host="os.lsac.org" />
 
 
 	<securecookie host="^.+\.lsac\.org$" name=".+" />
 
 
-	<rule from="^http://(llm|lsaclookup|os)\.lsac\.org/"
-		to="https://$1.lsac.org/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/MarketGid.com.xml
+++ b/src/chrome/content/rules/MarketGid.com.xml
@@ -50,7 +50,11 @@
 -->
 <ruleset name="MarketGid.com (partial)">
 
-	<target host="*.marketgid.com" />
+	<target host="a.marketgid.com" />
+	<target host="dashboard.marketgid.com" />
+	<target host="my.marketgid.com" />
+	<target host="tools.marketgid.com" />
+	<target host="usr.marketgid.com" />
 		<!--
 			Redirects to http:
 						-->
@@ -65,7 +69,6 @@
 	<securecookie host="^(?:dashboard|tools)\.marketgid\.com$" name=".+" />
 
 
-	<rule from="^http://(a|dashboard|my|tools|usr)\.marketgid\.com/"
-		to="https://$1.marketgid.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Mediametrie-eStat.xml
+++ b/src/chrome/content/rules/Mediametrie-eStat.xml
@@ -12,14 +12,14 @@
 -->
 <ruleset name="Médiamétrie-eStat (partial)">
 
-	<target host="*.estat.com" />
+	<target host="prof.estat.com" />
+	<target host="w.estat.com" />
 
 
 	<!--	e is set by prof & w	-->
 	<securecookie host="\.estat\.com$" name=".*" />
 
 
-	<rule from="^http://(prof|w)\.estat\.com/"
-		to="https://$1.estat.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Metropolia.fi.xml
+++ b/src/chrome/content/rules/Metropolia.fi.xml
@@ -1,6 +1,7 @@
 <ruleset name="Metropolia University of Applied Sciences">
-    <target host="*.metropolia.fi" />
+    <target host="metropooli.metropolia.fi" />
+	<target host="moodle.metropolia.fi" />
 
 
-    <rule from="^http://(moodle|metropooli)\.metropolia\.fi/" to="https://$1.metropolia.fi/" />
+    <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Np-Edv.at.xml
+++ b/src/chrome/content/rules/Np-Edv.at.xml
@@ -9,7 +9,12 @@
 -->
 <ruleset name="np-Edv.at (partial)">
 
-	<target host="*.np-edv.at" />
+	<target host="hosting.np-edv.at" />
+	<target host="it.np-edv.at" />
+	<target host="kawas.np-edv.at" />
+	<target host="mail.np-edv.at" />
+	<target host="stats.np-edv.at" />
+	<target host="wiki.np-edv.at" />
 		<!--exclusion pattern="^http://(static|www)\.np-edv\.at/" /-->
 
 
@@ -20,7 +25,6 @@
 	<!--securecookie host="^wiki\.np-edv\.at$" name="^DokuWiki$" /-->
 
 
-	<rule from="^http://(hosting|it|kawas|mail|stats|wiki)\.np-edv\.at/"
-		to="https://$1.np-edv.at/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/OrangeWebsite.com.xml
+++ b/src/chrome/content/rules/OrangeWebsite.com.xml
@@ -12,13 +12,13 @@
 -->
 <ruleset name="OrangeWebsite.com (partial)">
 
-	<target host="*.orangewebsite.com" />
+	<target host="jolnir.orangewebsite.com" />
+	<target host="secure.orangewebsite.com" />
 
 
 	<securecookie host="^secure\.orangewebsite\.com$" name=".+" />
 
 
-	<rule from="^http://(jolnir|secure)\.orangewebsite\.com/"
-		to="https://$1.orangewebsite.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Palo_Alto_Research_Center.xml
+++ b/src/chrome/content/rules/Palo_Alto_Research_Center.xml
@@ -1,6 +1,7 @@
 <ruleset name="Palo Alto Research Center">
 
-	<target host="*.parc.com" />
+	<target host="blogs.parc.com" />
+	<target host="www.parc.com" />
 
 
 	<securecookie host="^blogs\.parc\.com$" name=".+" />
@@ -8,7 +9,6 @@
 
 	<!--	^parc.com doesn't exist.
 					-->
-	<rule from="^http://(blogs|www)\.parc\.com/"
-		to="https://$1.parc.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Pocket_Casts.com.xml
+++ b/src/chrome/content/rules/Pocket_Casts.com.xml
@@ -10,10 +10,10 @@
 -->
 <ruleset name="Pocket Casts.com (partial)">
 
-	<target host="*.pocketcasts.com" />
+	<target host="play.pocketcasts.com" />
+	<target host="social.pocketcasts.com" />
 
 
-	<rule from="^http://(play|social)\.pocketcasts\.com/"
-		to="https://$1.pocketcasts.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Push.IO.xml
+++ b/src/chrome/content/rules/Push.IO.xml
@@ -6,13 +6,13 @@
 -->
 <ruleset name="Push.IO (partial)">
 
-	<target host="*.push.io" />
+	<target host="manage.push.io" />
+	<target host="status.push.io" />
 
 
 	<securecookie host="^manage\.push\.io$" name=".+" />
 
 
-	<rule from="^http://(manage|status)\.push\.io/"
-		to="https://$1.push.io/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Richmond.edu.xml
+++ b/src/chrome/content/rules/Richmond.edu.xml
@@ -80,7 +80,14 @@
 -->
 <ruleset name="Richmond.edu (partial)">
 
-	<target host="*.richmond.edu" />
+	<target host="autodiscover.richmond.edu" />
+	<target host="bannerweb.richmond.edu" />
+	<target host="blackboard.richmond.edu" />
+	<target host="dsl.richmond.edu" />
+	<target host="exchangemail.richmond.edu" />
+	<target host="facultystaff.richmond.edu" />
+	<target host="webapps.richmond.edu" />
+	<target host="webpass.richmond.edu" />
 
 
 	<!--	Server sets Secure for these:
@@ -92,7 +99,6 @@
 	<securecookie host="^(?:bannerweb|blackboard|webpass)\.richmond\.edu$" name=".+" />
 
 
-	<rule from="^http://(autodiscover|bannerweb|blackboard|dsl|exchangemail|facultystaff|webapps|webpass)\.richmond\.edu/"
-		to="https://$1.richmond.edu/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Roller_Net.us.xml
+++ b/src/chrome/content/rules/Roller_Net.us.xml
@@ -17,10 +17,11 @@
 -->
 <ruleset name="Roller Net.us (partial)">
 
-	<target host="*.rollernet.us" />
+	<target host="acc.rollernet.us" />
+	<target host="activesync.rollernet.us" />
+	<target host="webmail.rollernet.us" />
 
 
-	<rule from="^http://(acc|activesync|webmail)\.rollernet\.us/"
-		to="https://$1.rollernet.us/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/SharpSpring.xml
+++ b/src/chrome/content/rules/SharpSpring.xml
@@ -6,13 +6,13 @@
 -->
 <ruleset name="SharpSpring (partial)">
 
-	<target host="*.sharpspring.com" />
+	<target host="app.sharpspring.com" />
+	<target host="sfdc.sharpspring.com" />
 
 
 	<securecookie host=".+\.sharpspring\.com$" name=".+" />
 
 
-	<rule from="^http://(app|sfdc)\.sharpspring\.com/"
-		to="https://$1.sharpspring.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/SteelHousemedia.com.xml
+++ b/src/chrome/content/rules/SteelHousemedia.com.xml
@@ -15,7 +15,10 @@
 -->
 <ruleset name="SteelHousemedia.com (partial)">
 
-	<target host="*.steelhousemedia.com" />
+	<target host="cdn4s.steelhousemedia.com" />
+	<target host="dx.steelhousemedia.com" />
+	<target host="px.steelhousemedia.com" />
+	<target host="ww.steelhousemedia.com" />
 
 
 	<!--	Tracking cookies:
@@ -24,7 +27,6 @@
 	<securecookie host="^\.px\.steelhousemedia\.com$" name=".+" />
 
 
-	<rule from="^http://(cdn4s|dx|px|ww)\.steelhousemedia\.com/"
-		to="https://$1.steelhousemedia.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/SurpassHosting.com.xml
+++ b/src/chrome/content/rules/SurpassHosting.com.xml
@@ -30,7 +30,9 @@
 -->
 <ruleset name="SurpassHosting.com (partial)">
 
-	<target host="*.surpasshosting.com" />
+	<target host="chat.surpasshosting.com" />
+	<target host="core.surpasshosting.com" />
+	<target host="sh151.surpasshosting.com" />
 
 
 	<!--	Not secured by server:
@@ -38,7 +40,6 @@
 	<securecookie host="^core\.surpasshosting\.com$" name=".+" />
 
 
-	<rule from="^http://(chat|core|sh151)\.surpasshosting\.com/"
-		to="https://$1.surpasshosting.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/TAIFEX.com.tw.xml
+++ b/src/chrome/content/rules/TAIFEX.com.tw.xml
@@ -14,7 +14,8 @@
 -->
 <ruleset name="TAIFEX.com.tw">
 
-	<target host="*.taifex.com.tw" />
+	<target host="sim.taifex.com.tw" />
+	<target host="www.taifex.com.tw" />
 
 
 	<!--	Not secured by server:
@@ -25,7 +26,6 @@
 	<securecookie host="^(?:sim|www)\.taifex\.com\.tw$" name=".+" />
 
 
-	<rule from="^http://(sim|www)\.taifex\.com\.tw/"
-		to="https://$1.taifex.com.tw/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/TDS.net.xml
+++ b/src/chrome/content/rules/TDS.net.xml
@@ -13,7 +13,9 @@
 -->
 <ruleset name="TDS.net (partial)">
 
-	<target host="*.tds.net" />
+	<target host="secure.tds.net" />
+	<target host="sso.tds.net" />
+	<target host="tsm.tds.net" />
 
 
 	<!--	Tracking cookies:
@@ -23,7 +25,6 @@
 	<securecookie host="^sso\.tds\.net$" name=".+" />
 
 
-	<rule from="^http://(secure|sso|tsm)\.tds\.net/"
-		to="https://$1.tds.net/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/The_Newsmarket.xml
+++ b/src/chrome/content/rules/The_Newsmarket.xml
@@ -1,12 +1,12 @@
 <ruleset name="The Newsmarket (partial)">
 
-	<target host="*.thenewsmarket.com" />
+	<target host="br.thenewsmarket.com" />
+	<target host="previews.thenewsmarket.com" />
 
 
 	<securecookie host="^br\.thenewsmarket\.com$" name=".+" />
 
 
-	<rule from="^http://(br|previews)\.thenewsmarket\.com/"
-		to="https://$1.thenewsmarket.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/TradeNetworks.xml
+++ b/src/chrome/content/rules/TradeNetworks.xml
@@ -11,13 +11,13 @@
 -->
 <ruleset name="TradeNetworks (partial)">
 
-	<target host="*.tradenetworks.com" />
+	<target host="billing.tradenetworks.com" />
+	<target host="download.tradenetworks.com" />
 
 
 	<securecookie host="^billing\.tradenetworks\.com$" name=".+" />
 
 
-	<rule from="^http://(billing|download)\.tradenetworks\.com/"
-		to="https://$1.tradenetworks.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Trulia-cdn.com.xml
+++ b/src/chrome/content/rules/Trulia-cdn.com.xml
@@ -10,12 +10,12 @@
 -->
 <ruleset name="trulia-cdn.com">
 
-	<target host="*.trulia-cdn.com" />
+	<target host="css.trulia-cdn.com" />
+	<target host="static.trulia-cdn.com" />
 
 	<test url="http://css.trulia-cdn.com/" />
 	<test url="http://static.trulia-cdn.com/" />
 
-	<rule from="^http://(css|static)\.trulia-cdn\.com/"
-		to="https://$1.trulia-cdn.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/UJF-Grenoble.fr.xml
+++ b/src/chrome/content/rules/UJF-Grenoble.fr.xml
@@ -8,10 +8,11 @@
 -->
 <ruleset name="UJF-Grenoble.fr">
 
-	<target host="*.ujf-grenoble.fr" />
+	<target host="developpementdurable.ujf-grenoble.fr" />
+	<target host="liens.ujf-grenoble.fr" />
+	<target host="www.ujf-grenoble.fr" />
 
 
-	<rule from="^http://(developpementdurable|liens|www)\.ujf-grenoble\.fr/"
-		to="https://$1.ujf-grenoble.fr/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/UKNOF.org.uk.xml
+++ b/src/chrome/content/rules/UKNOF.org.uk.xml
@@ -9,7 +9,9 @@
 -->
 <ruleset name="UKNOF.org.uk (partial)">
 
-	<target host="*.uknof.org.uk" />
+	<target host="indico.uknof.org.uk" />
+	<target host="lists.uknof.org.uk" />
+	<target host="wiki.uknof.org.uk" />
 
 
 	<!--	Secured by server:
@@ -17,7 +19,6 @@
 	<!--securecookie host="^wiki\.uknof\.org\.uk$" name="^uknofwiki_mw_uknof__session$" /-->
 
 
-	<rule from="^http://(indico|lists|wiki)\.uknof\.org\.uk/"
-		to="https://$1.uknof.org.uk/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Verkkomaksut.fi.xml
+++ b/src/chrome/content/rules/Verkkomaksut.fi.xml
@@ -6,13 +6,13 @@
 -->
 <ruleset name="Verkkomaksut.fi (partial)">
 
-	<target host="*.verkkomaksut.fi" />
+	<target host="img.verkkomaksut.fi" />
+	<target host="payment.verkkomaksut.fi" />
 
 
 	<securecookie host="^(?:\.?payment)?\.verkkomaksut\.fi$" name=".+" />
 
 
-	<rule from="^http://(img|payment)\.verkkomaksut\.fi/"
-		to="https://$1.verkkomaksut.fi/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Vertriebsassistent.de.xml
+++ b/src/chrome/content/rules/Vertriebsassistent.de.xml
@@ -12,7 +12,8 @@
 -->
 <ruleset name="Vertriebsassistent.de (partial)">
 
-	<target host="*.vertriebsassistent.de" />
+	<target host="app.vertriebsassistent.de" />
+	<target host="stats.vertriebsassistent.de" />
 
 
 	<!--	Is this safe to secure?
@@ -21,7 +22,6 @@
 	<securecookie host="^stats\.vertriebsassistent\.de$" name=".+" />
 
 
-	<rule from="^http://(app|stats)\.vertriebsassistent\.de/"
-		to="https://$1.vertriebsassistent.de/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/ViaMichelin.com.xml
+++ b/src/chrome/content/rules/ViaMichelin.com.xml
@@ -13,13 +13,14 @@
 -->
 <ruleset name="ViaMichelin.com (partial)">
 
-	<target host="*.viamichelin.com" />
+	<target host="ccu.viamichelin.com" />
+	<target host="download.viamichelin.com" />
+	<target host="webservices.viamichelin.com" />
 
 
 	<securecookie host="^download\.viamichelin\.com$" name=".+" />
 
 
-	<rule from="^http://(ccu|download|webservices)\.viamichelin\.com/"
-		to="https://$1.viamichelin.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Vichan.net.xml
+++ b/src/chrome/content/rules/Vichan.net.xml
@@ -17,10 +17,11 @@
 -->
 <ruleset name="vichan.net (partial)">
 
-	<target host="*.vichan.net" />
+	<target host="au.vichan.net" />
+	<target host="int.vichan.net" />
+	<target host="pl.vichan.net" />
 
 
-	<rule from="^http://(au|int|pl)\.vichan\.net/"
-		to="https://$1.vichan.net/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/View_Central.com.xml
+++ b/src/chrome/content/rules/View_Central.com.xml
@@ -1,12 +1,12 @@
 <ruleset name="View Central.com (partial)">
 
-	<target host="*.viewcentral.com" />
+	<target host="admin.viewcentral.com" />
+	<target host="inter.viewcentral.com" />
 
 
 	<securecookie host="^(?:admin|inter)\.viewcentral\.com$" name=".+" />
 
 
-	<rule from="^http://(admin|inter)\.viewcentral\.com/"
-		to="https://$1.viewcentral.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>


### PR DESCRIPTION
 - move away from wildcard target if possible
 - let fetch test do its job!

P.S.  ~The Go code is not ready for review yet, please do not merge.~ 

The source code is available now. [`TrivializeWildcardSimpleRules.go`](https://github.com/cschanaj/covfefe/blob/master/src/TrivializeWildcardSimpleRules.go). 

Updates: 

A significant number of ruleset (35) failed the fetch test after the rewrite (see list below). @J0WI , @Hainish should I rewrite and `default_off='failed ruleset test'`ing them in another PR? @jeremyn Sorry for pinging you mistakenly.

 - InfluAds.xml
 - 24-7_Customer.xml
 - Financial-Content.xml
 - Marhab.xml
 - Blaze.com.xml
 - NJ_Edge.Net.xml
 - Enecto.com.xml
 - Ironwhale.com.xml
 - Hitachi_Data_Systems.xml
 - ChampionCasino.net.xml
 - Crimtan.xml
 - Friesland_Bank.nl.xml
 - AWcloud.net.xml
 - Mesh-Internet.xml
 - Brand_Embassy.xml
 - San_Francisco_Marathon.xml
 - Russia.ru.xml
 - Washington_Times.xml
 - Reed_Business_Information_Australia.xml
 - Redcats.xml
 - World_Television.xml
 - Bank_of_Taipei.com.tw.xml
 - AA.net.uk.xml
 - Serverloft.xml
 - Moreover-Technologies.xml
 - AkademiskaHus.se.xml
 - Network-Depot.xml
 - Sanalika.xml
 - Hostname.sk.xml
 - Ve_Interactive.xml
 - Perform.xml
 - University_of_Tennessee_System.xml
 - Nocdirect.com.xml
 - VisibleGains.com.xml
 - Locaweb.xml
 - Blaze.com.xml