### PR TITLE
Create cebix.net.xml

### DIFF
--- a/src/chrome/content/rules/cebix.net.xml
+++ b/src/chrome/content/rules/cebix.net.xml
@@ -1,0 +1,13 @@
+<ruleset name="cebix.net">
+	<target host="cebix.net" />
+	<target host="www.cebix.net" />
+	<target host="alephone.cebix.net" />
+	<target host="basilisk.cebix.net" />
+	<target host="cxmon.cebix.net" />
+	<target host="frodo.cebix.net" />
+	<target host="shapeshifter.cebix.net" />
+	<target host="sheepshaver.cebix.net" />
+	<target host="sidplayer.cebix.net" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>


### PR DESCRIPTION
With this ruleset the site runs fine in HTTPS, there are a few embedded image files however which are either unavailable or not secured.

On the subdomain https://alephone.cebix.net/ you will be receiving this:
> Loading mixed (insecure) display content “http://sflogo.sourceforge.net/sflogo.php?group_id=1997&type=13” on a secure page

Visiting https://cebix.net/beos.html will output the following:
> Loading mixed (insecure) display content “http://www.planbe.com/images/bering.gif” on a secure page

The miscellaneous part of the website https://cebix.net/misc.html leads to this:
> Loading mixed (insecure) display content “http://www.vierpfeile.de/vierpfeile_b1a.gif” on a secure page
> Loading mixed (insecure) display content “http://superwailingbonus.com/totalrecall/1697sp.png” on a secure page
> Loading mixed (insecure) display content “http://superwailingbonus.com/totalrecall/1697dp.png” on a secure page
> Loading mixed (insecure) display content “http://iidx.solidstatesquad.com/siginclude/97.png” on a secure page

Then there is a section containing various photos made in Japan, split into 2 pages which are https://www.cebix.net/photos/japan/ and https://www.cebix.net/photos/japan2/ as well as a miscellaneous photo page located at https://www.cebix.net/photos/misc/ which all lead to the following messages in the browser console:
> Loading mixed (insecure) display content “http://creativecommons.org/images/public/somerights.png” on a secure page
> Loading mixed (insecure) display content “https://creativecommons.org/images/public/somerights.png” on a secure page

In an effort to fix this I tried out the following rules to fix this to no avail:

```xml
<rule from="^http://creativecommons\.org/" to="https://creativecommons.org/" />
<rule from="^http://iidx\.solidstatesquad\.com/" to="https://iidx.solidstatesquad.com/" />
<rule from="^http://sflogo\.sourceforge\.net/" to="https://sflogo.sourceforge.net/" />
<rule from="^http://sourceforge\.net/" to="https://sourceforge.net/" />
<rule from="^http://superwailingbonus\.com/" to="https://superwailingbonus.com/" />
<rule from="^http://www\.vierpfeile\.de/" to="https://www.vierpfeile.de/" />
```