### PR TITLE
Excluding support-mail-links.atlassian.com...

### DIFF
--- a/src/chrome/content/rules/Atlassian.xml
+++ b/src/chrome/content/rules/Atlassian.xml
@@ -78,11 +78,12 @@
 
 	<!--target host="atlassian.wpengine.netdna-cdn.com" /-->
 
-		<exclusion pattern="http://(?:click\.mailer|status\.marketplace|swag)\.atlassian\.com/" />
+		<exclusion pattern="http://(?:click\.mailer|status\.marketplace|swag|support-mail-links)\.atlassian\.com/" />
 
 			<test url="http://click.mailer.atlassian.com/" />
 			<test url="http://status.marketplace.atlassian.com/" />
 			<test url="http://swag.atlassian.com/" />
+			<test url="http://support-mail-links.atlassian.com/" />
 
 		<!--	Added by Atlassian:
 						-->


### PR DESCRIPTION
... due to a limitation of transactional email vendor, Mandrill.