### PR TITLE
Add tgstation13.org rule

### DIFF
--- a/src/chrome/content/rules/tgstation13.org.xml
+++ b/src/chrome/content/rules/tgstation13.org.xml
@@ -1,0 +1,11 @@
+<ruleset name="tgstation13.org">
+	<target host="tgstation13.org" />
+	<target host="www.tgstation13.org" />
+	<target host="status.tgstation13.org" />
+
+	<rule from="^http:" to="https:" />
+		<test url="http://tgstation13.org" />
+		<test url="http://tgstation13.org/phpBB" />
+		<test url="http://tgstation13.org/wiki" />
+		<test url="http://status.tgstation13.org" />
+</ruleset>

--- a/src/chrome/content/rules/tgstation13.org.xml
+++ b/src/chrome/content/rules/tgstation13.org.xml
@@ -4,8 +4,8 @@
 	<target host="status.tgstation13.org" />
 
 	<rule from="^http:" to="https:" />
-		<test url="http://tgstation13.org" />
-		<test url="http://tgstation13.org/phpBB" />
-		<test url="http://tgstation13.org/wiki" />
-		<test url="http://status.tgstation13.org" />
+		<test url="http://tgstation13.org/" />
+		<test url="http://tgstation13.org/phpBB/" />
+		<test url="http://tgstation13.org/wiki/" />
+		<test url="http://status.tgstation13.org/" />
 </ruleset>


### PR DESCRIPTION
So, about the only question that I have is how this might apply to different ports. we have a webapp that communicates over ajax to :1337, but the end point for that is http only for legacy reasons, Would I need to exempt that, or would this by default not apply to that case.

(This is actually the reason we don't use htst or htst preload)