### PR TITLE
[Parkrun.org.uk] Fix and re-enable

### DIFF
--- a/src/chrome/content/rules/Parkrun.org.uk.xml
+++ b/src/chrome/content/rules/Parkrun.org.uk.xml
@@ -1,13 +1,6 @@
-
-<!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://images.parkrun.org.uk/ => https://images.parkrun.org.uk/: (6, 'Could not resolve host: images.parkrun.org.uk')
-
--->
-<ruleset name="parkrun.org.uk" default_off='failed ruleset test'>
+<ruleset name="parkrun.org.uk">
 
 	<target host="parkrun.org.uk" />
-	<target host="images.parkrun.org.uk" />
 	<target host="www.parkrun.org.uk" />
 
 


### PR DESCRIPTION
`images.parkrun.org.uk` has no DNS, so remove it completely.