### PR TITLE
Restore argos.co.uk

### DIFF
--- a/src/chrome/content/rules/Argos-fetcherror.xml
+++ b/src/chrome/content/rules/Argos-fetcherror.xml
@@ -1,0 +1,99 @@
+<!--
+Disabled by https-everywhere-checker because:
+Fetch error: http://argoscareers.com/ => https://www.argoscareers.com/: (28, 'Connection timed out after 20001 milliseconds')
+Fetch error: http://www.argoscareers.com/ => https://www.argoscareers.com/: (28, 'Connection timed out after 20000 milliseconds')
+Fetch error: http://argosonline.es/ => https://www.argosonline.es/: Too many redirects while fetching 'https://www.argosonline.es/'
+Fetch error: http://www.argosonline.es/ => https://www.argosonline.es/: Too many redirects while fetching 'https://www.argosonline.es/'
+Fetch error: http://www.greatcareers.co.uk/ => https://www.greatcareers.co.uk/: (28, 'Connection timed out after 20000 milliseconds')
+Fetch error: http://wearechoosy.com/ => https://www.wearechoosy.com/: (28, 'Connection timed out after 20004 milliseconds')
+Fetch error: http://www.wearechoosy.com/ => https://www.wearechoosy.com/: (28, 'Connection timed out after 20001 milliseconds')
+
+Disabled by https-everywhere-checker because:
+Fetch error: http://argosonline.es/ => https://www.argosonline.es/: (28, 'Operation timed out after 15001 milliseconds with 0 bytes received')
+Fetch error: http://www.argosonline.es/ => https://www.argosonline.es/: Cycle detected - URL already encountered: https://www.argosonline.es/
+Fetch error: http://www.greatcareers.co.uk/ => https://www.greatcareers.co.uk/: (60, 'SSL certificate problem: certificate has expired')
+Fetch error: http://wearechoosy.com/ => https://www.wearechoosy.com/: (60, 'SSL certificate problem: certificate has expired')
+Fetch error: http://www.wearechoosy.com/ => https://www.wearechoosy.com/: (60, 'SSL certificate problem: certificate has expired')
+
+	For other problematic rules, see Argos-mismatches.
+
+	For rules that are on by default, see Argos.xml.
+
+
+	Problematic domains:
+
+		- (www.)?argos-spain.co.uk *
+
+	* Handshake fails
+
+
+	Fully covered domains:
+
+		- (www.)?argos-spain.co.uk	(→ www.argosonline.es)
+
+-->
+<ruleset name="Argos (fetcherror)" platform="mixedcontent" default_off='failed ruleset test'>
+
+	<target host="argos.co.uk" />
+	<target host="*.argos.co.uk" />
+	<target host="image.email.argos.co.uk" />
+	<target host="argos.ie" />
+	<target host="*.argos.ie" />
+	<target host="argoscareers.com" />
+	<target host="www.argoscareers.com" />
+	<target host="argosemails.co.uk" />
+	<target host="www.argosemails.co.uk" />
+	<target host="argosonline.es" />
+	<target host="www.argosonline.es" />
+	<target host="argos-spain.co.uk" />
+	<target host="www.argos-spain.co.uk" />
+	<target host="www.greatcareers.co.uk" />
+	<target host="wearechoosy.com" />
+	<target host="www.wearechoosy.com" />
+
+
+	<securecookie host="^.*\.argos\.co\.uk$" name=".*" />
+	<securecookie host="^www\.argos\.ie$" name=".*" />
+	<securecookie host="^www\.argoscareers\.com$" name=".*" />
+	<securecookie host="^www\.argosemails\.co\.uk$" name=".*" />
+	<securecookie host="^www\.argosonline\.es$" name=".*" />
+	<securecookie host="^www\.greatcareers\.co\.uk$" name=".*" />
+	<securecookie host="^www\.wearechoosy\.com$" name=".*" />
+
+
+	<!--	Cert only matches www.	-->
+	<rule from="^http://(?:www\.)?argosemails\.co\.uk/"
+		to="https://www.argosemails.co.uk/" />
+
+	<rule from="^http://image\.email\.argos\.co\.uk/"
+		to="https://image.email.argos.co.uk/" />
+
+	<!--	Cert only matches www.	-->
+	<rule from="^http://(?:www\.)?argos\.ie/"
+		to="https://www.argos.ie/" />
+
+	<rule from="^http://competitions\.argos\.ie/"
+		to="https://competitions.argos.ie/" />
+
+	<!--	Redirect drops path and args:
+						-->
+	<rule from="^http://(?:www\.)?argos-spain\.co\.uk/.*"
+		to="https://www.argosonline.es/webapp/wcs/stores/servlet/LogonForm" />
+
+	<!--	!www: interrupted	-->
+	<rule from="^http://(?:www\.)?argoscareers\.com/"
+		to="https://www.argoscareers.com/" />
+
+	<!--	Cert only matches www.	-->
+	<rule from="^http://(?:www\.)?argosonline\.es/"
+		to="https://www.argosonline.es/" />
+
+	<!--	!www doesn't exist.	-->
+	<rule from="^http://www\.greatcareers\.co\.uk/"
+		to="https://www.greatcareers.co.uk/" />
+
+	<!--	Cert only matches www.	-->
+	<rule from="^http://(?:www\.)?wearechoosy\.com/"
+		to="https://www.wearechoosy.com/" />
+</ruleset>
+

--- a/src/chrome/content/rules/Argos.xml
+++ b/src/chrome/content/rules/Argos.xml
@@ -1,97 +1,12 @@
-
 <!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://argoscareers.com/ => https://www.argoscareers.com/: (28, 'Connection timed out after 20001 milliseconds')
