### PR TITLE
Restore indymedia ruleset, with broken hosts removed

### DIFF
--- a/src/chrome/content/rules/Indymedia.xml
+++ b/src/chrome/content/rules/Indymedia.xml
@@ -32,8 +32,6 @@
 		- liveradio ³
 		- mexico ²
 		- miami ²
-		- nantes ᵈ
-		- www.nantes ᵈ
 		- neworleans ²
 		- newsreal ²
 		- piter ʳ
@@ -151,6 +149,7 @@
 	<target host="lille.indymedia.org" />
 	<target host="linksunten.indymedia.org" />
 	<target host="www.linksunten.indymedia.org" />
+	<target host="nantes.indymedia.org" />
 	<target host="*.nantes.indymedia.org" />
 	<target host="nyc.indymedia.org" />
 	<target host="publish.nyc.indymedia.org" />
@@ -182,6 +181,7 @@
 					-->
 			<test url="http://www.belgium.indymedia.org/" />
 			<test url="http://www.grenoble.indymedia.org/" />
+			<test url="http://www.nantes.indymedia.org/" />
 
 		<!--	Sets cookie without Secure:
 							-->

--- a/src/chrome/content/rules/Indymedia.xml
+++ b/src/chrome/content/rules/Indymedia.xml
@@ -137,11 +137,8 @@
 	<target host="athens.indymedia.org" />
 	<target host="belgium.indymedia.org" />
 	<target host="brussels.indymedia.org" />
-	<target host="*.brussels.indymedia.org" />
 	<target host="bruxelles.indymedia.org" />
-	<target host="*.bruxelles.indymedia.org" />
 	<target host="bxl.indymedia.org" />
-	<target host="*.bxl.indymedia.org" />
 	<target host="de.indymedia.org" />
 	<target host="grenoble.indymedia.org" />
 	<target host="*.grenoble.indymedia.org" />
@@ -149,7 +146,7 @@
 	<target host="linksunten.indymedia.org" />
 	<target host="www.linksunten.indymedia.org" />
 	<target host="nantes.indymedia.org" />
-	<target host="*.nantes.indymedia.org" />
+	<target host="www.nantes.indymedia.org" />
 	<target host="nyc.indymedia.org" />
 	<target host="publish.nyc.indymedia.org" />
 	<target host="www.nyc.indymedia.org" />

--- a/src/chrome/content/rules/Indymedia.xml
+++ b/src/chrome/content/rules/Indymedia.xml
@@ -136,7 +136,6 @@
 	<target host="indymedia.org" />
 	<target host="athens.indymedia.org" />
 	<target host="belgium.indymedia.org" />
-	<target host="*.belgium.indymedia.org" />
 	<target host="brussels.indymedia.org" />
 	<target host="*.brussels.indymedia.org" />
 	<target host="bruxelles.indymedia.org" />

--- a/src/chrome/content/rules/Indymedia.xml
+++ b/src/chrome/content/rules/Indymedia.xml
@@ -1,22 +1,4 @@
-
 <!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://www.brussels.indymedia.org/ => https://www.brussels.indymedia.org/: (6, 'Could not resolve host: www.brussels.indymedia.org')
-Fetch error: http://www.bxl.indymedia.org/ => https://www.bxl.indymedia.org/: (6, 'Could not resolve host: www.bxl.indymedia.org')
-Fetch error: http://next.grenoble.indymedia.org/ => https://next.grenoble.indymedia.org/: (60, 'SSL certificate problem: unable to get local issuer certificate')
-Fetch error: http://publish.nyc.indymedia.org/nyc/servlet/OpenMir => https://publish.nyc.indymedia.org/nyc/servlet/OpenMir: (7, 'Failed to connect to publish.nyc.indymedia.org port 443: Connection refused')
-Fetch error: http://publish.indymedia.org/earth/servlet/OpenMir => https://publish.indymedia.org/earth/servlet/OpenMir: (7, 'Failed to connect to publish.indymedia.org port 443: Connection refused')
-Fetch error: http://indymedia.org/ => https://indymedia.org/: (7, 'Failed to connect to indymedia.org port 443: Connection refused')
-Fetch error: http://belarus.indymedia.org/ => https://belarus.indymedia.org/: (7, 'Failed to connect to belarus.indymedia.org port 443: No route to host')
-Fetch error: http://www.belarus.indymedia.org/ => https://www.belarus.indymedia.org/: (7, 'Failed to connect to www.belarus.indymedia.org port 443: No route to host')
-Fetch error: http://docs.indymedia.org/ => https://docs.indymedia.org/: (35, 'error:140770FC:SSL routines:SSL23_GET_SERVER_HELLO:unknown protocol')
-Fetch error: http://www.docs.indymedia.org/ => https://www.docs.indymedia.org/: (35, 'error:140770FC:SSL routines:SSL23_GET_SERVER_HELLO:unknown protocol')
-Fetch error: http://nyc.indymedia.org/ => https://nyc.indymedia.org/: (7, 'Failed to connect to nyc.indymedia.org port 443: Connection refused')
-Fetch error: http://publish.nyc.indymedia.org/ => https://publish.nyc.indymedia.org/: (7, 'Failed to connect to publish.nyc.indymedia.org port 443: Connection refused')
-Fetch error: http://www.nyc.indymedia.org/ => https://www.nyc.indymedia.org/: (7, 'Failed to connect to www.nyc.indymedia.org port 443: Connection refused')
-Fetch error: http://publish.indymedia.org/ => https://publish.indymedia.org/: (7, 'Failed to connect to publish.indymedia.org port 443: Connection refused')
-Fetch error: http://www.indymedia.org/ => https://www.indymedia.org/: (7, 'Failed to connect to www.indymedia.org port 443: Connection refused')
-
 	Other Indymedia rulesets:
 
 		- Indymedia.nl.xml
