### PR TITLE
Update NYDailyNews.xml

### DIFF
--- a/src/chrome/content/rules/NYDailyNews.xml
+++ b/src/chrome/content/rules/NYDailyNews.xml
@@ -4,6 +4,7 @@ Fetch error: http://nydailynews.com/ => http://nydailynews.com/: (60, 'SSL certi
 	For rules causing false/broken MCB, see NYDailyNews.com-falsemixed.xml.
 
 
+
 	CDN buckets:
 
 		- casmp.adperfect.com


### PR DESCRIPTION
This ruleset got re-activated in 9bf49cbe
```bash
git blame master -- NYDailyNews.xml
```
gives 
```
9bf49cbe (William Budington     2017-06-20 16:47:09 -0700 74) <ruleset name="NYDailyNews (partial)">
```

is in fact failing `rules-test`