### PR TITLE
Update ruleset-coverage-whitelist-cleanup.sh

### DIFF
--- a/utils/ruleset-coverage-whitelist-cleanup.sh
+++ b/utils/ruleset-coverage-whitelist-cleanup.sh
@@ -36,7 +36,7 @@ DELIM=","
   fi
 done) < "$WLIST"
 
-# Sorting by the second column (ruleset name)
+# Sorting by the 4th column (ruleset name)
 TMPFILE=`mktemp`
-(head -n1 "$WLIST" && tail -n +2 "$WLIST" | sort -t"," -b -u -k3) > "$TMPFILE"
+(head -n1 "$WLIST" && tail -n +2 "$WLIST" | sort -t"," -b -u -k4) > "$TMPFILE"
 mv "$TMPFILE" "$WLIST"


### PR DESCRIPTION
@Hainish it should be the 4th column if we are sorting according to the filenames. It is _sorted by the third column, then by the fourth column_ currently, leading to strange sorting in #11865 thank!

Also, please run the cleanup script for once after this has been merged.