### PR TITLE
Update Michal_Hrusecky.xml

### DIFF
--- a/src/chrome/content/rules/Michal_Hrusecky.xml
+++ b/src/chrome/content/rules/Michal_Hrusecky.xml
@@ -1,23 +1,33 @@
-
 <!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://hrusecky.net/ => https://www.hrusecky.net/: (51, "SSL: no alternative certificate subject name matches target host name 'www.hrusecky.net'")
+	Non-functional hosts
+		SSL peer certificate was not OK:
+		- hrusecky.net
+		- arch.jan.hrusecky.net
+		- architecture.jan.hrusecky.net
+		- photo.jan.hrusecky.net
+		- people.photo.jan.hrusecky.net
+		- www.michal.hrusecky.net
+		- queeg.hrusecky.net
+		- sobas.hrusecky.net
+		- www.sobas.hrusecky.net
+		- svatba.hrusecky.net
+		- fotky.svatba.hrusecky.net
+		- www.svatba.hrusecky.net
+		- www.hrusecky.net
 
-Disabled by https-everywhere-checker because:
-Fetch error: http://hrusecky.net/ => https://www.hrusecky.net/: (60, 'SSL certificate problem: self signed certificate in certificate chain')
-	!www: cert only matches *.hrusecky.net
+		Peer certificate cannot be authenticated with given CA certificates:
+		- analytics.hrusecky.net
+		- piwik.hrusecky.net
 
+		Incomplete certificate chain error:
+		- friends.hrusecky.net
+		- mail.hrusecky.net
+
+		Mixed content blocking (MCB) triggered:
+		- michal.hrusecky.net
 -->
-<ruleset name="Michal Hrušecký" platform="cacert" default_off='failed ruleset test'>
+<ruleset name="Michal Hrušecký" platform="mixedcontent">
+	<target host="michal.hrusecky.net" />
 
-	<target host="hrusecky.net" />
-	<target host="*.hrusecky.net" />
-
-
-	<rule from="^http://(?:www\.)?hrusecky\.net/"
-		to="https://www.hrusecky.net/" />
-
-	<rule from="^http://michal\.hrusecky\.net/"
-		to="https://michal.hrusecky.net/" />
-
+	<rule from="^http:" to="https:" />
 </ruleset>


### PR DESCRIPTION
#9582 Only one subdomain support HTTPS with `mixedcontent` issues, thus I think it is appropriate to delete this ruleset. 

P.S. I can rebase this on request. thanks!

```
<!--
	Non-functional hosts
		SSL peer certificate was not OK:
		- hrusecky.net
		- www.hrusecky.net
		- arch.jan.hrusecky.net
		- architecture.jan.hrusecky.net
		- photo.jan.hrusecky.net
		- people.photo.jan.hrusecky.net
		- www.michal.hrusecky.net
		- queeg.hrusecky.net
		- sobas.hrusecky.net
		- www.sobas.hrusecky.net
		- svatba.hrusecky.net
		- www.svatba.hrusecky.net
		- fotky.svatba.hrusecky.net

		Peer certificate cannot be authenticated with given CA certificates:
		- analytics.hrusecky.net
		- piwik.hrusecky.net

		Incomplete certificate chain error:
		- friends.hrusecky.net
		- mail.hrusecky.net

		Mixed content blocking (MCB) triggered:
		- michal.hrusecky.net
-->
```