### PR TITLE
Create ogdb.eu.xml

### DIFF
--- a/src/chrome/content/rules/ogdb.eu.xml
+++ b/src/chrome/content/rules/ogdb.eu.xml
@@ -1,0 +1,6 @@
+<ruleset name="ogdb.eu">
+	<target host="ogdb.eu" />
+	<target host="www.ogdb.eu" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>


### PR DESCRIPTION
Hello,

this is my first contribution to the **HTTPS Everywhere** project.

While I didn't notice any major page malfunctioning i.e. missing images etc., there seems to be a problem with the password field located on the left side of the page.

When opening https://ogdb.eu/ with my normal Firefox profile and clicking on the `Login` button I get the following **security warning**:

> The information you have entered on this page will be sent over an insecure connection and could be read by a third party.
> 
> Are you sure you want to send this information?

Running Firefox with a test profile with the command `bash test/firefox.sh --justrun` and opening the login link triggers the same message. Running Firefox in the normal configuration and actually clicking on the login link will redirect you to the unencrypted page http://ogdb.eu/loginprocess.php. Doing the same with the firefox.sh shell script however, will redirect you to the encrypted version https://ogdb.eu/loginprocess.php. I assume this problem arises from the following HTML excerpt:

```html
<form method="POST" action="http://ogdb.eu/loginprocess.php">
```

**HTTPS Everywhere** seems to redirect to the encrypted version, I am not sure however, if the password itself is actually sent over SSL or not.