### PR TITLE
Split SWISS-Virtual.com from Swiss.xml

### DIFF
--- a/src/chrome/content/rules/SWISS-Virtual.com.xml
+++ b/src/chrome/content/rules/SWISS-Virtual.com.xml
@@ -1,0 +1,14 @@
+<!--
+	Note: SWISS-Virtual.com is not affiliated to 
+		Swiss International Air Lines Ltd. 
+
+	Non-functional hosts
+		Couldn't connect to server:
+		- db1.swiss-virtual.com
+-->
+<ruleset name="SWISS-Virtual.com">
+	<target host="swiss-virtual.com" />
+	<target host="www.swiss-virtual.com" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/Swiss.xml
+++ b/src/chrome/content/rules/Swiss.xml
@@ -13,8 +13,6 @@ Fetch error: http://mobile.swiss.com/ => https://mobile.swiss.com/: (51, "SSL: n
 	<target host="booking.swiss.com"/>
 	<target host="mobile.swiss.com"/>
 	<target host="my.swiss.com"/>
-	<target host="swiss-virtual.com"/>
-	<target host="www.swiss-virtual.com"/>
 
 	<securecookie host="^(?:.*\.)?swiss\.com$" name=".+" />
 


### PR DESCRIPTION
SWISS Virtual is **NOT** affiliated to Swiss International Air Lines Ltd.

Please refer to the disclaimer at the bottom of https://www.swiss-virtual.com/en/

P.S. I know that `Swiss.xml` is still `default_off`, but it should be works of a separate PR.