### PR TITLE
Created ruleset for theanarchistlibrary

### DIFF
--- a/src/chrome/content/rules/theanarchistlibrary.xml
+++ b/src/chrome/content/rules/theanarchistlibrary.xml
@@ -1,0 +1,11 @@
+<ruleset name="theanarchistlibrary">
+  <target host="*.theanarchistlibrary.org" />
+  <target host="theanarchistlibrary.org" />
+  <target host="anarhisticka-biblioteka.net" />
+  <target host="anarhisticka-biblioteka.org" />
+  <target host="anarchistischebibliothek.org" />
+  
+
+  <rule from="^http:"
+          to="https:" />
+</ruleset>


### PR DESCRIPTION
Added rules for theanarchistlibrary.org, its subdomains (such as fr.theanarchistlibrary.org) and other domains.