### PR TITLE
New ruleset for Kiwix

### DIFF
--- a/src/chrome/content/rules/Kiwix.xml
+++ b/src/chrome/content/rules/Kiwix.xml
@@ -3,11 +3,14 @@
 	Problematic subdomains:
 
 	- ^			(connection refused)
+	- android		(times out)
 	- bugs			(times out)
 	- mirror.download	(cert mismatch)
 	- forum			(times out)
 	- input			(connection refused)
+	- ios			(times out)
 	- microblog		(times out)
+	- planet		(unable to connect)
 	- reportabug		(times out)
 	- stats			(connection refused)
 	- wiki			(connection refused)

--- a/src/chrome/content/rules/Kiwix.xml
+++ b/src/chrome/content/rules/Kiwix.xml
@@ -1,0 +1,25 @@
+<!--
+
+	Problematic subdomains:
+
+	- ^			(connection refused)
+	- bugs			(times out)
+	- mirror.download	(cert mismatch)
+	- forum			(times out)
+	- input			(connection refused)
+	- microblog		(times out)
+	- reportabug		(times out)
+	- stats			(connection refused)
+	- wiki			(connection refused)
+	- www			(cert mismatch)
+
+-->
+<ruleset name="Kiwix (partial)">
+
+	<target host="download.kiwix.org" />
+
+	<securecookie host="^download\.kiwix\.org$" name=".+" />
+
+	<rule from="^http:" to="https:" />
+
+</ruleset>


### PR DESCRIPTION
At the current time, for the Kiwix site, it appears that only the `download` subdomain supports HTTPS. Even so, this may be useful if, for example, a user on an external site accesses a link such as http://download.kiwix.org/zim/wikipedia_hi_medicine.zim.

In addition, it may be that the `mirror.download` subdomain is intended to identically mirror the contents of the `download` subdomain. If that is the case, then there is the question of whether it would be useful to have the ruleset redirect requests from `http://mirror.download.kiwix.org/` to `https://download.kiwix.org/`. At the same time, there is the possibility as to whether redirecting such requests could lead to redirect loops or, for that matter, if the content under the `mirror.download` and `download` subdomains is not quite identical.