### PR TITLE
Remove netdna-ssl.com targets duplicated across rulesets

### DIFF
--- a/src/chrome/content/rules/Avadirect.com.xml
+++ b/src/chrome/content/rules/Avadirect.com.xml
@@ -11,9 +11,6 @@
   <target host="avadirect.com"/>
   <target host="www.avadirect.com"/>
 
-	<target host="avadirect-freedomusainc1.netdna-ssl.com" />
-	<target host="static-freedomusainc1.netdna-ssl.com" />
-
 		<!--	Redirects to http:
 						-->
 		<!--exclusion pattern="^http://www\.avadirect\.com/$" /-->

--- a/src/chrome/content/rules/Lester_Chan.net.xml
+++ b/src/chrome/content/rules/Lester_Chan.net.xml
@@ -25,8 +25,6 @@
 	<target host="lesterchan.net" />
 	<target host="www.lesterchan.net" />
 
-	<target host="lesterchan-lesterchan.netdna-ssl.com" />
-
 	<!--	Complications:
 				-->
 	<target host="lc2.lcstatic.net" />

--- a/src/chrome/content/rules/Soundcloud.xml
+++ b/src/chrome/content/rules/Soundcloud.xml
@@ -53,8 +53,6 @@
 	<target host="visuals.soundcloud.com" />
 	<target host="w.soundcloud.com" />
 	
-	<target host="soundcloud-wpengine.netdna-ssl.com" />
-
 	<securecookie host=".+" name=".+" />
 
 	<rule from="^http:"	to="https:" />


### PR DESCRIPTION
All targets are already secured in `Netdna-ssl.com.xml`