### PR TITLE
[Simply-Hired-clients.xml] Remove broken targets

### DIFF
--- a/src/chrome/content/rules/Simply-Hired-clients.xml
+++ b/src/chrome/content/rules/Simply-Hired-clients.xml
@@ -2,20 +2,15 @@
 -->
 <ruleset name="Simply Hired clients" default_off="mismatched">
 
-	<!--	*.jobamatic.com	-->
-	<target host="jobs.businessinsider.com" />
 	<target host="jobs.datacenterknowledge.com"/>
-	<target host="jobs.nodejs.org"/>
 	<target host="jobs.pcworld.com" />
 		<!--	handled in DataCenterKnowledge.xml & PCWorld.xml.	-->
-		<exclusion pattern="^http://jobs\.(?:datacenterknowledge|pcworld)\.com/c/"/>
-
+		<exclusion pattern="^http://jobs\.(datacenterknowledge|pcworld)\.com/c/"/>
 
 	<!--	is cross-domain cookie used on unsecure pages?	-->
-	<securecookie host="^jobs\.(?:datacenterknowledge|nodejs|pcworld)\.org$" name=".*"/>
+	<securecookie host=".+" name=".*"/>
 
-
-	<rule from="^http://jobs\.(businessinsider|datacenterknowledge|nodejs|pcworld)\.com/"
-		to="https://jobs.$1.com/"/>
+	<rule from="^http:"
+		to="https:"/>
 
 </ruleset>


### PR DESCRIPTION
- jobs.businessinsider.com gone from DNS
- nodejs.org: different content