### PR TITLE
OSnews submission form doesn’t work over HTTPS

### DIFF
--- a/src/chrome/content/rules/osnews.com.xml
+++ b/src/chrome/content/rules/osnews.com.xml
@@ -2,5 +2,8 @@
 	<target host="osnews.com" />
 	<target host="www.osnews.com" />
 
+	<!-- submission of form only works over HTTP -->
+	<exclusion pattern="^http://(www\.)?osnews\.com/submit" />
+
 	<rule from="^http:" to="https:" />
 </ruleset>


### PR DESCRIPTION
Preview button doesn’t work, so can’t progress to submission. Form works when loaded over HTTP.