### PR TITLE
Update Netgear.xml

### DIFF
--- a/src/chrome/content/rules/Netgear.xml
+++ b/src/chrome/content/rules/Netgear.xml
@@ -1,16 +1,11 @@
 <!--
 	Nonfunctional subdomains:
 
-		- (www.) ¹
 		- download ¹
-		- www.download ²
-		- investor ³
-		- powershift
-		- support ³
+		- investor ²
 
-	¹ Refused
-	² 400; mismatched, CN: ssl2.cdngc.net
-	³ Dropped
+	¹ NXDOMAIN
+	² Dropped
 
 -->
 <ruleset name="Netgear (partial)">
@@ -26,10 +21,7 @@
 	<securecookie host="^my\.netgear\.com$" name=".*" />
 
 
-	<rule from="^http://(?:www\.)?netgear\.com/css/img/(?:(backgrounds/(?:body|nav)_bg\.jpg)|logos/(logo-netgear\.gif))"
-		to="https://my.netgear.com/myNETGEAR/includes/images/$1$2" />
-
-	<rule from="^http://my\.netgear\.com/"
-		to="https://my.netgear.com/" />
+	<rule from="^http://((?:www(?:\.download)?|powershift|support)\.)?netgear\.com/"
+		to="https://$1netgear.com/" />
 
 </ruleset>


### PR DESCRIPTION
Previously nonfunctional domains that now work:
- `(www.)` [not enforced by server]
- `www.download` [not enforced by server]
- `powershift` [303 redirect]
- `support` [301 redirect to `www`]

Removing domain:
- `my` [HSTS preloaded and 301 redirect]