### PR TITLE
Add smile.amazon.de

### DIFF
--- a/src/chrome/content/rules/amazon.de.xml
+++ b/src/chrome/content/rules/amazon.de.xml
@@ -44,6 +44,7 @@
 	<target host="webservices.amazon.de" />
 	<target host="widgets.amazon.de" />
 	<target host="ws.amazon.de" />
+	<target host="smile.amazon.de" />
 
 		<!--	Amazon has a history of breaking us soon after
 			adding rulesets, so these are here to detect that.


### PR DESCRIPTION
smile.amazon.de is a domain for contributing for charity. It supports HTTPs.