### PR TITLE
Create Novaapi.net.xml

### DIFF
--- a/src/chrome/content/rules/Novaapi.net.xml
+++ b/src/chrome/content/rules/Novaapi.net.xml
@@ -1,0 +1,6 @@
+<ruleset name="Novaapi.net">
+	<target host="novaapi.net" />
+	<target host="www.novaapi.net" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>


### PR DESCRIPTION
I’m a developer of the [NOVA API](https://novaapi.net) project and I want to add our website to the HTTPS Everywhere rule list while the HTTP to HTTPS redirection still [hasn’t been properly implemented](https://github.com/NOVA-Team/nova-team.github.io/issues/14).

