### PR TITLE
[Minijob-zentrale.de] Simplify rewrite rule

### DIFF
--- a/src/chrome/content/rules/Minijob-zentrale.de.xml
+++ b/src/chrome/content/rules/Minijob-zentrale.de.xml
@@ -10,7 +10,7 @@
 	<target host="blog.minijob-zentrale.de" />
 
 	<rule from="^http://minijob-zentrale\.de/"
-		to="https://www.minijob-zentrale.de" />
+		to="https://www.minijob-zentrale.de/" />
 
 	<rule from="^http:" to="https:" />
 

--- a/src/chrome/content/rules/Minijob-zentrale.de.xml
+++ b/src/chrome/content/rules/Minijob-zentrale.de.xml
@@ -1,5 +1,17 @@
+<!--
+	Invalid certificate:
+		minijob-zentrale.de
+
+-->
 <ruleset name="Minijob-Zentrale.de">
-<target host="www.minijob-zentrale.de" />
-<target     host="minijob-zentrale.de" />
-<rule from="^https?://(?:www\.)?minijob-zentrale\.de/" to="https://www.minijob-zentrale.de/" />
+
+	<target host="minijob-zentrale.de" />
+	<target host="www.minijob-zentrale.de" />
+	<target host="blog.minijob-zentrale.de" />
+
+	<rule from="^http://minijob-zentrale\.de/"
+		to="https://www.minijob-zentrale.de" />
+
+	<rule from="^http:" to="https:" />
+
 </ruleset>


### PR DESCRIPTION
#10843

I could not find any valid reason for the `https` -> `https` rewrite.