### PR TITLE
Re-activate and Update Nokia.xml

### DIFF
--- a/src/chrome/content/rules/Nokia.xml
+++ b/src/chrome/content/rules/Nokia.xml
@@ -1,139 +1,31 @@
-
 <!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://nokia.co.uk/ => https://www.nokia.co.uk/: (51, "SSL: no alternative certificate subject name matches target host name 'www.nokia.co.uk'")
-Fetch error: http://www.nokia.co.uk/ => https://www.nokia.co.uk/: (51, "SSL: no alternative certificate subject name matches target host name 'www.nokia.co.uk'")
-Fetch error: http://nokiausa.com/ => https://www.nokiausa.com/: (51, "SSL: no alternative certificate subject name matches target host name 'www.nokiausa.com'")
-Fetch error: http://www.nokiausa.com/ => https://www.nokiausa.com/: (51, "SSL: no alternative certificate subject name matches target host name 'www.nokiausa.com'")
-
-Disabled by https-everywhere-checker because:
-Fetch error: http://nokia.co.uk/ => https://www.nokia.co.uk/: (51, "SSL: no alternative certificate subject name matches target host name 'www.nokia.co.uk'")
-Fetch error: http://www.nokia.co.uk/ => https://www.nokia.co.uk/: (51, "SSL: no alternative certificate subject name matches target host name 'www.nokia.co.uk'")
-Fetch error: http://nokiausa.com/ => https://www.nokiausa.com/: (28, 'Operation timed out after 15000 milliseconds with 0 bytes received')
-Fetch error: http://www.nokiausa.com/ => https://www.nokiausa.com/: (28, 'Operation timed out after 15001 milliseconds with 0 bytes received')
 	Other Nokia rulesets:
+		+ Here.com.xml
+		+ NAVTEQ.xml
+		+ Ovi.com.xml
 
-		- Here.com.xml
-		- Ovi.com.xml
-		- NAVTEQ.xml
+	Non-functional hosts
+		Couldn't connect to server:
+		- developer.qt.nokia.com
 
+		Timeout was reached:
+		- qt.nokia.com
 
-	discussions.nokia.co.uk is handled mostly in Lithium-clients.xml.
+		SSL peer certificate was not OK:
+		- map.nokia.com
 
-
-	Problematic domains:
-
-		- nokia.(ca|co.uk|de|fr)	(mismatched, CN:  www.nokia.com)
-		- www.nokia.ca			(akamai)
-		- discussions.nokia.co.uk	(mismatched, CN: secure02.lithium.com)
-
-		- nokia.com subdomains:
-
-			- advertising		(self-signed)
-			- (www.)map ⁵
-			- qt			(works; mismatched, CN: *.digia.com)
-			- blog.qt *
-			- developer.qt		(works; mismatched, CN: qt-project.org)
-			- labs.qt *
-			- doc.qt		(times out)
-
-		- nokiausa.com			(no https)
-
-		* Expired
-	⁵ Mismatched, CN: here.com
-
-
-	Partially covered domains:
-
-		- discussions.nokia.co.uk	(→ discussions.europe.nokia.com)
-		- (www.)developer.nokia.com	(some pages redirect to http)
-
-
-
-	Fully covered domains:
-
-		- (www.)nokia.ca	(→ nokia.com)
-		- (www.)nokia.co.uk	(^ → www)
-
-		- nokia.com subdomains:
-
-			- account
-			- advertising	(→ primeplace)
-
-			- developer subdomains:
-
-				- analytics
-				- projects
-				- sso
-
-			- discussions.europe
-			- i
-			- (www.)maps	(→ here.com)
-			- api.maps
-			- maps.nlp
-			- \d.maps.nlp
-			- primeplace
-
-			- qt subdomains:
-
-				- ^		(→ qt.digia.com)
-				- blog		(→ blog.qt.digia.com)
-				- developer	(→ qt-project.org)
-				- labs		(→ blog.qt.digia.com)
-
-		- (www.)nokia.de	(^ → www)
-		- (www.)nokia.fr	(^ → www)
-		- (www.)nokiausa.com	(^ → www)
-
+		4xx client error:
+		- maps.nlp.nokia.com
+		- 1.maps.nlp.nokia.com
+		- 2.maps.nlp.nokia.com
+		- 3.maps.nlp.nokia.com
+		- 4.maps.nlp.nokia.com
 -->
