### PR TITLE
[01.org] Update ruleset.

### DIFF
--- a/src/chrome/content/rules/01.org.xml
+++ b/src/chrome/content/rules/01.org.xml
@@ -1,29 +1,17 @@
 <!--
+
 	For other Intel coverage, see Intel.xml.
-
-
-	Mixed content:
-
-		- Images on ^ from www.gravatar.com *
-
-	* Secured by us
 
 -->
 <ruleset name="01.org">
 
-	<!--	Direct rewrites:
-				-->
 	<target host="01.org" />
-	<target host="lists.01.org" />
 	<target host="www.01.org" />
-
-	<!--	Complications:
-				-->
-	<target host="mx.01.org" />
-
-
-	<rule from="^http://mx\.01\.org/"
-		to="https://lists.01.org/mailman/listinfo" />
+	<target host="download.01.org" />
+	<target host="intel-iot-refkit.01.org" />
+	<target host="lists.01.org" />
+	<target host="ml01.01.org" />
+	<target host="origin-download.01.org" />
 
 	<rule from="^http:"
 		to="https:" />


### PR DESCRIPTION
`mx` is gone from dns.