### PR TITLE
Update LinuxTag.org.xml (cacert)

### DIFF
--- a/src/chrome/content/rules/LinuxTag.org.xml
+++ b/src/chrome/content/rules/LinuxTag.org.xml
@@ -1,30 +1,37 @@
-
 <!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://www.linuxtag.org/ => https://www.linuxtag.org/: (60, 'SSL certificate problem: unable to get local issuer certificate')
-Fetch error: http://linuxtag.org/ => https://www.linuxtag.org/: (60, 'SSL certificate problem: unable to get local issuer certificate')
+	Non-functional hosts
+		Timeout was reached:
+		- eticket.linuxtag.org
+		- hacking.linuxtag.org
+		- mailtest.linuxtag.org
 
-	linuxtag.org: Mismatched
-
+		Incomplete certificate chain error:
+		- linuxtag.org
+		- www.linuxtag.org
+		- intern.linuxtag.org
+		- mail.linuxtag.org
+		- newsletter.linuxtag.org
+		- openmusic.linuxtag.org
+		- planet.linuxtag.org
+		- ssl.linuxtag.org
+		- staging.linuxtag.org
+		- svn.linuxtag.org
+		- vcc.linuxtag.org
+		- wiki.linuxtag.org
 -->
-<ruleset name="LinuxTag.org" platform="cacert" default_off='failed ruleset test'>
-
-	<!--	Direct rewrites:
-				-->
-	<target host="www.linuxtag.org" />
-
-	<!--	Complications:
-				-->
+<ruleset name="LinuxTag.org" default_off="cert-chain">
 	<target host="linuxtag.org" />
+	<target host="www.linuxtag.org" />
+	<target host="intern.linuxtag.org" />
+	<target host="mail.linuxtag.org" />
+	<target host="newsletter.linuxtag.org" />
+	<target host="openmusic.linuxtag.org" />
+	<target host="planet.linuxtag.org" />
+	<target host="ssl.linuxtag.org" />
+	<target host="staging.linuxtag.org" />
+	<target host="svn.linuxtag.org" />
+	<target host="vcc.linuxtag.org" />
+	<target host="wiki.linuxtag.org" />
 
-
-	<securecookie host="^www\.linuxtag\.org$" name=".+" />
-
-
-	<rule from="^http://linuxtag\.org/"
-		to="https://www.linuxtag.org/" />
-
-	<rule from="^http:"
-		to="https:" />
-
+	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/LinuxTag.org.xml
+++ b/src/chrome/content/rules/LinuxTag.org.xml
@@ -19,7 +19,7 @@
 		- vcc.linuxtag.org
 		- wiki.linuxtag.org
 -->
-<ruleset name="LinuxTag.org" default_off="cert-chain">
+<ruleset name="LinuxTag.org">
 	<target host="linuxtag.org" />
 	<target host="www.linuxtag.org" />
 	<target host="intern.linuxtag.org" />

--- a/src/chrome/content/rules/LinuxTag.org.xml
+++ b/src/chrome/content/rules/LinuxTag.org.xml
@@ -5,19 +5,9 @@
 		- hacking.linuxtag.org
 		- mailtest.linuxtag.org
 
-		Incomplete certificate chain error:
-		- linuxtag.org
-		- www.linuxtag.org
-		- intern.linuxtag.org
-		- mail.linuxtag.org
-		- newsletter.linuxtag.org
+		SSL peer certificate was not OK:
 		- openmusic.linuxtag.org
-		- planet.linuxtag.org
-		- ssl.linuxtag.org
-		- staging.linuxtag.org
-		- svn.linuxtag.org
-		- vcc.linuxtag.org
-		- wiki.linuxtag.org
+
 -->
 <ruleset name="LinuxTag.org">
 	<target host="linuxtag.org" />
@@ -25,7 +15,6 @@
 	<target host="intern.linuxtag.org" />
 	<target host="mail.linuxtag.org" />
 	<target host="newsletter.linuxtag.org" />
-	<target host="openmusic.linuxtag.org" />
 	<target host="planet.linuxtag.org" />
 	<target host="ssl.linuxtag.org" />
 	<target host="staging.linuxtag.org" />


### PR DESCRIPTION
#9582 
```xml
<!--
	Non-functional hosts
		Couldn't connect to server:
		- hacking.linuxtag.org

		Timeout was reached:
		- eticket.linuxtag.org
		- mailtest.linuxtag.org

		Incomplete certificate chain error:
		- linuxtag.org
		- www.linuxtag.org
		- intern.linuxtag.org
		- mail.linuxtag.org
		- newsletter.linuxtag.org
		- openmusic.linuxtag.org
		- planet.linuxtag.org
		- ssl.linuxtag.org
		- staging.linuxtag.org
		- svn.linuxtag.org
		- vcc.linuxtag.org
		- wiki.linuxtag.org
-->
```