### PR TITLE
[AOL] Enable ruleset, remove nonfunctional domains, slightly expand coverage

### DIFF
--- a/src/chrome/content/rules/AOL.xml
+++ b/src/chrome/content/rules/AOL.xml
@@ -51,6 +51,7 @@
 
 			- ^ ʳ
 			- about ʳ
+			- advertising ᶠ
 			- autos ʰ
 			- dev.sandbox.autos ʳ
 			- misc.blogsmith ʳ
@@ -99,6 +100,7 @@
 		- blog.winamp.com
 
 	ᵃ Shows another domain
+	ᶠ Content fails to load
 	ʳ Refused
 	ʰ Redirects to http
 	ᵉ Cert expired
@@ -163,7 +165,6 @@
 	<target host="www.aol.com" />
 	<target host="account.aol.com" />
 	<target host="adinfo.aol.com" />
-	<target host="advertising.aol.com" />
 	<target host="bill.aol.com" />
 	<target host="build.aol.com" />
 	<target host="captcha.aol.com" />
@@ -236,7 +237,7 @@
 	<!--securecookie host="^\.search\.aol\.com$" name="^(?:MVT_TB[PV]|RSP_CHECK_PORTAL_SEARCH\.AOL\.COM|s_guid)$" /-->
 
 	<securecookie host="^\." name="^(?:_ga|optimizely)" />
-	<securecookie host="^(?:dev\.sandbox\.autos|new)\.aol\.com$" name="." />
+	<securecookie host="(^|\.)(bill|build|discover|i|myaccount|mybenefits|new|portfolios|postmaster|dashboard\.voice)\.aol\.com$" name=".+" />
 
 
 	<rule from="^http://expapi\.oscar\.aol\.com/"

--- a/src/chrome/content/rules/AOL.xml
+++ b/src/chrome/content/rules/AOL.xml
@@ -1,14 +1,4 @@
-
 <!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://autos.aol.com/ => https://autos.aol.com/: (7, 'Failed to connect to autos.aol.com port 443: Connection refused')
-Fetch error: http://els-sso.corp.aol.com/ => https://els-sso.corp.aol.com/: (6, 'Could not resolve host: els-sso.corp.aol.com')
-Fetch error: http://s.on.aol.com/ => https://s.on.aol.com/: (60, 'SSL certificate problem: certificate has expired')
-Fetch error: http://t.on.aol.com/ => https://t.on.aol.com/: (60, 'SSL certificate problem: certificate has expired')
-Fetch error: http://cdn.webmail.aol.com/ => https://cdn.webmail.aol.com/: (6, 'Could not resolve host: cdn.webmail.aol.com')
-Fetch error: http://as.on.aol.com/ => https://s.on.aol.com/: (60, 'SSL certificate problem: certificate has expired')
-Fetch error: http://at.on.aol.com/ => https://t.on.aol.com/: (60, 'SSL certificate problem: certificate has expired')
-Fetch error: http://support.on.aol.com/ => https://support.aolonnetwork.com/: (60, 'SSL certificate problem: certificate has expired')
 
 	For problematic coverage, see AOL-mismatches.xml.
 
@@ -61,6 +51,7 @@ Fetch error: http://support.on.aol.com/ => https://support.aolonnetwork.com/: (6
 
 			- ^ ʳ
 			- about ʳ
+			- autos ʰ
 			- dev.sandbox.autos ʳ
 			- misc.blogsmith ʳ
 			- browsers ʳ
@@ -80,9 +71,12 @@ Fetch error: http://support.on.aol.com/ => https://support.aolonnetwork.com/: (6
 			- music
 			- on ʰ
 
+			- s.on ᵉ
 			- stg.s.on
 			- stg.on
+			- support.on ᵉ
 			- stg.support.on
+			- t.on ᵉ
 			- stg.t.on
 
 			- netscape ʰ
@@ -96,7 +90,6 @@ Fetch error: http://support.on.aol.com/ => https://support.aolonnetwork.com/: (6
 			- weather ʳ
 			- webmail ʳ
 			- welcome ʰ
-			- www ʰ
 
 		- (www.)joystiq.com
 		- massively.joystiq.com
@@ -108,19 +101,17 @@ Fetch error: http://support.on.aol.com/ => https://support.aolonnetwork.com/: (6
 	ᵃ Shows another domain
 	ʳ Refused
 	ʰ Redirects to http
+	ᵉ Cert expired
 	³ 503, Akamai
 
 
 	Problematic hosts in *aol.com:
 
-		- as.on ᴬ
-		- at.on	ᴬ
-		- support.on
-
 		- expapi.oscar ᵐ
+		- webmail ᵑ
 
-	ᴬ Akamai / mismatched
 	ᵐ Cert only matches api.oscar.aol.com
+	ᵑ Refused
 
 
 	Partially covered hosts in *aol.com:
@@ -164,19 +155,20 @@ Fetch error: http://support.on.aol.com/ => https://support.aolonnetwork.com/: (6
 		- favicon on adinfo from www.aol.com
 
 -->
-<ruleset name="AOL.com (partial)" default_off='failed ruleset test'>
+<ruleset name="AOL.com (partial)">
 
 	<!--	Direct rewrites:
 				-->
