### PR TITLE
Re-activate and Update Red_Bull.xml

### DIFF
--- a/src/chrome/content/rules/Red_Bull.xml
+++ b/src/chrome/content/rules/Red_Bull.xml
@@ -1,221 +1,66 @@
-
 <!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://redbull.co.uk/ => https://www.redbull.com/uk/en: invalid group reference at position 13 ^http://(?:launchpad|twtvsl)\.redbullusa\.com/
-Fetch error: http://augmentedracing.redbull.es/ => https://augmentedracing.redbull.es/: (6, 'Could not resolve host: augmentedracing.redbull.es')
-Fetch error: http://cricket.redbull.in/ => https://cricket.redbull.in/: (51, "SSL: no alternative certificate subject name matches target host name 'cricket.redbull.in'")
-Fetch error: http://forage.redbull.ru/ => https://forage.redbull.ru/: (51, "SSL: no alternative certificate subject name matches target host name 'forage.redbull.ru'")
-Fetch error: http://redbullusa.com/ => https://www.redbull.com/us/en: invalid group reference at position 13 ^http://(?:launchpad|twtvsl)\.redbullusa\.com/
-
-Disabled by https-everywhere-checker because:
-Fetch error: http://cricket.redbull.in/ => https://cricket.redbull.in/: (51, "SSL: no alternative certificate subject name matches target host name 'cricket.redbull.in'")
 	Other Red Bull rulesets:
+		+ Kart_Fighter.com.xml
+		+ Red_Bull_Content_Pool.xml
+		+ Red_Bull_Media_House.xml
+		+ Red_Bull_Mobile.xml
+		+ Red_Bull_TV.xml
+		+ Wiiings.com.xml
 
-		- Red_Bull_Content_Pool.xml
-		- Red_Bull_Media_House.xml
-		- Red_Bull_Mobile.xml
-		- Red_Bull_TV.xml
-		- Kart_Fighter.com.xml
-		- Wiiings.com.xml
+	Non-functional hosts
+		Timeout was reached:
+		- flugtagglasaj.redbull.com
 
+		SSL peer certificate was not OK:
+		- creativearchive-staging.redbull.com
+		- energydrink-at.redbull.com
+		- energydrink-de.redbull.com
+		- energydrink-fr.redbull.com
+		- energydrink-it.redbull.com
+		- energydrink-uk.redbull.com
+		- energydrink-us.redbull.com
+		- enterdannysmind.redbull.com
+		- forage.redbull.com
+		- games.redbull.com
+		- soapbox.redbull.com
+		- stage-energydrink.redbull.com
 
-	Nonfunctional domains:
+		4xx client error:
+		- create.redbull.com
+		- creativearchive-test.redbull.com
 
-		- redbull.com subdomains:
+		5xx server error:
+		- editorial.redbull.com
 
-			- energydrink-fr *
-			- flugtagglasaj		(shows hmapps.net; mismatched, CN: hmapps.net)
-			- games **
-			- rbx00412.microsites *
-
-		- trabajaconnosotros.redbull.es *
-		- score.redbull.mobi		(times out)
-		- atwork.redbull.ua **
-		- forage.redbull.ua **
-
-	* Refused
-	** Reset
-
-
-	Problematic domains:
-
-		- redbull.co.uk *
-		- www.redbull.co.uk **
-		- soapbox.redbull.com **
-		- redbull.(de|es|fr|in|no|ru|se|ua) *
-		- www.redbull.(de|es|fr|in|no|ru|se|ua) **
-		- redbullusa.com *
-		- www.redbullusa.com **
-
-	* Mismatched
-	** Reset
-
-
-	Partially covered domains:
-
-		- (www.)redbull.co.uk	(→ www.redbull.com)
-		- soapbox.redbull.com				(→ www)
-		- (www.)redbull.(de|es|fr|in|no|ru|se|ua)	(→ www.redbull.com)
-		- (www.)redbullusa.com				(→ www.redbull.com)
-
-
-	Fully covered domains:
-
-		- redbull.co.uk subdomains:
-
-			- challengetravis
-			- enterdannysmind
-			- formembed
-			- admin.rbri2012
-
-		- redbull.com subdomains:
-
-			- (www.)
-			- api
-			- athletewidget
-			- balconyshot-game
-			- cache-workbench
-			- confluence
-			- connect
-			- create
-			- creativearchive
-			- creativearchive-staging
-			- creativearchive-test
-			- editorial
-			- energydrink
-			- energydrink-at
-			- energydrink-de
-			- energydrink-it
-			- energydrink-uk
-			- energydrink-us
-			- enterdannysmind
-			- eventwidget
-			- forage
-			- gigya
-			- gigya-tests
-			- image
-			- image[123]
-			- infonet
-			- infonet2
-			- rbx00185.microsites
-			- mobile-ads
-			- stage-api
-			- stage-connect
-			- stage-energydrink
-			- streetstyle-game
-			- tibbr
-			- tibbr-ext
-			- tools
-			- trickshot-game
-			- workbench
-
-		- kontakt.redbull.de
-		- sugarfree.redbull.de
-		- augmentedracing.redbull.es
-		- cricket.redbull.in
-		- forage.redbull.ru
-		- lab.redbulls.com
-		- training.redbulls.com
-		- launchpad.redbullusa.com
-		- twtvsl.redbullusa.com
-
-
-	Mixed content:
-
-		- Images on www.redbull.com from image\d.redbull.com *
-
-		- Web bugs, on www.redbull.com from:
-
-			- redbull01.webtrekk.net *
-			- statse.webtrendslive.com *
-
-	* Secured by us
-
+		Mixed content blocking (MCB) triggered:
+		- balconyshot-game.redbull.com
+		- energydrink.redbull.com
+		- gigya.redbull.com
+		- rbx00185.microsites.redbull.com
+		- streetstyle-game.redbull.com
+		- trickshot-game.redbull.com
 -->
