### PR TITLE
[Twimg.com] Add test urls

### DIFF
--- a/src/chrome/content/rules/Twimg.com.xml
+++ b/src/chrome/content/rules/Twimg.com.xml
@@ -60,6 +60,7 @@
 	<!--	Direct rewrites:
 					-->
 	<target host="abs.twimg.com" />
+		<test url="http://abs.twimg.com/favicons/favicon.ico" />
 	<target host="amp.twimg.com" />
 	<target host="dnt.twimg.com" />
 	<target host="ea.twimg.com" />
@@ -77,6 +78,7 @@
 	<target host="o.twimg.com" />
 	<target host="p.twimg.com" />
 	<target host="pbs.twimg.com" />
+		<test url="http://pbs.twimg.com/profile_images/877299816228835328/BzlF5IzF_400x400.jpg" />
 	<target host="r.twimg.com" />
 	<target host="syndication.twimg.com" />
 	<target host="syndication-o.twimg.com" />
@@ -88,6 +90,7 @@
 	<!--	Special cases:
 				-->
 	<target host="s.twimg.com" />
+		<test url="http://s.twimg.com/business/twitter101forbusiness.pdf" />
 
 
 	<rule from="^http://s\.twimg\.com/"


### PR DESCRIPTION
Because the rewrite to `*.cloudfront.net` is somewhat dangerous, I am not comfortable with leaving it without a test url.