+	<target host="aol.com" />
+	<target host="www.aol.com" />
 	<target host="account.aol.com" />
 	<target host="adinfo.aol.com" />
 	<target host="advertising.aol.com" />
-	<target host="autos.aol.com" />
 	<target host="bill.aol.com" />
+	<target host="build.aol.com" />
 	<target host="captcha.aol.com" />
 	<target host="ui.comet.aol.com" />
 	<target host="contactus.aol.com" />
-	<target host="els-sso.corp.aol.com" />
 	<target host="idgfm.corp.aol.com" />
 	<target host="discover.aol.com" />
 	<target host="feedback.aol.com" />
@@ -188,35 +180,32 @@ Fetch error: http://support.on.aol.com/ => https://support.aolonnetwork.com/: (6
 
 	<target host="mail.aol.com" />
 	<target host="api.mail.aol.com" />
+	<target host="beta.mail.aol.com" />
 	<target host="cdn.mail.aol.com" />
 	<target host="rpc.mail.aol.com" />
 	<target host="rpc1.mail.aol.com" />
+	<target host="webmail1.mail.aol.com" />
 
 	<target host="membernotifications.aol.com" />
 	<target host="myaccount.aol.com" />
 	<target host="mybenefits.aol.com" />
 	<target host="new.aol.com" />
-	<target host="s.on.aol.com" />
-	<target host="t.on.aol.com" />
 	<target host="openid.aol.com" />
 	<target host="api.oscar.aol.com" />
 	<target host="portfolios.aol.com" />
+	<target host="postmaster.aol.com" />
 	<target host="s2c.aol.com" />
 	<target host="my.screenname.aol.com" />
 	<target host="search.aol.com" />
 	<target host="shop.aol.com" />
 	<target host="dashboard.voice.aol.com" />
-	<target host="cdn.webmail.aol.com" />
 
 		<test url="http://cdn.komentary.aol.com/confab/1/styles/confab.css" />
 
 	<!--	Complications:
 				-->
-	<target host="as.on.aol.com" />
-	<target host="at.on.aol.com" />
-	<target host="support.on.aol.com" />
-
 	<target host="expapi.oscar.aol.com" />
+	<target host="webmail.aol.com" />
 
 		<!--	Added by AOL, required for http logout.
 								-->
@@ -250,14 +239,11 @@ Fetch error: http://support.on.aol.com/ => https://support.aolonnetwork.com/: (6
 	<securecookie host="^(?:dev\.sandbox\.autos|new)\.aol\.com$" name="." />
 
 
-	<rule from="^http://a(s|t)\.on\.aol\.com/"
-		to="https://$1.on.aol.com/" />
-
-	<rule from="^http://support\.on\.aol\.com/"
-		to="https://support.aolonnetwork.com/" />
-
 	<rule from="^http://expapi\.oscar\.aol\.com/"
 		to="https://api.oscar.aol.com/" />
+
+	<rule from="^http://webmail\.aol\.com/"
+		to="https://mail.aol.com/" />
 
 	<rule from="^http:"
 		to="https:" />


### PR DESCRIPTION
With this pull request, a number of problematical targets (and rules specifically related to those targets) have been removed from the ruleset. However, it is not clear as to how, and whether, these targets should be documented in the ruleset's comments about nonfunctional domains and problematic hosts. In particular, the difference between "nonfunctional" and "problematic" is not totally clear. In addition, if a domain does not work for both HTTP and HTTPS, should it be listed in the ruleset comments at all? (Or, are the ruleset comments about nonfunctional and problematic domains specifically intended for domains that work with HTTP but which have issues only with HTTPS?)

The behavior of the removed targets is as follows:

* `autos.aol.com` - http://autos.aol.com/ generates a redirect to http://www.autoblog.com/, https://autos.aol.com/ generates an "Unable to connect" error.
* `els-sso.corp.aol.com` - http://els-sso.corp.aol.com/ and https://els-sso.corp.aol.com/ both generate a "Server not found" error.
* `s.on.aol.com` - http://s.on.aol.com/ generates a 503 response, https://s.on.aol.com/ generates a certificate expired error.
* `t.on.aol.com` - http://t.on.aol.com/ generates a 503 response, https://t.on.aol.com/ generates a certificate expired error.
* `cdn.webmail.aol.com` - http://cdn.webmail.aol.com/ and https://cdn.webmail.aol.com/ both generate a "Server not found" error.
* `as.on.aol.com` - http://as.on.aol.com/ and https://as.on.aol.com/ both generate a "Server not found" error.
* `at.on.aol.com` - http://at.on.aol.com/ and https://at.on.aol.com/ both generate a "Server not found" error.
* `support.on.aol.com` - http://support.on.aol.com/ generates a 503 response, https://support.on.aol.com/ generates a certificate expired error.

At the current time, `autos` is listed as a nonfunctional subdomain that redirects to HTTP. The `s.on`, `t.on`, and `support.on` subdomains are listed as nonfunctional domains that give a cert expired error. The subdomains that give a "Server not found" error for both HTTP and HTTPS are not listed at all.