### PR TITLE
WIP: Export settings

### DIFF
--- a/src/chrome/content/code/HTTPSRules.js
+++ b/src/chrome/content/code/HTTPSRules.js
@@ -311,15 +311,18 @@ const RuleWriter = {
       this.log(WARN, "TARGETS IS NULL");
     var data = this.readFromFile(file);
     if (!data) return null;
-    return this.readFromString(data, rule_store, ruleset_id);
+    return this.readFromString(data, rule_store, ruleset_id, true);
   },
 
-  readFromString: function(data, rule_store, ruleset_id) {
+  readFromString: function(data, rule_store, ruleset_id, custom) {
     try {
       var xmlruleset = dom_parser.parseFromString(data, "text/xml");
     } catch(e) { // file has been corrupted; XXX: handle error differently
       this.log(WARN,"Error in XML data: " + e + "\n" + data);
       return null;
+    }
+    if(custom){
+      HTTPSRules.custom_rulesets.push(data);
     }
     this.parseOneRuleset(xmlruleset.documentElement, rule_store, ruleset_id);
   },
@@ -406,6 +409,7 @@ const RuleWriter = {
 const HTTPSRules = {
   init: function() {
     try {
+      this.custom_rulesets = [];
       this.rulesets = [];
       this.targets = {};  // dict mapping target host pattern -> list of
                           // applicable ruleset ids
@@ -593,7 +597,7 @@ const HTTPSRules = {
 
   // Load a ruleset by numeric id, e.g. 234
   loadRulesetById: function(ruleset_id) {
-    RuleWriter.readFromString(this.rulesetStrings[ruleset_id], this, ruleset_id);
+    RuleWriter.readFromString(this.rulesetStrings[ruleset_id], this, ruleset_id, false);
   },
 
   // Get all rulesets matching a given target, lazy-loading from DB as necessary.

--- a/src/chrome/content/export-settings.js
+++ b/src/chrome/content/export-settings.js
@@ -1,0 +1,8 @@
+const CC = Components.classes;
+let HTTPSEverywhere = CC["@eff.org/https-everywhere;1"]
+                      .getService(Components.interfaces.nsISupports)
+                      .wrappedJSObject;
+
+function exportSettingsToFile(){
+  HTTPSEverywhere.exportSettingsToFile(window);
+}

--- a/src/chrome/content/export-settings.xul
+++ b/src/chrome/content/export-settings.xul
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet href="chrome://global/skin/" type="text/css"?>
+<?xml-stylesheet href="chrome://https-everywhere/content/preferences.css" type="text/css"?>
+
+<!DOCTYPE overlay SYSTEM "chrome://https-everywhere/locale/https-everywhere.dtd">
+
+<dialog id="https-everywhere-export-settings"
+  xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
+  xmlns:html="http://www.w3.org/1999/xhtml"
+  buttons="cancel,accept"
+  title="&https-everywhere.prefs.export_settings;"
+  ondialogaccept="return exportSettingsToFile();"
+  width="640"
+  height="480"
+  align="center">
+  <script type="application/x-javascript" src="chrome://https-everywhere/content/export-settings.js"/>
+  <vbox style="overflow:auto" flex="1">
+    <label style="text-align:center; font-weight:bold; font-size:22px;">&https-everywhere.about.ext_name; - &https-everywhere.prefs.export_settings;</label>
+    <label><span style="text-align:center; font-size:18px; margin-bottom:10px; color: red; font-weight: bold;">&https-everywhere.prefs.settings_warning;</span>&#160;<span style="text-align:center; font-size:18px; margin-bottom:10px;">&https-everywhere.prefs.settings_warning_delete;</span></label>
+    <label style="font-weight:bold; margin-top:10px;">&https-everywhere.prefs.settings_warning_explain;</label>
+    <label style="margin-top:10px; margin-left: 30px;">&#8226; &https-everywhere.prefs.settings_global;</label>
+    <label style="margin-top:10px; margin-left: 30px;">&#8226; &https-everywhere.prefs.settings_toggle;</label>
+    <label style="margin-top:10px; margin-left: 30px;">&#8226; &https-everywhere.prefs.settings_custom;</label>
+    <label style="margin-top: 10px;"><span style="font-weight: bold; color: red;">&https-everywhere.prefs.settings_click_ok;</span>&#160;<span>&https-everywhere.prefs.settings_warning_closing;</span></label>
+  </vbox>
+</dialog>

--- a/src/chrome/content/toolbar_button.js
+++ b/src/chrome/content/toolbar_button.js
@@ -441,23 +441,5 @@ function migratePreferences(gBrowser) {
 }
 
 function exportSettingsToFile(){
-  var settings = JSON.stringify(HTTPSEverywhere.exportSettings());
-
-  var nsIFilePicker = CI.nsIFilePicker;
-  var fp = Components.classes["@mozilla.org/filepicker;1"].createInstance(nsIFilePicker);
-  fp.init(window, "Save Settings to File", nsIFilePicker.modeSave);
-  fp.defaultString = "https_everywhere_settings.json";
-  fp.defaultExtension = "json";
-  fp.addToRecentDocs = true;
-  var res = fp.show();
-  if (res != nsIFilePicker.returnCancel){
-    var file_path = fp.file.path;
-    var file = CC["@mozilla.org/file/local;1"].createInstance(CI.nsILocalFile);
-    file.initWithPath(file_path);
-
-    output_stream = Components.classes["@mozilla.org/network/file-output-stream;1"].createInstance(CI.nsIFileOutputStream);
-    output_stream.init(file, 0x02 | 0x08 | 0x20, 0600, 0);
-    output_stream.write(settings, settings.length);
-    output_stream.close();
-  }
+  HTTPSEverywhere.exportSettingsToFile(window);
 }

--- a/src/chrome/content/toolbar_button.js
+++ b/src/chrome/content/toolbar_button.js
@@ -439,3 +439,25 @@ function migratePreferences(gBrowser) {
     HTTPSEverywhere.prefs.setIntPref("prefs_version", prefs_version+1);
   }
 }
+
+function exportSettingsToFile(){
+  var settings = JSON.stringify(HTTPSEverywhere.exportSettings());
+
+  var nsIFilePicker = CI.nsIFilePicker;
+  var fp = Components.classes["@mozilla.org/filepicker;1"].createInstance(nsIFilePicker);
+  fp.init(window, "Save Settings to File", nsIFilePicker.modeSave);
+  fp.defaultString = "https_everywhere_settings.json";
+  fp.defaultExtension = "json";
+  fp.addToRecentDocs = true;
+  var res = fp.show();
+  if (res != nsIFilePicker.returnCancel){
+    var file_path = fp.file.path;
+    var file = CC["@mozilla.org/file/local;1"].createInstance(CI.nsILocalFile);
+    file.initWithPath(file_path);
+
+    output_stream = Components.classes["@mozilla.org/network/file-output-stream;1"].createInstance(CI.nsIFileOutputStream);
+    output_stream.init(file, 0x02 | 0x08 | 0x20, 0600, 0);
+    output_stream.write(settings, settings.length);
+    output_stream.close();
+  }
+}

--- a/src/chrome/content/toolbar_button.xul
+++ b/src/chrome/content/toolbar_button.xul
@@ -44,6 +44,8 @@
       <menupopup id="https-everywhere-context" onpopupshowing="show_applicable_list(this)">
         <!-- entries will be written here by ApplicableList.populate_menu() -->
         <menuseparator class="hide-on-disable"/>
+        <menuitem label="&https-everywhere.prefs.export_settings;"
+          command="https-everywhere-menuitem-exportSettings" class="hide-on-disable"/>
         <menuitem label="&https-everywhere.prefs.reset_defaults;"
           command="https-everywhere-menuitem-resetToDefaults" class="hide-on-disable"/>
         <menuitem label="&https-everywhere.menu.viewAllRules;"
@@ -63,6 +65,8 @@
   <commandset>
     <command id="https-everywhere-menuitem-rule-toggle-template"
       oncommand="toggle_rule(event.target.attributes['data-id'].value)" />
+    <command id="https-everywhere-menuitem-exportSettings"
+      oncommand="exportSettingsToFile()" />
     <command id="https-everywhere-menuitem-resetToDefaults"
       oncommand="httpsEverywhere.toolbarButton.resetToDefaults()" />
     <command id="https-everywhere-menuitem-globalEnableToggle"

--- a/src/components/https-everywhere.js
+++ b/src/components/https-everywhere.js
@@ -790,7 +790,47 @@ HTTPSEverywhere.prototype = {
       thisBranch.setBoolPref("enabled", true);
       this.httpNowhereEnabled = true;
     }
+  },
+
+  exportSettings: function(){
+    var changed = false;
+
+    var prefs = {
+      http_nowhere_enabled: this.prefs.getBoolPref("http_nowhere.enabled"),
+      global_enabled: this.prefs.getBoolPref("globalEnabled"),
+      show_counter: this.prefs.getBoolPref("show_counter")
+    };
+
+    if(prefs.http_nowhere_enabled == true ||
+       prefs.global_enabled == false ||
+       prefs.show_counter == true
+    ){
+      changed = true;
+    }
+
+    var rule_toggle = {}
+    for(rule_toggle_key of this.rule_toggle_prefs.getChildList("", {})){
+      let current_state = this.rule_toggle_prefs.getBoolPref(rule_toggle_key);
+      if(HTTPSRules.rulesetsByName[rule_toggle_key].on_by_default != current_state){
+        rule_toggle[rule_toggle_key] = current_state;
+        changed = true;
+      }
+    }
+
+    if(HTTPSRules.custom_rulesets.length !== 0){
+      changed = true;
+    }
+
+    var export_object = {
+      prefs: prefs,
+      rule_toggle: rule_toggle,
+      custom_rulesets: HTTPSRules.custom_rulesets,
+      changed: changed
+    };
+
+    return export_object;
   }
+
 };
 
 var prefs = 0;

--- a/src/defaults/preferences/preferences.js
+++ b/src/defaults/preferences/preferences.js
@@ -1,6 +1,7 @@
 pref("extensions.https_everywhere.LogLevel", 5);
 pref("extensions.https_everywhere.log_to_stdout", false);
 pref("extensions.https_everywhere.globalEnabled",true);
+pref("extensions.https_everywhere.show_counter",false);
 
 // this is the HTTPS Everywhere preferences version (for migrations)
 pref("extensions.https_everywhere.prefs_version", 0);

--- a/src/defaults/preferences/preferences.js
+++ b/src/defaults/preferences/preferences.js
@@ -2,6 +2,7 @@ pref("extensions.https_everywhere.LogLevel", 5);
 pref("extensions.https_everywhere.log_to_stdout", false);
 pref("extensions.https_everywhere.globalEnabled",true);
 pref("extensions.https_everywhere.show_counter",false);
+pref("extensions.https_everywhere.export_popup_shown",false);
 
 // this is the HTTPS Everywhere preferences version (for migrations)
 pref("extensions.https_everywhere.prefs_version", 0);


### PR DESCRIPTION
Partially resolves https://github.com/EFForg/https-everywhere/issues/10007.

Note: This PR does not include the import code, which I am still working on.

This allows users to export their HTTPS Everywhere settings to a `json` file.  The `json` file includes five top-level keys:

1. `prefs`: Two high-level preferences - whether the extension is turned on at all, and whether 2. `Block all unencrypted requests` is enabled.
3. `rule_toggle`: This is an object of rulesets, keyed by ruleset name, the value for each being either `true` or `false` depending on if the user enabled or disabled the ruleset.  If a ruleset has a default value, it is not included in this object.
4. `custom_rulesets`: A list of the full text of all custom rulesets in the `HTTPSEverywhereCustomUserRules` profile path.
5. `changed`: Whether this user has changed default settings at all.  Not strictly needed for the export, but will be useful come time for imports.

The exported `json` file is readily understandable and I encourage any reviewer to look at the export to ensure it matches expectations.

There are two ways to export this file.

1. The PR adds a menu option, `Export Settings`, which opens a dialogue to save the settings.
2. The PR adds a new resource, opened in a tab, which warns users of the fact that they are about to lose their settings.  This tab is opened once, and a pref is set so that it will not be opened again.  Once a user clicks "OK" in the tab, they will be prompted to save the settings file.

This adds several strings that should be translated into our supported languages quickly.  I request that any reviewer look at the text of these strings carefully first.  Transifex needs these translations commited into `master` before translations can begin, so it is a priority to get the English version into `master` ASAP, even if the underlying functionality changes.  This need for expediency explains why some of the strings to be translated are not present in the extension yet, and only expected to appear once the import functionality is complete.

When testing, you may want to test if the popup persists.  In order to do so, you can create a persisting Firefox profile directory for testing.  Run `mktemp -d`.  This generates a random temporary directory, which you can apply with a patch:

```patch
diff --git a/test/firefox.sh b/test/firefox.sh
index 0ff398c..5fccc6c 100755
--- a/test/firefox.sh
+++ b/test/firefox.sh
@@ -18,8 +18,8 @@ source utils/mktemp.sh
 TEST_ADDON_PATH=./test/firefox/
 
 # We'll create a Firefox profile here and install HTTPS Everywhere into it.
-PROFILE_DIRECTORY="$(mktemp -d)"
-trap 'rm -r "$PROFILE_DIRECTORY"' EXIT
+PROFILE_DIRECTORY="/tmp/tmp.7CPWfjEIb6"
+#trap 'rm -r "$PROFILE_DIRECTORY"' EXIT
 HTTPSE_INSTALL_DIRECTORY=$PROFILE_DIRECTORY/extensions/https-everywhere-eff@eff.org
 
 # Build the XPI to run all the validations in makexpi.sh, and to ensure that
diff --git a/test/firefox/test_profile_skeleton/prefs.js b/test/firefox/test_profile_skeleton/prefs.js
index 42b3f0a..07110f0 100644
--- a/test/firefox/test_profile_skeleton/prefs.js
+++ b/test/firefox/test_profile_skeleton/prefs.js
@@ -4,7 +4,7 @@ user_pref("extensions.https_everywhere._observatory.enabled", true);
 user_pref("extensions.https_everywhere._observatory.popup_shown", true);
 user_pref("extensions.https_everywhere.toolbar_hint_shown", true);
 // Show all logs.
-user_pref("extensions.https_everywhere.LogLevel", 0);
+user_pref("extensions.https_everywhere.LogLevel", 5);
 user_pref("extensions.https_everywhere.log_to_stdout", true);
 // Make it quicker to make manual config changes.
 user_pref("general.warnOnAboutConfig", false);
```

This way you can run `./test/firefox.sh --justrun` for the first run, and `firefox -profile /tmp/tmp.7CPWfjEIb6/` for the second run.