### PR TITLE
Update https_everywhere_checker/check_rules.py, Fix #10877

### DIFF
--- a/test/rules/coverage.checker.config
+++ b/test/rules/coverage.checker.config
@@ -4,6 +4,7 @@
 [rulesets]
 rulesdir = src/chrome/content/rules
 check_coverage = true
+check_target_validity = true
 check_nonmatch_groups = true
 check_test_formatting = true
 include_default_off = false

--- a/test/rules/requirements.txt
+++ b/test/rules/requirements.txt
@@ -2,3 +2,4 @@ pycurl
 regex
 bsdiff4
 python-Levenshtein
+tldextract

--- a/test/rules/src/https_everywhere_checker/check_rules.py
+++ b/test/rules/src/https_everywhere_checker/check_rules.py
@@ -130,11 +130,18 @@ class UrlComparisonThread(threading.Thread):
 		logging.debug("Fetching plain page %s", plainUrl)
 		# If we get an exception (e.g. connection refused,
 		# connection timeout) on the plain page, don't treat
-		# that as a failure.
+		# that as a failure (except DNS resolution errors)
 		plainRcode, plainPage = None, None
 		try:
 			plainRcode, plainPage = fetcherPlain.fetchHtml(plainUrl)
 		except Exception, e:
+			errno, message = e
+			if errno == 6:
+				message = "Fetch error: %s => %s: %s" % (
+					plainUrl, transformedUrl, e)
+				self.queue_result("error", "fetch-error %s"% e, ruleFname, plainUrl, https_url=transformedUrl)
+				return message
+
 			logging.debug("Non-fatal fetch error for plain page %s: %s" % (plainUrl, e))
 
 		# Compare HTTP return codes - if original page returned 2xx,

--- a/test/rules/src/https_everywhere_checker/check_rules.py
+++ b/test/rules/src/https_everywhere_checker/check_rules.py
@@ -290,6 +290,9 @@ def cli():
 	checkCoverage = False
 	if config.has_option("rulesets", "check_coverage"):
 		checkCoverage = config.getboolean("rulesets", "check_coverage")
+	checkTargetValidity = False
+	if config.has_option("rulesets", "check_target_validity"):
+		checkTargetValidity = config.getboolean("rulesets", "check_target_validity")
 	checkNonmatchGroups = False
 	if config.has_option("rulesets", "check_nonmatch_groups"):
 		checkNonmatchGroups = config.getboolean("rulesets", "check_nonmatch_groups")
@@ -341,6 +344,7 @@ def cli():
 	
 	rulesets = []
 	coverageProblemsExist = False
+	targetValidityProblemExist = False
 	nonmatchGroupProblemsExist = False
 	testFormattingProblemsExist = False
 	for xmlFname in xmlFnames:
@@ -362,6 +366,12 @@ def cli():
 			problems = ruleset.getCoverageProblems()
 			for problem in problems:
 				coverageProblemsExist = True
+				logging.error(problem)
+		if checkTargetValidity:
+			logging.debug("Checking target validity for '%s'." % ruleset.name)
+			problems = ruleset.getTargetValidityProblems()
+			for problem in problems:
+				targetValidityProblemExist = True
 				logging.error(problem)
 		if checkNonmatchGroups:
 			logging.debug("Checking non-match groups for '%s'." % ruleset.name)
@@ -444,6 +454,9 @@ def cli():
 			json_output(resQueue, args.json_file, problems)
 	if checkCoverage:
 		if coverageProblemsExist:
+			return 1 # exit with error code
+	if checkTargetValidity:
+		if targetValidityProblemExist:
 			return 1 # exit with error code
 	if checkNonmatchGroups:
 		if nonmatchGroupProblemsExist:

--- a/test/rules/src/https_everywhere_checker/rules.py
+++ b/test/rules/src/https_everywhere_checker/rules.py
@@ -1,8 +1,8 @@
 from tldextract import tldextract
 from urlparse import urlparse
 
-
 import regex
+import socket
 
 class Rule(object):
 	"""Represents one from->to rule element."""
@@ -195,11 +195,25 @@ class Ruleset(object):
 			# Ignore right-wildcard targets
 			if target.endswith(".*"):
 				continue
+
+			# Ignore if target is an ipv4 address
+			try:
+				socket.inet_aton(target)
+				continue
+			except:
+				pass
+
+			# Ignore if target is an ipv6 address
+			try:
+				socket.inet_pton(socket.AF_INET6, target)
+				continue
+			except:
+				pass
 				
 			# Extract TLD from target if possible
 			res = tldextract.extract(target)
-			if res.suffix == "":
-				problems.append("%s: Target '%s' missing gTLD/ ccTLD" % (self.filename, target))
+			if res.domain == "" or res.suffix == "":
+				problems.append("%s: Target '%s' missing eTLD" % (self.filename, target))
 				
 		return problems
 

--- a/test/rules/src/https_everywhere_checker/rules.py
+++ b/test/rules/src/https_everywhere_checker/rules.py
@@ -212,8 +212,10 @@ class Ruleset(object):
 				
 			# Extract TLD from target if possible
 			res = tldextract.extract(target)
-			if res.domain == "" or res.suffix == "":
+			if res.suffix == "":
 				problems.append("%s: Target '%s' missing eTLD" % (self.filename, target))
+			elif res.domain == "":
+				problems.append("%s: Target '%s' containing entire eTLD" % (self.filename, target))
 				
 		return problems
 


### PR DESCRIPTION
~Blocked by [`Xxxbunker.com.xml#L44`](https://github.com/EFForg/https-everywhere/blob/master/src/chrome/content/rules/Xxxbunker.com.xml#L44)~. See also #11185 Fix #10877. 

Hopefully before #11240 since we have a huge number of PR these days.

P.S. It is assumed that `target` matched the regex in  [`relaxng.xml#L36`](https://github.com/EFForg/https-everywhere/blob/master/utils/relaxng.xml#L36)