### PR TITLE
[Color Of Change] Enable ruleset, remove unsupported subdomains

### DIFF
--- a/src/chrome/content/rules/Color-Of-Change.xml
+++ b/src/chrome/content/rules/Color-Of-Change.xml
@@ -1,21 +1,10 @@
-
-<!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://orig.colorofchange.org/ => https://orig.colorofchange.org/: (28, 'Operation timed out after 30001 milliseconds with 0 bytes received')
-Fetch error: http://stories.colorofchange.org/ => https://stories.colorofchange.org/: (28, 'Operation timed out after 30001 milliseconds with 0 bytes received')
-
--->
-<ruleset name="Color Of Change" default_off='failed ruleset test'>
+<ruleset name="Color Of Change">
 
 	<target host="colorofchange.org" />
 	<target host="act.colorofchange.org" />
 	<target host="iam.colorofchange.org" />
-	<target host="orig.colorofchange.org" />
 	<target host="represent.colorofchange.org" />
-	<target host="secure.colorofchange.org" />
 	<target host="static.colorofchange.org" />
-	<target host="stories.colorofchange.org" />
-	<target host="vote.colorofchange.org" />
 	<target host="www.colorofchange.org" />
 
 	<securecookie host="^(act|iam|represent|www)?\.colorofchange\.org$"


### PR DESCRIPTION
The Color Of Change ruleset previously contained a number of subdomains (`orig`, `secure`, `stories`, and `vote`) that no longer appear to be functional. When I last checked, these subdomains gave errors related to Cloudflare when accessed.

http://orig.colorofchange.org/ref/hud_2.html
http://secure.colorofchange.org/
http://stories.colorofchange.org/
http://vote.colorofchange.org/

In addition, this pull request may be relevant with regard to issue #11114.