-<ruleset name="Red Bull (partial)" default_off='failed ruleset test'>
+<ruleset name="Red Bull.com (partial)">
+	<target host="redbull.com" />
+	<target host="api.redbull.com" />
+	<target host="athletewidget.redbull.com" />
+	<target host="connect.redbull.com" />
+	<target host="creativearchive.redbull.com" />
+	<target host="eventwidget.redbull.com" />
+	<target host="gigya-tests.redbull.com" />
+	<target host="image.redbull.com" />
+	<target host="image1.redbull.com" />
+	<target host="image2.redbull.com" />
+	<target host="image3.redbull.com" />
+	<target host="infonet.redbull.com" />
+	<target host="infonet2.redbull.com" />
+	<target host="rbx00412.microsites.redbull.com" />
+	<target host="mobile-ads.redbull.com" />
+	<target host="stage-api.redbull.com" />
+	<target host="stage-connect.redbull.com" />
+	<target host="tools.redbull.com" />
+	<target host="workbench.redbull.com" />
+	<target host="www.redbull.com" />
 
-	<target host="redbull.*" />
-	<target host="www.redbull.*" />
-	<target host="redbull.co.uk" />
-	<target host="*.redbull.co.uk" />
-	<target host="*.redbull.com" />
-	<target host="*.redbull.de" />
-	<target host="augmentedracing.redbull.es" />
-	<target host="cricket.redbull.in" />
-	<target host="forage.redbull.ru" />
-	<target host="*.redbulls.com" />
-	<target host="redbullusa.com" />
-	<target host="*.redbullusa.com" />
-
-
-	<securecookie host="^(?:challengetravis|enterdannysmind|formembed|admin\.rbri2012)\.redbull\.co\.uk$" name=".+" />
-	<securecookie host="^(?:(?:api|athletewidget|balconyshot-game|cache-workbench|connect|create|creativearchive(?:-staging|-test)?|energydrink|energydrink-(?:at|de|it|uk|us)|enterdannysmind|eventwidget|forage|giga|gigya-tests|image\d?|infonet2?|rbx00185\.microsites|mobile-ads|stage-(?:api|connect|energydrink)|streetstyle-game|tibbr|tools|trickshot-game|workbench|www)\.)?redbull\.com$" name=".+" />
-	<securecookie host="^(?:kontakt|sugarfree)\.redbull\.de$" name=".+" />
-	<securecookie host="^augmentedracing\.redbull\.es$" name=".+" />
-	<securecookie host="^cricket\.redbull\.in$" name=".+" />
-	<securecookie host="^forage\.redbull\.ru$" name=".+" />
-	<securecookie host="^(?:lab|training)\.redbulls\.com$" name=".+" />
-	<securecookie host="^(?:launchpad|twtvsl)\.redbullusa\.com$" name=".+" />
-
-
-	<rule from="^http://(?:www\.)?redbull\.co\.uk/(\?.*)?$"
-		to="https://www.redbull.com/uk/en$1" />
-
-	<rule from="^http://(?:www\.)?redbull\.(?:co\.uk|\w\w)/cs/"
-		to="https://www.redbull.com/cs/" />
-
-	<rule from="^http://(challengetravis|enterdannysmind|formembed|admin\.rbri2012)\.redbull\.co\.uk/"
-		to="https://$1.redbull.co.uk/" />
-
-	<rule from="^http://((?:api|athletewidget|balconyshot-game|confluence|connect|create|creativearchive(?:-staging|-test)?|editorial|energydrink|energydrink-(?:at|de|it|uk|us)|enterdannysmind|eventwidget|forage|gigya|gigya-tests|image\d?|infonet2?|rbx00185\.microsites|mobile-ads|stage-(?:api|connect|energydrink)|streetstyle-game|tibbr|tibbr-ext|tools|trickshot-game|workbench|www)\.)?redbull\.com/"
-		to="https://$1redbull.com/" />
-
-	<rule from="^http://soapbox\.redbull\.com/(?:\?.*)?$"
-		to="https://www.redbull.com/" />
-
-	<rule from="^http://(?:www\.)?redbull\.de/(\?.*)?$"
-		to="https://www.redbull.com/cs/Satellite/de_DE/RED-BULL-DE/001242746061488$1" />
-
-	<rule from="^http://(kontakt|sugarfree)\.redbull\.de/"
-		to="https://$1.redbull.de/" />
-
-	<rule from="^http://(?:www\.)?redbull\.es/(\?.*)?$"
-		to="https://www.redbull.com/cs/Satellite/es_ES/RED-BULL-ES/001242746062075$1" />
-
-	<rule from="^http://augmentedracing\.redbull\.es/"
-		to="https://augmentedracing.redbull.es/" />
-
-	<rule from="^http://(?:www\.)?redbull\.fr/(\?.*)?$"
-		to="https://www.redbull.com/cs/Satellite/fr_FR/RED-BULL-Home-page_FR/001242746062375$1" />
-
-	<rule from="^http://(?:www\.)?redbull\.in/(\?.*)?$"
-		to="https://www.redbull.com/cs/Satellite/en_IN/Red-Bull-Home/001242877412074$1" />
-
-	<rule from="^http://cricket\.redbull\.in/"
-		to="https://cricket.redbull.in/" />
-
-	<rule from="^http://(?:www\.)?redbull\.no/(\?.*)?$"
-		to="https://www.redbull.com/cs/Satellite/no_NO/RedBull/001242760618750$1" />
-
-	<rule from="^http://(?:www\.)?redbull\.ru/(\?.*)?$"
-		to="https://www.redbull.com/cs/Satellite/ru_RU/Red-Bull-Russia/001242758643321$1" />
-
-	<rule from="^http://forage\.redbull\.ru/"
-		to="https://forage.redbull.ru/" />
-
-	<rule from="^http://(?:www\.)?redbull\.se/(\?.*)?$"
-		to="https://www.redbull.com/cs/Satellite/sv_SE/REDBULL/001242760548154$1" />
-
-	<rule from="^http://(?:www\.)?redbull\.ua/(\?.*)?$"
-		to="https://www.redbull.com/cs/Satellite/ru_UA/Red-Bull/001242776437928$1" />
-
-	<rule from="^http://(lab|training)\.redbulls\.com/"
-		to="https://$1.redbulls.com/" />
-
-	<rule from="^http://(?:www\.)?redbullusa\.com/(?:\?.*)?$"
-		to="https://www.redbull.com/us/en" />
-
-	<rule from="^http://(?:launchpad|twtvsl)\.redbullusa\.com/"
-		to="https://$1.redbullusa.com/" />
-
+	<rule from="^http:" to="https:" />
 </ruleset>


