### PR TITLE
Update Stack.nl.xml

### DIFF
--- a/src/chrome/content/rules/Stack.nl.xml
+++ b/src/chrome/content/rules/Stack.nl.xml
@@ -1,47 +1,17 @@
 <!--
-	Fully covered subdomains:
-
-		- (www.)
-		- dbadmin
-		- koelkast
-		- uqm
-		- bugs.uqm
-		- forum.uqm
-		- wiki.uqm
-		- webmail
-		- websites
-
-
-	^stack.nl doesn't exist.
-
-
-	Observed cookie domains:
-
-		- dbadmin
-		- .bugs.uqm
-		- forum.uqm
-		- wiki.uqm
-		- .webmail
-		- websites
-		- www
-
-
-	Mixed content:
-
-		- Image on wiki.uqm from creativecommons.org *
-
-	* Secured by us
-
+	Non-functional hosts
+		Incomplete certificate chain error:
+		- dbadmin.stack.nl
+		- uqm.stack.nl
+		- bugs.uqm.stack.nl
+		- forum.uqm.stack.nl
+		- wiki.uqm.stack.nl
+		- webmail.stack.nl
 -->
-<ruleset name="Stack.nl" platform="cacert">
+<ruleset name="Stack.nl (partial)">
+	<target host="koelkast.stack.nl" />
+	<target host="websites.stack.nl" />
+	<target host="www.stack.nl" />
 
-	<target host="*.stack.nl" />
-
-
-	<securecookie host=".+\.stack\.nl$" name=".+" />
-
-
-	<rule from="^http://(dbadmin|koelkast|((?:bugs|forum|wiki)\.)?uqm|webmail|websites|www)\.stack\.nl/"
-		to="https://$1.stack.nl/" />
-
+	<rule from="^http:" to="https:" />
 </ruleset>


### PR DESCRIPTION
#9582 no longer `cacert`, did not perform domain enumeration intentionally.