### PR TITLE
trivialize securecookie (^0 -> ^9)

### DIFF
--- a/src/chrome/content/rules/0x.co.xml
+++ b/src/chrome/content/rules/0x.co.xml
@@ -4,7 +4,7 @@
 	<target host="www.0x.co" />
 
 
-	<securecookie host="^\w" name="." />
+	<securecookie host=".+" name=".+" />
 
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/10antz.co.jp.xml
+++ b/src/chrome/content/rules/10antz.co.jp.xml
@@ -4,7 +4,7 @@
 	<target host="www.10antz.co.jp" />
 
 
-	<securecookie host="^\w" name="." />
+	<securecookie host=".+" name=".+" />
 
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/10dollar.ca.xml
+++ b/src/chrome/content/rules/10dollar.ca.xml
@@ -17,7 +17,7 @@
 					-->
 	<!--securecookie host="^(?:www\.)?10dollar\.ca$" name="^(?:AWSELB$|PHPSESSID)" /-->
 
-	<securecookie host="^\w" name="." />
+	<securecookie host=".+" name=".+" />
 
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/1105_Media.com.xml
+++ b/src/chrome/content/rules/1105_Media.com.xml
@@ -33,7 +33,7 @@
 					-->
 	<!--securecookie host="^(?:design\.|www\.)?1105media\.com$" name="^BIGipServer" /-->
 
-	<securecookie host="^\w" name="." />
+	<securecookie host=".+" name=".+" />
 
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/1105_pubs.com.xml
+++ b/src/chrome/content/rules/1105_pubs.com.xml
@@ -23,7 +23,7 @@
 					-->
 	<!--securecookie host="^newsletters\.1105pubs\.com$" name="^JSESSIONID$" /-->
 
-	<securecookie host="^newsletters\.1105pubs\.com$" name=".+" />
+	<securecookie host=".+" name=".+" />
 
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/123ContactForm.com.xml
+++ b/src/chrome/content/rules/123ContactForm.com.xml
@@ -4,8 +4,7 @@
 	<target host="www.123contactform.com" />
 
 
-	<securecookie host="^\." name="^_gat?$" />
-	<securecookie host="^\w" name="." />
+	<securecookie host=".+" name=".+" />
 
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/15Mpedia.xml
+++ b/src/chrome/content/rules/15Mpedia.xml
@@ -3,7 +3,7 @@
 	<target host="15mpedia.org" />
 	<target host="www.15mpedia.org" />
 
-  	<securecookie host="^(www\.)?15mpedia\.org$" name=".+" />
+	<securecookie host=".+" name=".+" />
 
 	<rule from="^http:"
 		to="https:" />

--- a/src/chrome/content/rules/1984_Hosting.com.xml
+++ b/src/chrome/content/rules/1984_Hosting.com.xml
@@ -18,7 +18,7 @@
 					-->
 	<!--securecookie host="^(www\.)?1984hosting\.com$" name="^(csrftoken|user_id)$" /-->
 
-  <securecookie host="^(?:\.|www\.)?1984hosting\.com$" name=".*" />
+	<securecookie host=".+" name=".+" />
 
   <rule from="^http:" to="https:"/>
 </ruleset>

--- a/src/chrome/content/rules/1stWarning.com.xml
+++ b/src/chrome/content/rules/1stWarning.com.xml
@@ -8,7 +8,7 @@
 	<target host="www.1stwarning.com" />
 
 
-	<securecookie host="^(?:.*\.)?1stwarning\.com$" name=".*" />
+	<securecookie host=".+" name=".+" />
 
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/1xbet.com.xml
+++ b/src/chrome/content/rules/1xbet.com.xml
@@ -12,7 +12,7 @@
 	<target host="www.1xbet.com" />
 
 
-	<securecookie host="^(?:w*\.)?1xbet\.com$" name=".+" />
+	<securecookie host=".+" name=".+" />
 
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/23Systems.xml
+++ b/src/chrome/content/rules/23Systems.xml
@@ -4,7 +4,7 @@
 	<target host="www.23systems.net" />
 
 
-	<securecookie host="^(?:w*\.)?23systems\.net$" name=".+" />
+	<securecookie host=".+" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/254a.com.xml
+++ b/src/chrome/content/rules/254a.com.xml
@@ -3,7 +3,7 @@
 	<target host="d.254a.com" />
 
 
-	<securecookie host="^d\.254a\.com$" name=".+" />
+	<securecookie host=".+" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/2cnt.net.xml
+++ b/src/chrome/content/rules/2cnt.net.xml
@@ -22,7 +22,7 @@
 	<!--securecookie host="^\.2cnt\.net$" name="^i00$" /-->
 	<!--securecookie host="^ssl-fromcs\.2cnt\.net$" name="^srp$" /-->
 
-	<securecookie host="^ssl-fromcs\.2cnt\.net$" name=".+" />
+	<securecookie host=".+" name=".+" />
 
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/360_Total_Security.com.xml
+++ b/src/chrome/content/rules/360_Total_Security.com.xml
@@ -19,8 +19,7 @@
 					-->
 	<!--securecookie host="^blog\.360totalsecurity\.com$" name="^pll_language$" /-->
 
-	<securecookie host="^\." name="^_gat?$" />
-	<securecookie host="^\w" name="." />
+	<securecookie host=".+" name=".+" />
 
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/360buyimg.com.xml
+++ b/src/chrome/content/rules/360buyimg.com.xml
@@ -19,7 +19,7 @@
 		<test url="http://static-alias-1.360buyimg.com/jzt/temp/js/adPic.new.20150909.min.js" />
 	<target host="storage.360buyimg.com" />
 