@@ -32,8 +14,12 @@ Fetch error: http://www.indymedia.org/ => https://www.indymedia.org/: (7, 'Faile
 		- barcelona ᵃ
 		- bc ¹
 		- beirut ²
+		- belarus ᵈ
+		- www.belarus ᵈ
 		- boston ²
 		- dev.boston ²
+		- docs ᵖ
+		- www.docs ᵖ
 		- bristol	Redirects to http
 		- colorado ᵈ
 		- cyprus ʳ
@@ -80,6 +66,7 @@ Fetch error: http://www.indymedia.org/ => https://www.indymedia.org/: (7, 'Faile
 		- chat ¹ ²
 		- emiliaromagna ᵉ ᵘ
 		- grenoble ³
+		- next.grenoble ² ⁵
 		- irc ¹
 		- israel ¹ ² ⁴
 		- italy	¹ ⁵
@@ -140,14 +127,12 @@ Fetch error: http://www.indymedia.org/ => https://www.indymedia.org/: (7, 'Faile
 	* Secured by us, see https://www.paulirish.com/2010/the-protocol-relative-url/
 
 -->
-<ruleset name="Indymedia.org (partial)" default_off='failed ruleset test'>
+<ruleset name="Indymedia.org (partial)">
 
 	<!--	Direct rewrites:
 				-->
 	<target host="indymedia.org" />
 	<target host="athens.indymedia.org" />
-	<target host="belarus.indymedia.org" />
-	<target host="www.belarus.indymedia.org" />
 	<target host="belgium.indymedia.org" />
 	<target host="*.belgium.indymedia.org" />
 	<target host="brussels.indymedia.org" />
@@ -157,8 +142,6 @@ Fetch error: http://www.indymedia.org/ => https://www.indymedia.org/: (7, 'Faile
 	<target host="bxl.indymedia.org" />
 	<target host="*.bxl.indymedia.org" />
 	<target host="de.indymedia.org" />
-	<target host="docs.indymedia.org" />
-	<target host="www.docs.indymedia.org" />
 	<target host="grenoble.indymedia.org" />
 	<target host="*.grenoble.indymedia.org" />
 	<target host="lille.indymedia.org" />
@@ -197,9 +180,6 @@ Fetch error: http://www.indymedia.org/ => https://www.indymedia.org/: (7, 'Faile
 			<!--	-ve:
 					-->
 			<test url="http://www.belgium.indymedia.org/" />
-			<test url="http://www.brussels.indymedia.org/" />
-			<test url="http://www.bxl.indymedia.org/" />
-			<test url="http://next.grenoble.indymedia.org/" />
 			<test url="http://www.grenoble.indymedia.org/" />
 			<test url="http://www.nantes.indymedia.org/" />
 

--- a/src/chrome/content/rules/Indymedia.xml
+++ b/src/chrome/content/rules/Indymedia.xml
@@ -32,6 +32,8 @@
 		- liveradio ³
 		- mexico ²
 		- miami ²
+		- nantes ᵈ
+		- www.nantes ᵈ
 		- neworleans ²
 		- newsreal ²
 		- piter ʳ
@@ -71,6 +73,7 @@
 		- israel ¹ ² ⁴
 		- italy	¹ ⁵
 		- lille ³
+		- www.lille ²
 		- manila ²
 		- napoli ᵉ ᵘ
 		- netherlands ²
@@ -82,6 +85,7 @@
 		- roma ¹ ⁵
 		- swizerland ²
 		- ukraine ¹ ᵀ
+		- wichmann ²
 
 	ᵀ CAcert
 	¹ Expired
@@ -145,17 +149,14 @@
 	<target host="grenoble.indymedia.org" />
 	<target host="*.grenoble.indymedia.org" />
 	<target host="lille.indymedia.org" />
-	<target host="www.lille.indymedia.org" />
 	<target host="linksunten.indymedia.org" />
 	<target host="www.linksunten.indymedia.org" />
-	<target host="nantes.indymedia.org" />
 	<target host="*.nantes.indymedia.org" />
 	<target host="nyc.indymedia.org" />
 	<target host="publish.nyc.indymedia.org" />
 	<target host="www.nyc.indymedia.org" />
 	<target host="pouget.indymedia.org" />
 	<target host="publish.indymedia.org" />
-	<target host="wichmann.indymedia.org" />
 	<target host="www.indymedia.org" />
 
 		<!--	includeSubdomains applies to one level only, so:
@@ -181,7 +182,6 @@
 					-->
 			<test url="http://www.belgium.indymedia.org/" />
 			<test url="http://www.grenoble.indymedia.org/" />
-			<test url="http://www.nantes.indymedia.org/" />
 
 		<!--	Sets cookie without Secure:
 							-->


### PR DESCRIPTION
- Remove broken hosts which caused the ruleset to be disabled
- Keep some of the hosts which are working once again.