### PR TITLE
Update makecrx.sh

### DIFF
--- a/makecrx.sh
+++ b/makecrx.sh
@@ -99,7 +99,6 @@ trap 'rm -f "$pub" "$sig" "$zip"' EXIT
 # zip up the crx dir
 cwd=$(pwd -P)
 (cd "$dir" && ../../utils/create_xpi.py -n "$cwd/$zip" -x "../../.build_exclusions" .)
-echo >&2 "Unsigned package has sha1sum: $(openssl dgst -sha1 "$cwd/$zip" | awk '{print $2}')"
 
 # signature
 openssl sha1 -sha1 -binary -sign "$key" < "$zip" > "$sig"


### PR DESCRIPTION
Not sure why do we compute the SHA1 checksum of the unsigned ZIP file, since the signed CRX will have a different checksum.