-	<securecookie host="^\w" name="." />
+	<securecookie host=".+" name=".+" />
 
 	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/38degrees.xml
+++ b/src/chrome/content/rules/38degrees.xml
@@ -12,7 +12,7 @@
 					-->
 	<!--securecookie host="^you\.38degrees\.org\.uk$" name="^_agra_session$" /-->
 
-    <securecookie host="^(?:.*\.)?38degrees\.org\.uk$" name=".+" />
+	<securecookie host=".+" name=".+" />
 
 	<rule from="^http:"
 		to="https:" />

--- a/src/chrome/content/rules/3DStats.xml
+++ b/src/chrome/content/rules/3DStats.xml
@@ -17,7 +17,7 @@
 					-->
 	<!--securecookie host="^(?:www\.)?3dstats\.com$" name="^NC1U$" /-->
 
-	<securecookie host="^(?:.*\.)?3dstats\.com$" name=".*"/>
+	<securecookie host=".+" name=".+" />
 
 	<rule from="^http:"
 		to="https:" />

--- a/src/chrome/content/rules/3dsupply.de.xml
+++ b/src/chrome/content/rules/3dsupply.de.xml
@@ -6,7 +6,7 @@
 	<target host="www.3dsupply.de" />
 
 
-	<securecookie host="^\w" name="." />
+	<securecookie host=".+" name=".+" />
 
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/419_Eater.com.xml
+++ b/src/chrome/content/rules/419_Eater.com.xml
@@ -16,7 +16,7 @@
 					-->
 	<!--securecookie host="^forum\.419eater\.com$" name="^phpbbn_eater_(data|sid)$" /-->
 
-	<securecookie host="^forum\.419eater\.com$" name=".+" />
+	<securecookie host=".+" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/451-Group.xml
+++ b/src/chrome/content/rules/451-Group.xml
@@ -3,7 +3,7 @@
 	<target host="451research.com"/>
 	<target host="www.451research.com"/>
 
-	<securecookie host="^(?:.*\.)?451research\.com$" name=".+"/>
+	<securecookie host=".+" name=".+" />
 
 	<rule from="^http:"
 		to="https:" />

--- a/src/chrome/content/rules/4dsply.com.xml
+++ b/src/chrome/content/rules/4dsply.com.xml
@@ -21,7 +21,7 @@
 	<target host="cdn.engine.4dsply.com" />
 
 
-	<securecookie host="^\w" name="." />
+	<securecookie host=".+" name=".+" />
 
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/58.com.xml
+++ b/src/chrome/content/rules/58.com.xml
@@ -51,7 +51,7 @@
 	<target host="zhaobiao.58.com" />
 		<test url="http://zhaobiao.58.com/app/download/index" />
 
-	<securecookie host="^\w" name="." />
+	<securecookie host=".+" name=".+" />
 
 	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/58CDN.com.cn.xml
+++ b/src/chrome/content/rules/58CDN.com.cn.xml
@@ -27,7 +27,7 @@
 		<test url="http://pic1.58cdn.com.cn/p1/big/n_v1bl2lwkm45sevpuuk6isq.jpg" />
 		<test url="http://t1.58cdn.com.cn/bidding/tiny/n_v1bj3gzr2u4ervr6x3j4aq.jpg" />
 
-	<securecookie host="^\w" name="." />
+	<securecookie host=".+" name=".+" />
 
 	<rule from="^http:"	to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/5vpn.net.xml
+++ b/src/chrome/content/rules/5vpn.net.xml
@@ -4,7 +4,7 @@
 	<target host="www.5vpn.net" />
 
 
-	<securecookie host="^(?:www\.)?5vpn.net$" name=".+" />
+	<securecookie host=".+" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/6connect.com.xml
+++ b/src/chrome/content/rules/6connect.com.xml
@@ -4,7 +4,7 @@
 	<target host="www.6connect.com" />
 
 
-	<securecookie host="^\w" name="." />
+	<securecookie host=".+" name=".+" />
 
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/7_Springs.com.xml
+++ b/src/chrome/content/rules/7_Springs.com.xml
@@ -21,7 +21,7 @@ Fetch error: http://www.7springs.com/ => https://www.7springs.com/: (7, 'Failed 
 	<target host="www.7springs.com" />
 
 
-	<securecookie host="^(?:www\.)?7springs\.com$" name=".+" />
+	<securecookie host=".+" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/99Bitcoins.com.xml
+++ b/src/chrome/content/rules/99Bitcoins.com.xml
@@ -10,8 +10,7 @@
 	<target host="www.99bitcoins.com" />
 
 
-	<securecookie host="^\w" name="." />
-	<securecookie host="^\." name="^_gat?$" />
+	<securecookie host=".+" name=".+" />
 
 
 	<rule from="^http:"


### PR DESCRIPTION
GO script used [`trivialize-secure-cookie.go`](https://github.com/cschanaj/lambda/blob/master/src/trivialize-secure-cookie.go)

Similar to previous massive rewrites, subsequent PRs will be much larger (300+ files PRs), please help to review the script if possible. thanks!

```
(1) exclude files which are 'default_off'
(2) exclude files which contain wildcard 'target'
(3) exclude files with 'exclusion' or complicated 'rule'
(4) IF for each `target`, exist at least one 'securecookie#host' match 'target' 
    and 'securecookie#name' is a wildcard. THEN rewrite.
(5) checkout files failing 'fetch-test'
```

P.S. around 3k files are subjected to modification, 1.3k files are ignored because they are `default_off`.

**To reviewer**: if possible, please merge #11525 before this. Otherwise, there might be some huge number of merge conflicts needed to be resolved in future PRs. Thanks!