### PR TITLE
[Mutterschaftsgeld.de] Remove https rewrite and update default_off

### DIFF
--- a/src/chrome/content/rules/Mutterschaftsgeld.de.xml
+++ b/src/chrome/content/rules/Mutterschaftsgeld.de.xml
@@ -1,12 +1,8 @@
+<ruleset name="Mutterschaftsgeld.de" default_off="missing certificate chain">
 
-<!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://www.mutterschaftsgeld.de/ => https://www.mutterschaftsgeld.de/: (60, 'SSL certificate problem: unable to get local issuer certificate')
-Fetch error: http://mutterschaftsgeld.de/ => https://www.mutterschaftsgeld.de/: (60, 'SSL certificate problem: unable to get local issuer certificate')
+	<target host="mutterschaftsgeld.de" />
+	<target host="www.mutterschaftsgeld.de" />
+	
+	<rule from="^http:" to="https:" />
 
--->
-<ruleset name="Mutterschaftsgeld.de" default_off='failed ruleset test'>
-<target host="www.mutterschaftsgeld.de" />
-<target host="mutterschaftsgeld.de" />
-<rule from="^https?://(?:www\.)?mutterschaftsgeld\.de/" to="https://www.mutterschaftsgeld.de/" />
 </ruleset>


### PR DESCRIPTION
#10843 

I could not find any reason for the `https` -> `https` rewrite.