### PR TITLE
Simplify MyUS.com.xml

### DIFF
--- a/src/chrome/content/rules/MyUS.com.xml
+++ b/src/chrome/content/rules/MyUS.com.xml
@@ -1,64 +1,8 @@
 <ruleset name="MyUS.com (partial)">
-
 	<target host="myus.com" />
-	<target host="*.myus.com" />
-		<!--exclusion pattern="^http://www\.myus\.com/(?:$|en/contact/|en/tips-faq/|getmedia/)" /-->
+	<target host="www.myus.com" />
 
+	<securecookie host=".+" name=".+" />
 
-	<!--	!www paths that don't support https redirect to http://www.	-->
-	<rule from="^http://(account)?myus\.com/"
-		to="https://$1myus.com/" />
-
-	<!--	- Some pages redirect to http
-		- There may be more than handled here that don't
-
-		Paths that do redirect to http:
-
-			- $
-			- en/contact/$
-			- en/login$
-			- en/tips-faq/top-faq/$
-			- getmedia/
-
-		Paths that don't:
-
-			NB: some in en/... redirect to http when requested *once* but don't on the 2nd request.
-				Shouldn't be a problem.  Hopefully.
-
-			- app_themes/
-			- App_Themes/
-			- CMSPages/
-			- en/$
-			- en/about-myus/$
-			- en/blog/$
-			- en/compare-memberships/$
-			- en/customer-reviews/$
-			- en/deals-coupons/$
-			- en/global-ecommerce/$
-			- en/home/$
-			- en/how-it-works/$
-			- en/login/
-			- en/my-account/$
-			- en/news-press/$
-			- en/our-services/$
-			- en/our-story/$
-			- en/personal-shopper/$
-			- en/price-comparison/$
-			- en/register/$
-			- en/ship-globally/$
-			- en/shop-smarter/$
-			- en/top-usa-stores/$
-			- en/whichmembership/$
-			- en/why-myus/$
-			- favicon.ico$
-			- MyUs/media/MyUS_WebsiteImages/MyUS-Awards/
-				-->
-	<rule 
-from="^http://www\.myus\.com/([aA]pp_[tT]hemes/|CMSPages/|en/(?:blog|customer-reviews|global-commerce|home|my-account|news-press|our-services|our-story|personal-shopper|price-register|register|ship-globally|shop-smarter|top-usa-stores|whichmembership|why-myus)/|favicon\.ico|MyUs/)"
-		to="https://www.myus.com/$1" />
-
-	<!--	Redirects to http before login/	-->
-	<rule from="^http://www\.myus\.com/en/login$"
-		to="https://www.myus.com/en/login/" />
-
+	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/MyUS.com.xml
+++ b/src/chrome/content/rules/MyUS.com.xml
@@ -1,3 +1,8 @@
+<!--
+	Non-functional hosts
+		Secure connection redirects to plaintext:
+		- account.myus.com
+-->
 <ruleset name="MyUS.com (partial)">
 	<target host="myus.com" />
 	<target host="www.myus.com" />


### PR DESCRIPTION
this domain serves HSTS now, removed unnecessary complicated rules.  In particular, `http://myus.com` redirect (301) to `https://www.myus.com`, so all user will be exposed to the HSTS headers. No subdomains enumeration is performed.

```bash
$ curl -I https://www.myus.com
HTTP/1.1 200 OK
Content-Type: text/html; charset=utf-8
X-AspNetMvc-Version: 4.0
Content-Length: 25218
X-Frame-Option: DENY
Cache-Control: private, max-age=38277
Expires: Thu, 03 Aug 2017 01:00:20 GMT
Date: Wed, 02 Aug 2017 14:22:23 GMT
Connection: keep-alive
Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
```