### PR DESCRIPTION
#11203 It seems that only `*redbull.com` support HTTPS properly and other ccTLD simply redirect to `redbull.com`, see [`Red_Bull.xml (old)`](https://gist.github.com/cschanaj/0ac81bf991af720efec4959f59c836f4). 

P.S. All domains are extracted from the existing rule manually, so I might have missed some of them.

List of domains covered in the existing rulesets
```
redbull.com
api.redbull.com
athletewidget.redbull.com
balconyshot-game.redbull.com
cache-workbench.redbull.com
confluence.redbull.com
connect.redbull.com
create.redbull.com
creativearchive.redbull.com
creativearchive-staging.redbull.com
creativearchive-test.redbull.com
editorial.redbull.com
energydrink.redbull.com
energydrink-at.redbull.com
energydrink-de.redbull.com
energydrink-fr.redbull.com
energydrink-it.redbull.com
energydrink-uk.redbull.com
energydrink-us.redbull.com
enterdannysmind.redbull.com
eventwidget.redbull.com
flugtagglasaj.redbull.com
forage.redbull.com
games.redbull.com
gigya.redbull.com
gigya-tests.redbull.com
image.redbull.com
image1.redbull.com
image2.redbull.com
image3.redbull.com
image4.redbull.com
image5.redbull.com
image6.redbull.com
image7.redbull.com
image8.redbull.com
image9.redbull.com
infonet.redbull.com
infonet2.redbull.com
rbx00185.microsites.redbull.com
rbx00412.microsites.redbull.com
mobile-ads.redbull.com
soapbox.redbull.com
stage-api.redbull.com
stage-connect.redbull.com
stage-energydrink.redbull.com
streetstyle-game.redbull.com
tibbr.redbull.com
tibbr-ext.redbull.com
tools.redbull.com
trickshot-game.redbull.com
workbench.redbull.com
www.redbull.com
lab.redbulls.com
training.redbulls.com
redbullusa.com
launchpad.redbullusa.com
twtvsl.redbullusa.com
www.redbullusa.com
redbull.de
kontakt.redbull.de
sugarfree.redbull.de
www.redbull.de
redbull.es
augmentedracing.redbull.es
trabajaconnosotros.redbull.es
www.redbull.es
redbull.fr
www.redbull.fr
redbull.in
cricket.redbull.in
www.redbull.in
redbull.no
www.redbull.no
redbull.ru
forage.redbull.ru
www.redbull.ru
redbull.ua
atwork.redbull.ua
forage.redbull.ua
www.redbull.ua
redbull.co.uk
challengetravis.redbull.co.uk
enterdannysmind.redbull.co.uk
formembed.redbull.co.uk
admin.rbri2012.redbull.co.uk
www.redbull.co.uk
```