### PR TITLE
Update connect.me.xml ruleset

### DIFF
--- a/src/chrome/content/rules/Connect.me.xml
+++ b/src/chrome/content/rules/Connect.me.xml
@@ -1,6 +1,9 @@
 <ruleset name="Connect.me">
 
 	<!--	Complications:
+                  The domain connect.me is
+                  currently serving an incomplete
+                  certificate chain.
 				-->
   <target host="www.connect.me"/>
 
@@ -10,7 +13,5 @@
 					-->
 	<rule from="^http:"
 		to="https:" />
-
-		<test url="http://www.connect.me/" />
 
 </ruleset>

--- a/src/chrome/content/rules/Connect.me.xml
+++ b/src/chrome/content/rules/Connect.me.xml
@@ -1,22 +1,16 @@
-<!--
-	^connect.me: Expired, missing certificate chain
-	www.connect.me: Refused
-
--->
 <ruleset name="Connect.me">
 
 	<!--	Complications:
 				-->
-  <target host="connect.me"/>
   <target host="www.connect.me"/>
 
 
 	<!--	Redirect keeps path and args,
 		but not forward slash:
 					-->
-	<rule from="^http://(?:www\.)?connect\.me/+"
-		to="https://www.respectnetwork.com/connect-me-2/" />
+	<rule from="^http:"
+		to="https:" />
 
-		<test url="http://connect.me//" />
+		<test url="http://www.connect.me/" />
 
 </ruleset>


### PR DESCRIPTION
The previous ruleset was pointing to another domain that was
generating a 404. It now simply replaces http with https. Also,
it now only handles www.connect.me.