### PR TITLE
Remove unnecessary exclusion from CNBC.com.xml

### DIFF
--- a/src/chrome/content/rules/CNBC.com.xml
+++ b/src/chrome/content/rules/CNBC.com.xml
@@ -29,12 +29,6 @@
 <ruleset name="CNBC.com (partial)">
 	<target host="cnbc.com" />
 	<target host="www.cnbc.com" />
-	<exclusion pattern="^http://www\.cnbc\.com/$" />
-		<test url="http://www.cnbc.com/fonts/fontawesome-webfont.woff2?v=4.3.0" />
-		<test url="http://www.cnbc.com/fonts/cnbc_font_icons.woff?-k1ej6q" />
-		<test url="http://www.cnbc.com/staticContent/showads.js" />
-		<test url="http://www.cnbc.com/staticcontent/global.2.css?vn=399" />
-		<test url="http://www.cnbc.com/staticcontent/home_page_ng.css?vn=399" />
 	<target host="commentsapi.cnbc.com" />
 	<target host="fm.cnbc.com" />
 		<test url="http://fm.cnbc.com/applications/cnbc.com/resources/img/editorial/2016/09/14/103940717-DSC_3362-2.350x197.jpg" />
@@ -56,13 +50,5 @@
 	<target host="register.cnbc.com" />
 	<target host="pages.response.cnbc.com" />
 
-	<rule from="^http://cnbc\.com/" 
-			to="https://cnbc.com/" />
-	
-	<rule from="^http://(commentsapi|fm|gdsapi|login|media|mps|portfolio|pro|quote|register|pages\.response)\.cnbc\.com/"
-			to="https://$1.cnbc.com/" />
-
-	<rule from="^http://www\.cnbc\.com/(fonts|staticcontent|staticContent)/" 
-			to="https://www.cnbc.com/$1/" />
-
+	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/CNBC.com.xml
+++ b/src/chrome/content/rules/CNBC.com.xml
@@ -17,7 +17,6 @@
 			 - bigdata.cnbc.com
 
 		Secure connection redirects to plaintext:
-			 - www.cnbc.com
 			 - deliveringalpha.cnbc.com
 			 - futuresnow.cnbc.com
 			 - watchlist.cnbc.com


### PR DESCRIPTION
`http://cnbc.com`  now redirect (301) to `http://www.cnbc.com` which work over HTTPS correctly. 