### PR TITLE
[Stallman.org] Simplify ruleset

### DIFF
--- a/src/chrome/content/rules/Stallman.org.xml
+++ b/src/chrome/content/rules/Stallman.org.xml
@@ -1,21 +1,14 @@
+<!--
+	Invalid certificate:
+		ww.stallman.org
+
+-->
 <ruleset name="Stallman.org">
+
 	<target host="stallman.org" />
-	<target host="ww.stallman.org" />
 	<target host="www.stallman.org" />
 
-	<test url="http://stallman.org/" />
-	<test url="http://www.stallman.org/" />
-	<test url="http://ww.stallman.org/" />
-	<test url="https://ww.stallman.org/" />
+	<rule from="^http:"
+		to="https:" />
 
-	<!-- The stallman.org site does in fact have a
-	working ww (not a typo) subdomain that supports
-	HTTPS (but with a certificate mismatch error)
-	and which has the same content as the normal
-	www subdomain. As such, the ww subdomain is
-	redirected to the www subdomain. -->
-	<rule from="^https?://ww\.stallman\.org/"
-		to="https://www.stallman.org/" />
-	<rule from="^http://(www\.)?stallman\.org/"
-		to="https://$1stallman.org/" />
 </ruleset>


### PR DESCRIPTION
#10843 

Content now differs between `ww.stallman.org` and `www.stallman.org`:

```sh
curl -s -L https://www.stallman.org/ | sha256sum
76d0ccca480bdc1e37482d3c2da299b98776228e17599219f2d4f39ef436f6f2
```

```sh
curl -s -L -k https://ww.stallman.org/ | sha256sum 
69c7a2ea3ed62a710b54ffb574168411cb948e0cb38fb3609dddecd1b28b41c6
```