### PR TITLE
Update geekzone.co.nz to cover entire domain

### DIFF
--- a/src/chrome/content/rules/Geekzone.xml
+++ b/src/chrome/content/rules/Geekzone.xml
@@ -1,8 +1,7 @@
 <ruleset name="geekzone.co.nz (partial cdn)">
 	<target host="cdn.geekzone.co.nz" />
 	<target host="images.geekzone.co.nz" />
-	<target host="avatar.geekzone.co.nz" />
-
+	
 	<rule from="^http:"
 		to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Geekzone.xml
+++ b/src/chrome/content/rules/Geekzone.xml
@@ -1,6 +1,25 @@
+<!--
+        Served over HTTP:
+			feeds.geekzone.co.nz
+			m.geekzone.co.nz
+			price.geekzone.co.nz
+			www.geekzone.co.nz
+
+		Available over HTTPS (301 redirect from HTTP)
+			cdn.geekzone.co.nz
+			images.geekzone.co.nz
+			live.geekzone.co.nz
+			testip.geekzone.co.nz
+
+		Available over HTTPS only, no need for rewrite
+			api.geekzone.co.nz
+			metaweblog.geekzone.co.nz
+-->
 <ruleset name="geekzone.co.nz (partial cdn)">
 	<target host="cdn.geekzone.co.nz" />
 	<target host="images.geekzone.co.nz" />
+	<target host="live.geekzone.co.nz" />
+	<target host="testip.geekzone.co.nz" />
 	
 	<rule from="^http:"
 		to="https:" />

--- a/src/chrome/content/rules/Geekzone.xml
+++ b/src/chrome/content/rules/Geekzone.xml
@@ -1,25 +1,31 @@
 <!--
-        Served over HTTP:
+        Served over HTTP only (no response on HTTP):
 			feeds.geekzone.co.nz
-			m.geekzone.co.nz
 			price.geekzone.co.nz
-			www.geekzone.co.nz
 
-		Available over HTTPS (301 redirect from HTTP)
+		Available over HTTPS (301 redirect if HTTP schema requested)
 			cdn.geekzone.co.nz
+			gadget.geekzone.co.nz
 			images.geekzone.co.nz
 			live.geekzone.co.nz
+			m.geekzone.co.nz
 			testip.geekzone.co.nz
-
-		Available over HTTPS only, no need for rewrite
+			www.geekzone.co.nz
+			
+		Available over HTTPS only (no response on HTTP)
 			api.geekzone.co.nz
 			metaweblog.geekzone.co.nz
 -->
-<ruleset name="geekzone.co.nz (partial cdn)">
+<ruleset name="geekzone.co.nz">
+	<target host="api.geekzone.co.nz" />
 	<target host="cdn.geekzone.co.nz" />
+	<target host="gadget.geekzone.co.nz" />
 	<target host="images.geekzone.co.nz" />
 	<target host="live.geekzone.co.nz" />
+	<target host="m.geekzone.co.nz" />
+	<target host="metaweblog.geekzone.co.nz" />
 	<target host="testip.geekzone.co.nz" />
+	<target host="www.geekzone.co.nz" />
 	
 	<rule from="^http:"
 		to="https:" />

--- a/src/chrome/content/rules/Geekzone.xml
+++ b/src/chrome/content/rules/Geekzone.xml
@@ -1,31 +1,8 @@
 <!--
-        Served over HTTP only (no response on HTTP):
-			feeds.geekzone.co.nz
-			price.geekzone.co.nz
-
-		Available over HTTPS (301 redirect if HTTP schema requested)
-			cdn.geekzone.co.nz
-			gadget.geekzone.co.nz
-			images.geekzone.co.nz
-			live.geekzone.co.nz
-			m.geekzone.co.nz
-			testip.geekzone.co.nz
-			www.geekzone.co.nz
-			
-		Available over HTTPS only (no response on HTTP)
-			api.geekzone.co.nz
-			metaweblog.geekzone.co.nz
+        HSTS is enabled, all subdomains serve over HTTPS or issue a 301 if needed
 -->
 <ruleset name="geekzone.co.nz">
-	<target host="api.geekzone.co.nz" />
-	<target host="cdn.geekzone.co.nz" />
-	<target host="gadget.geekzone.co.nz" />
-	<target host="images.geekzone.co.nz" />
-	<target host="live.geekzone.co.nz" />
-	<target host="m.geekzone.co.nz" />
-	<target host="metaweblog.geekzone.co.nz" />
-	<target host="testip.geekzone.co.nz" />
-	<target host="www.geekzone.co.nz" />
+	<target host="*.geekzone.co.nz" />
 	
 	<rule from="^http:"
 		to="https:" />

--- a/src/chrome/content/rules/Pjak.eu.xml
+++ b/src/chrome/content/rules/Pjak.eu.xml
@@ -1,0 +1,6 @@
+<ruleset name="Pjak.eu" platform="mixedcontent">
+	<target host="pjak.eu" />
+	<target host="www.pjak.eu" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>


### PR DESCRIPTION
Entire domain served over HTTPS. HTTP requests automatically redirect with 301. HTTPS response headers include HSTS.