### PR TITLE
 Trivialize capturing direct rewrite rules (linked, platform)

### DIFF
--- a/src/chrome/content/rules/US_Geological_Survey.xml
+++ b/src/chrome/content/rules/US_Geological_Survey.xml
@@ -29,10 +29,11 @@
 -->
 <ruleset name="U.S. Geological Survey" platform="mixedcontent">
 
-	<target host="*.usgs.gov" />
+	<target host="answers.usgs.gov" />
+	<target host="nccwsc.usgs.gov" />
+	<target host="water.usgs.gov" />
 
 
-	<rule from="^http://(answers|nccwsc|water)\.usgs\.gov/"
-		to="https://$1.usgs.gov/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>


### PR DESCRIPTION
Related: #10965 however, it turns out only 1 such ruleset passing Travis.

Following ruleset failed Travis build (4):

 - Bigmir.net-falsemixed.xml
 - Element14.com-Mixed.xml
 - Tinypass.com-falsemixed.xml
 - Vungle.com-falsemixed.xml