-<ruleset name="Nokia (partial)" default_off='failed ruleset test'>
+<ruleset name="Nokia (partial)">
+	<target host="nokia.com" />
+	<target host="www.nokia.com" />
+	<target host="account.nokia.com" />
+	<target host="api.maps.nokia.com" />
 
-	<target host="nokia.*" />
-	<target host="www.nokia.*" />
-	<target host="nokia.co.uk" />
-	<target host="www.nokia.co.uk" />
-	<target host="*.nokia.com" />
-		<!--
-			Redirect to http:
-						-->
-		<exclusion pattern="^http://www\.developer\.nokia\.com/(?:$|De(?:sign|velop|vices)/|Distribute/|info/)" />
-	<target host="nokiausa.com" />
-	<target host="www.nokiausa.com" />
-
-
-	<securecookie host="^(?:.*\.)?nokia\.(?:com|co\.uk|de|fr)$" name=".+" />
-
-
-	<rule from="^http://(?:www\.)?nokia\.ca/"
-		to="https://www.nokia.com/ca-en/" />
-
-	<rule from="^http://(?:www\.)?nokia\.(co\.uk|de|fr)/"
-		to="https://www.nokia.$1/" />
-
-	<rule from="^http://advertising\.nokia\.com/"
-		to="https://primeplace.nokia.com/" />
-
-	<rule from="^http://((?:account|(?:(?:analytics|projects|sso|www)\.)?developer|discussions\.europe|[ir](?:\.prod)?|maps\.nlp|api\.maps|\d\.maps\.nlp|primeplace|www)\.)?nokia\.com/"
-		to="https://$1nokia.com/" />
-
-	<rule from="^http://developer\.nokia\.com/"
-		to="https://qt-project.org/" />
-
-	<!--	Redirect keeps path and args:
-						-->
-	<rule from="^http://(?:www\.)?maps\.nokia\.com/+"
-		to="https://here.com/" />
-
-	<rule from="^http://qt\.nokia\.com/"
-		to="https://qt.digia.com/" />
-
-	<rule from="^http://(?:blog|labs)\.qt\.nokia\.com/"
-		to="https://blog.qt.digia.com/" />
-
-	<rule from="^http://discussions\.nokia\.co\.uk/html/images/"
-		to="https://discussions.europe.nokia.com/html/images/" />
-
-	<rule from="^http://(?:www\.)?nokiausa\.com/"
-		to="https://www.nokiausa.com/" />
-
+	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Nokia.xml
+++ b/src/chrome/content/rules/Nokia.xml
@@ -12,7 +12,11 @@
 		- qt.nokia.com
 
 		SSL peer certificate was not OK:
+		- resources.ext.nokia.com
+		- tools.ext.nokia.com
+		- m.nokia.com
 		- map.nokia.com
+		- resources.nokia.com
 
 		4xx client error:
 		- maps.nlp.nokia.com
@@ -26,6 +30,10 @@
 	<target host="www.nokia.com" />
 	<target host="account.nokia.com" />
 	<target host="api.maps.nokia.com" />
+	<target host="health.nokia.com" />
+	<target host="insight.nokia.com" />
+	<target host="networks.nokia.com" />
+	<target host="ozo.nokia.com" />
 
 	<rule from="^http:" to="https:" />
 </ruleset>


### PR DESCRIPTION
#11203 Only `*nokia.com` works over HTTPS.

```
account.nokia.com
advertising.nokia.com
analytics.developer.nokia.com
projects.developer.nokia.com
sso.developer.nokia.com
discussions.europe.nokia.com
i.nokia.com
map.nokia.com
www.map.nokia.com
api.maps.nokia.com
maps.nlp.nokia.com
0.maps.nlp.nokia.com
1.maps.nlp.nokia.com
2.maps.nlp.nokia.com
3.maps.nlp.nokia.com
4.maps.nlp.nokia.com
5.maps.nlp.nokia.com
6.maps.nlp.nokia.com
7.maps.nlp.nokia.com
8.maps.nlp.nokia.com
9.maps.nlp.nokia.com
primeplace.nokia.com
qt.nokia.com
blog.qt.nokia.com
developer.qt.nokia.com
doc.qt.nokia.com
labs.qt.nokia.com
```

See https://gist.github.com/cschanaj/9ad8c01eaecc5f575150aad949d26f0f