-Fetch error: http://www.argoscareers.com/ => https://www.argoscareers.com/: (28, 'Connection timed out after 20000 milliseconds')
-Fetch error: http://argosonline.es/ => https://www.argosonline.es/: Too many redirects while fetching 'https://www.argosonline.es/'
-Fetch error: http://www.argosonline.es/ => https://www.argosonline.es/: Too many redirects while fetching 'https://www.argosonline.es/'
-Fetch error: http://www.greatcareers.co.uk/ => https://www.greatcareers.co.uk/: (28, 'Connection timed out after 20000 milliseconds')
-Fetch error: http://wearechoosy.com/ => https://www.wearechoosy.com/: (28, 'Connection timed out after 20004 milliseconds')
-Fetch error: http://www.wearechoosy.com/ => https://www.wearechoosy.com/: (28, 'Connection timed out after 20001 milliseconds')
-
-Disabled by https-everywhere-checker because:
-Fetch error: http://argosonline.es/ => https://www.argosonline.es/: (28, 'Operation timed out after 15001 milliseconds with 0 bytes received')
-Fetch error: http://www.argosonline.es/ => https://www.argosonline.es/: Cycle detected - URL already encountered: https://www.argosonline.es/
-Fetch error: http://www.greatcareers.co.uk/ => https://www.greatcareers.co.uk/: (60, 'SSL certificate problem: certificate has expired')
-Fetch error: http://wearechoosy.com/ => https://www.wearechoosy.com/: (60, 'SSL certificate problem: certificate has expired')
-Fetch error: http://www.wearechoosy.com/ => https://www.wearechoosy.com/: (60, 'SSL certificate problem: certificate has expired')
-	For problematic rules, see Argos-mismatches.
-
-
-	Problematic domains:
-
-		- (www.)?argos-spain.co.uk *
-
-	* Handshake fails
-
-
-	Fully covered domains:
-
-		- (www.)?argos-spain.co.uk	(→ www.argosonline.es)
+	For problematic rules, see Argos-mismatches and Argos-fetcherror.
 
 -->
-<ruleset name="Argos (partial)" platform="mixedcontent" default_off='failed ruleset test'>
+<ruleset name="Argos (partial)">
+	<target host="www.argos.co.uk" />
+                <test url="http://www.argos.co.uk/help/terms-and-conditions/" />
+                <test url="http://www.argos.co.uk/help/privacy-policy/" />
 
-	<target host="argos.co.uk" />
-	<target host="*.argos.co.uk" />
-	<target host="image.email.argos.co.uk" />
-	<target host="argos.ie" />
-	<target host="*.argos.ie" />
-	<target host="argoscareers.com" />
-	<target host="www.argoscareers.com" />
-	<target host="argosemails.co.uk" />
-	<target host="www.argosemails.co.uk" />
-	<target host="argosonline.es" />
-	<target host="www.argosonline.es" />
-	<target host="argos-spain.co.uk" />
-	<target host="www.argos-spain.co.uk" />
-	<target host="www.greatcareers.co.uk" />
-	<target host="wearechoosy.com" />
-	<target host="www.wearechoosy.com" />
-
-
-	<securecookie host="^.*\.argos\.co\.uk$" name=".*" />
-	<securecookie host="^www\.argos\.ie$" name=".*" />
-	<securecookie host="^www\.argoscareers\.com$" name=".*" />
-	<securecookie host="^www\.argosemails\.co\.uk$" name=".*" />
-	<securecookie host="^www\.argosonline\.es$" name=".*" />
-	<securecookie host="^www\.greatcareers\.co\.uk$" name=".*" />
-	<securecookie host="^www\.wearechoosy\.com$" name=".*" />
-
-
-	<!--	Cert only matches www.	-->
-	<rule from="^http://(?:www\.)?argosemails\.co\.uk/"
-		to="https://www.argosemails.co.uk/" />
-
-	<rule from="^http://image\.email\.argos\.co\.uk/"
-		to="https://image.email.argos.co.uk/" />
-
-	<!--	Cert only matches www.	-->
-	<rule from="^http://(?:www\.)?argos\.ie/"
-		to="https://www.argos.ie/" />
-
-	<rule from="^http://competitions\.argos\.ie/"
-		to="https://competitions.argos.ie/" />
-
-	<!--	Redirect drops path and args:
-						-->
-	<rule from="^http://(?:www\.)?argos-spain\.co\.uk/.*"
-		to="https://www.argosonline.es/webapp/wcs/stores/servlet/LogonForm" />
-
-	<!--	!www: interrupted	-->
-	<rule from="^http://(?:www\.)?argoscareers\.com/"
-		to="https://www.argoscareers.com/" />
-
-	<!--	Cert only matches www.	-->
-	<rule from="^http://(?:www\.)?argosonline\.es/"
-		to="https://www.argosonline.es/" />
-
-	<!--	!www doesn't exist.	-->
-	<rule from="^http://www\.greatcareers\.co\.uk/"
-		to="https://www.greatcareers.co.uk/" />
-
-	<!--	Cert only matches www.	-->
-	<rule from="^http://(?:www\.)?wearechoosy\.com/"
-		to="https://www.wearechoosy.com/" />
-
+	<rule from="^http:" to="https:" />
 </ruleset>
+


### PR DESCRIPTION
Commit b69a6d7a7baa0ec7842e7a1375d39a29b9192df7 deactivated HTTPS
Everywhere for www.argos.co.uk . This subdomain now appears to work OK
with HTTPS.

This commit reactivates that subdomain, while moving the other
(sub)domains previously found to be problematic into a different ruleset
that is disabled by default, until someone can review them.