### PR TITLE
Trivialize some securecookie rulesets too

### DIFF
--- a/src/chrome/content/rules/1nsk.ru.xml
+++ b/src/chrome/content/rules/1nsk.ru.xml
@@ -23,7 +23,6 @@ Fetch error: http://live.1nsk.ru/ => https://live.1nsk.ru/: (28, 'Connection tim
 	<securecookie host="^live\.1nsk\.ru$" name=".+" />
 
 
-	<rule from="^http://live\.1nsk\.ru/"
-		to="https://live.1nsk.ru/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/5NINES.xml
+++ b/src/chrome/content/rules/5NINES.xml
@@ -17,7 +17,6 @@ Fetch error: http://portal.5ninesdata.com/ => https://portal.5ninesdata.com/: (2
 	<securecookie host="^portal\.5ninesdata\.com$" name=".*" />
 
 
-	<rule from="^http://portal\.5ninesdata\.com/"
-		to="https://portal.5ninesdata.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/ACTION_Kooperative.xml
+++ b/src/chrome/content/rules/ACTION_Kooperative.xml
@@ -14,7 +14,6 @@ Fetch error: http://mail.action.at/ => https://mail.action.at/: (51, "SSL: no al
 	<securecookie host="^mail\.action\.at$" name=".+" />
 
 
-	<rule from="^http://mail\.action\.at/"
-		to="https://mail.action.at/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/ARM.com-problematic.xml
+++ b/src/chrome/content/rules/ARM.com-problematic.xml
@@ -13,7 +13,6 @@
 	<securecookie host="^(?:i|malidevelope)r\.arm\.com$" name=".+" />
 
 
-	<rule from="^http://(i|malidevelope)r\.arm\.com/"
-		to="https://$1r.arm.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/ASN_Bank.nl-problematic.xml
+++ b/src/chrome/content/rules/ASN_Bank.nl-problematic.xml
@@ -14,7 +14,6 @@
 	<securecookie host="^nieuws\.asnbank\.nl$" name=".+" />
 
 
-	<rule from="^http://nieuws\.asnbank\.nl/"
-		to="https://nieuws.asnbank.nl/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/AWeber-Communications.xml
+++ b/src/chrome/content/rules/AWeber-Communications.xml
@@ -5,6 +5,5 @@
 
 	<securecookie host="^(?:forms|help|labs)\.aweber\.com$" name=".+" />
 
-	<rule from="^http://(forms|help|labs)\.aweber\.com/"
-		to="https://$1.aweber.com/" />
+	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Add2Net-mismatches.xml
+++ b/src/chrome/content/rules/Add2Net-mismatches.xml
@@ -4,7 +4,6 @@
 
 	<securecookie host="^marketing\.lunarpages\.com$" name=".*"/>
 
-	<rule from="^http://marketing\.lunarpages\.com/"
-		to="https://marketing.lunarpages.com/"/>
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Agence-France-Presse.xml
+++ b/src/chrome/content/rules/Agence-France-Presse.xml
@@ -7,7 +7,6 @@
 	<securecookie host="^ediplomacy\.afp\.com$" name=".*" />
 
 
-	<rule from="^http://ediplomacy\.afp\.com/"
-		to="https://ediplomacy.afp.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Antevenio.xml
+++ b/src/chrome/content/rules/Antevenio.xml
@@ -18,7 +18,6 @@ Fetch error: http://reachandrich.antevenio.com/ => https://reachandrich.anteveni
 	<securecookie host="^reachandrich\.antevenio\.com$" name=".+" />
 
 
-	<rule from="^http://reachandrich\.antevenio\.com/"
-		to="https://reachandrich.antevenio.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Aufbix.org-problematic.xml
+++ b/src/chrome/content/rules/Aufbix.org-problematic.xml
@@ -10,7 +10,6 @@
 	<securecookie host="^tnt\.aufbix\.org$" name=".+" />
 
 
-	<rule from="^http://tnt\.aufbix\.org/"
-		to="https://tnt.aufbix.org/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Axamba.xml
+++ b/src/chrome/content/rules/Axamba.xml
@@ -12,7 +12,6 @@ Fetch error: http://my.webtapestry.net/ => https://my.webtapestry.net/: (28, 'Co
 
 	<securecookie host="^my\.webtapestry\.net$" name=".*"/>
 
-	<rule from="^http://my\.webtapestry\.net/"
-		to="https://my.webtapestry.net/"/>
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Axboe.xml
+++ b/src/chrome/content/rules/Axboe.xml
@@ -18,7 +18,6 @@ Fetch error: http://webmail.axboe.dk/ => https://webmail.axboe.dk/: (60, 'SSL ce
 	<securecookie host="^webmail\.axboe\.dk$" name=".*" />
 
 
-	<rule from="^http://webmail\.axboe\.dk/"
-		to="https://webmail.axboe.dk/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Biddeal.xml
+++ b/src/chrome/content/rules/Biddeal.xml
@@ -14,7 +14,6 @@ Fetch error: http://www.biddeal.com/ => https://www.biddeal.com/: (60, 'SSL cert
 	<securecookie host="^\.(?:www\.)?biddeal\.com$" name=".+" />
 
 
-	<rule from="^http://www\.biddeal\.com/"
-		to="https://www.biddeal.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Bravenet_Media.xml
+++ b/src/chrome/content/rules/Bravenet_Media.xml
@@ -29,7 +29,6 @@ Fetch error: http://redvase.bravenet.com/ => https://redvase.bravenet.com/: (60,
 	<securecookie host="^redvase\.bravenet\.com$" name=".+" />
 
 
-	<rule from="^http://redvase\.bravenet\.com/"
-		to="https://redvase.bravenet.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Breakfast-Quay.xml
+++ b/src/chrome/content/rules/Breakfast-Quay.xml
@@ -10,8 +10,7 @@ Fetch error: http://code.breakfastquay.com/ => https://code.breakfastquay.com/: 
 
 	<target host="code.breakfastquay.com"/>
 
-	<rule from="^http://code\.breakfastquay\.com/"
-		to="https://code.breakfastquay.com/"/>
+	<rule from="^http:" to="https:" />
 
 	<securecookie host="^code\.breakfastquay\.com$" name=".*"/>
 

--- a/src/chrome/content/rules/Burning-Shed.xml
+++ b/src/chrome/content/rules/Burning-Shed.xml
@@ -7,6 +7,5 @@
 	<securecookie host="^(?:www\.)?burningshed\.co(?:m|(?:\.uk))$"
 			name=".+" />
 
-	<rule from="^http://(www\.)?burningshed\.co(m|(\.uk))/"
-		to="https://$1burningshed.co$2/" />
+	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/CBS_Local.xml
+++ b/src/chrome/content/rules/CBS_Local.xml
@@ -6,7 +6,6 @@
 	<securecookie host="^sacramento\.cbslocal\.com$" name=".+" />
 
 
-	<rule from="^http://sacramento\.cbslocal\.com/"
-		to="https://sacramento.cbslocal.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Cactus_Complete_Commerce.xml
+++ b/src/chrome/content/rules/Cactus_Complete_Commerce.xml
@@ -19,7 +19,6 @@ Fetch error: http://app.cactuscompletecommerce.com/ => https://app.cactuscomplet
 	<securecookie host="^app\.cactuscompletecommerce\.com$" name=".+" />
 
 
-	<rule from="^http://app\.cactuscompletecommerce\.com/"
-		to="https://app.cactuscompletecommerce.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/California-Franchise-Tax-Board.xml
+++ b/src/chrome/content/rules/California-Franchise-Tax-Board.xml
@@ -12,6 +12,5 @@
 	<test url="http://stats.ftb.ca.gov/dcsk16hof000004bfefbkcw6o_1f9b/njs.gif?dcsuri=/nojavascript&amp;WT.js=No&amp;WT.tv=10.4.1&amp;dcssip=www.ftb.ca.gov" />
 	<test url="http://webapp.ftb.ca.gov/MyFTBAccess/iUserName.aspx" />
 
-	<rule from="^http://((stats|webapp|www)\.)?ftb\.ca\.gov/"
-		to="https://$1ftb.ca.gov/" />
+	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Canadian_Institute_of_Chartered_Accountants.xml
+++ b/src/chrome/content/rules/Canadian_Institute_of_Chartered_Accountants.xml
@@ -18,7 +18,6 @@ Fetch error: http://secure.cica.ca/ => https://secure.cica.ca/: (60, 'SSL certif
 	<securecookie host="^secure\.cica\.ca$" name=".+" />
 
 
-	<rule from="^http://secure\.cica\.ca/"
-		to="https://secure.cica.ca/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Carecareers.com.au.xml
+++ b/src/chrome/content/rules/Carecareers.com.au.xml
@@ -28,7 +28,6 @@ Fetch error: http://jobs.carecareers.com.au/ => https://jobs.carecareers.com.au/
 	<securecookie host="^jobs\.carecareers\.com\.au$" name=".+" />
 
 
-	<rule from="^http://jobs\.carecareers\.com\.au/"
-		to="https://jobs.carecareers.com.au/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Carnegie-Mellon-University-mismatches.xml
+++ b/src/chrome/content/rules/Carnegie-Mellon-University-mismatches.xml
@@ -14,7 +14,6 @@
 		repository cookie is handled in Carnegie-Mellon-University.xml.	-->
 
 
-	<rule from="^http://(athletics|portal\.etc|repository)\.cmu\.edu/"
-		to="https://$1.cmu.edu/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Cheap-Ass-Gamer.xml
+++ b/src/chrome/content/rules/Cheap-Ass-Gamer.xml
@@ -6,6 +6,5 @@
 	<securecookie host="(\.|^)cheapassgamer\.com$"
 			name=".+" />
 
-	<rule from="^http://((cache|www)\.)?cheapassgamer\.com/"
-		to="https://$1cheapassgamer.com/" />
+	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Childrens_Mutual.xml
+++ b/src/chrome/content/rules/Childrens_Mutual.xml
@@ -15,7 +15,6 @@
 	<securecookie host="^ctf\.thechildrensmutual\.co\.uk$" name=".+" />
 
 
-	<rule from="^http://ctf\.thechildrensmutual\.co\.uk/"
-		to="https://ctf.thechildrensmutual.co.uk/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/ChipLand.hu.xml
+++ b/src/chrome/content/rules/ChipLand.hu.xml
@@ -10,5 +10,5 @@ Fetch error: http://www.chipland.hu/ => https://www.chipland.hu/: (60, 'SSL cert
 	<target host="www.chipland.hu" />
 
 	<securecookie host="^www\.chipland\.hu$" name=".+" />
-	<rule from="^http://www\.chipland\.hu/" to="https://www.chipland.hu/" />
+	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Claranet-mismatches.xml
+++ b/src/chrome/content/rules/Claranet-mismatches.xml
@@ -5,10 +5,6 @@
 
 	<securecookie host="^admin-vh\.es\.clara\.net$" name=".*"/>
 
-	<rule from="^http://admin-vh\.es\.clara\.net/"
-		to="https://admin-vh.es.clara.net/"/>
-
-	<rule from="^http://signup\.claranet\.de/"
-		to="https://signup.claranet.de/"/>
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/CompaniesInTheUK.xml
+++ b/src/chrome/content/rules/CompaniesInTheUK.xml
@@ -4,6 +4,5 @@
 
   <securecookie host="^(?:.+\.)?companiesintheuk\.co\.uk$" name=".*"/>
 
-  <rule from="^http://companiesintheuk\.co\.uk/" to="https://companiesintheuk.co.uk/"/>
-  <rule from="^http://(www)\.companiesintheuk\.co\.uk/" to="https://$1.companiesintheuk.co.uk/"/>
+  <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Competitive_Enterprise_Institute.xml
+++ b/src/chrome/content/rules/Competitive_Enterprise_Institute.xml
@@ -21,7 +21,6 @@ Fetch error: http://shop.cei.org/ => https://shop.cei.org/: (60, 'SSL certificat
 	<securecookie host="^shop\.cei\.org$" name=".+" />
 
 
-	<rule from="^http://shop\.cei\.org/"
-		to="https://shop.cei.org/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Con-tech.de.xml
+++ b/src/chrome/content/rules/Con-tech.de.xml
@@ -23,7 +23,6 @@ Fetch error: http://ct-cds.con-tech.de/ => https://ct-cds.con-tech.de/: (7, 'Fai
 	<securecookie host="^ct-cds\.con-tech\.de$" name=".+" />
 
 
-	<rule from="^http://ct-cds\.con-tech\.de/"
-		to="https://ct-cds.con-tech.de/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Cronius.net.xml
+++ b/src/chrome/content/rules/Cronius.net.xml
@@ -28,7 +28,6 @@
 	<securecookie host="^webmanager\.cronius\.net$" name=".+" />
 
 
-	<rule from="^http://webmanager\.cronius\.net/"
-		to="https://webmanager.cronius.net/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Cyprus_Satellite.xml
+++ b/src/chrome/content/rules/Cyprus_Satellite.xml
@@ -18,7 +18,6 @@ Fetch error: http://forums.satellitecyprus.com/ => https://forums.satellitecypru
 	<securecookie host="^forums\.satellitecyprus\.com$" name=".+" />
 
 
-	<rule from="^http://forums\.satellitecyprus\.com/"
-		to="https://forums.satellitecyprus.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Deutschen-Forschungsgemeinschaft.xml
+++ b/src/chrome/content/rules/Deutschen-Forschungsgemeinschaft.xml
@@ -18,7 +18,6 @@
 	<securecookie host="^research-explorer\.dfg\.de$" name=".*" />
 
 
-	<rule from="^http://research-explorer\.dfg\.de/"
-		to="https://research-explorer.dfg.de/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/DilbertFiles.org.xml
+++ b/src/chrome/content/rules/DilbertFiles.org.xml
@@ -22,7 +22,6 @@ Fetch error: http://secure.dilbertfiles.com/ => https://secure.dilbertfiles.com/
 	<securecookie host="^secure\.dilbertfiles\.com$" name=".+" />
 
 
-	<rule from="^http://secure\.dilbertfiles\.com/"
-		to="https://secure.dilbertfiles.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/EE_Times-mixed.xml
+++ b/src/chrome/content/rules/EE_Times-mixed.xml
@@ -16,7 +16,6 @@ Fetch error: http://video.eetimes.com/ => https://video.eetimes.com/: (6, 'Could
 	<securecookie host="^video\.eetimes\.com$" name=".+" />
 
 
-	<rule from="^http://video\.eetimes\.com/"
-		to="https://video.eetimes.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/ENTP-clients.xml
+++ b/src/chrome/content/rules/ENTP-clients.xml
@@ -22,13 +22,6 @@
 	<securecookie host="^help\.goodsie\.com$" name=".*" />
 
 
-	<rule from="^http://support\.arpnetworks\.com/"
-		to="https://support.arpnetworks.com/" />
-
-	<rule from="^http://help\.flavors\.me/"
-		to="https://help.flavors.me/" />
-
-	<rule from="^http://help\.goodsie\.com/"
-		to="https://help.goodsie.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Eli-Lilly.xml
+++ b/src/chrome/content/rules/Eli-Lilly.xml
@@ -7,7 +7,6 @@
 	<securecookie host="^lillypad\.lilly\.c(?:a|om)$" name=".*" />
 
 
-	<rule from="^http://lillypad\.lilly\.c(a|om)/"
-		to="https://lillypad.lilly.c$1/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Emediate.eu.xml
+++ b/src/chrome/content/rules/Emediate.eu.xml
@@ -8,9 +8,6 @@
 	<securecookie host="^eas8\.emediate\.eu$" name=".+" />
 
 
-	<rule from="^http://eas4\.emediate\.eu/"
-		to="https://eas4.emediate.eu/" />
-	<rule from="^http://eas8\.emediate\.eu/"
-		to="https://eas8.emediate.eu/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Epek.xml
+++ b/src/chrome/content/rules/Epek.xml
@@ -22,7 +22,6 @@
 	<securecookie host="^signin\.epek\.com$" name=".*" />
 
 
-	<rule from="^http://signin\.epek\.com/"
-		to="https://signin.epek.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Eurogap.cz.xml
+++ b/src/chrome/content/rules/Eurogap.cz.xml
@@ -10,7 +10,6 @@
 	<securecookie host="^dealers\.eurogap\.cz$" name=".+" />
 
 
-	<rule from="^http://dealers\.eurogap\.cz/"
-		to="https://dealers.eurogap.cz/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Fairfax-Digital.xml
+++ b/src/chrome/content/rules/Fairfax-Digital.xml
@@ -57,10 +57,6 @@ Fetch error: http://ads.afraccess.com/ => https://ads.afraccess.com/: (28, 'Conn
 
 	<securecookie host="^membercentre\.fairfax\.com\.au$" name=".*" />
 
-	<rule from="^http://ads\.afraccess\.com/"
-		to="https://ads.afraccess.com/" />
-
-	<rule from="^http://membercentre\.fairfax\.com\.au/"
-		to="https://membercentre.fairfax.com.au/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/FastWebHost.com-mismatches.xml
+++ b/src/chrome/content/rules/FastWebHost.com-mismatches.xml
@@ -4,7 +4,6 @@
 
 	<securecookie host="^webmail\.fastwebhost\.com$" name=".*"/>
 
-	<rule from="^http://webmail\.fastwebhost\.com/"
-		to="https://webmail.fastwebhost.com/"/>
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Finam.xml
+++ b/src/chrome/content/rules/Finam.xml
@@ -10,8 +10,7 @@ Fetch error: http://fb.finam.ru/ => https://fb.finam.ru/: (28, 'Connection timed
 
 	<target host="fb.finam.ru"/>
 
-	<rule from="^http://fb\.finam\.ru/"
-		to="https://fb.finam.ru/"/>
+	<rule from="^http:" to="https:" />
 
 	<securecookie host="^fb\.finam\.ru$" name=".*"/>
 

--- a/src/chrome/content/rules/Fineproxy.org-problematic.xml
+++ b/src/chrome/content/rules/Fineproxy.org-problematic.xml
@@ -11,7 +11,6 @@
 	<securecookie host="^billingproxy\.fineproxy\.org$" name=".+" />
 
 
-	<rule from="^http://billingproxy\.fineproxy\.org/"
-		to="https://billingproxy.fineproxy.org/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Firedoglake.xml
+++ b/src/chrome/content/rules/Firedoglake.xml
@@ -22,7 +22,6 @@ Fetch error: http://members.firedoglake.com/ => https://members.firedoglake.com/
 	<securecookie host="^members\.firedoglake\.com$" name=".+" />
 
 
-	<rule from="^http://members\.firedoglake\.com/"
-		to="https://members.firedoglake.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Flurry-problematic.xml
+++ b/src/chrome/content/rules/Flurry-problematic.xml
@@ -10,7 +10,6 @@
 	<securecookie host="^blog\.flurry\.com$" name=".+" />
 
 
-	<rule from="^http://blog\.flurry\.com/"
-		to="https://blog.flurry.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Forthnet.gr.xml
+++ b/src/chrome/content/rules/Forthnet.gr.xml
@@ -15,5 +15,5 @@ Fetch error: http://services.forthnet.gr/ => https://services.forthnet.gr/: (56,
 	<securecookie host="^webmail.forthnet\.gr$" name=".*"/>
 	<securecookie host="^services.forthnet\.gr$" name=".*"/>
 
-  <rule from="^http://(webmail|services)\.forthnet\.gr/" to="https://$1.forthnet.gr/"/>
+  <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Frostmourne-WoW.eu.xml
+++ b/src/chrome/content/rules/Frostmourne-WoW.eu.xml
@@ -17,7 +17,6 @@
 	<securecookie host="^img\.frostmourne-wow\.eu$" name=".+" />
 
 
-	<rule from="^http://img\.frostmourne-wow\.eu/"
-		to="https://img.frostmourne-wow.eu/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/FusionNet.xml
+++ b/src/chrome/content/rules/FusionNet.xml
@@ -4,6 +4,5 @@
 
   <securecookie host="^(?:.+\.)?fusion-net.co.uk$" name=".*"/>
 
-  <rule from="^http://fusion-net\.co\.uk/" to="https://fusion-net.co.uk/"/>
-  <rule from="^http://www\.fusion-net\.co\.uk/" to="https://www.fusion-net.co.uk/"/>
+  <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Gemalto.com-problematic.xml
+++ b/src/chrome/content/rules/Gemalto.com-problematic.xml
@@ -12,7 +12,6 @@
 	<securecookie host="^support\.gemalto\.com$" name=".+" />
 
 
-	<rule from="^http://support\.gemalto\.com/"
-		to="https://support.gemalto.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Global-Marketing-Strategies.xml
+++ b/src/chrome/content/rules/Global-Marketing-Strategies.xml
@@ -39,19 +39,6 @@ Fetch error: http://www.howtowriteabookasap.com/ => https://www.howtowriteabooka
 	<securecookie host="^www\.termsofservicegenerator\.com$" name=".+" />
 
 
-	<rule from="^http://(www\.)?fanpagegeneratorpro\.com/"
-		to="https://$1fanpagegeneratorpro.com/" />
-
-	<rule from="^http://(www\.)?(free|professional)privacypolicy\.com/"
-		to="https://$1$2privacypolicy.com/" />
-
-	<rule from="^http://(www\.)?howtowriteabookasap\.com/"
-		to="https://$1howtowriteabookasap.com/" />
-
-	<rule from="^http://(www\.)?termsofservicegenerator\.com/"
-		to="https://$1termsofservicegenerator.com/" />
-
-	<rule from="^http://(www\.)?whatsuccesstakes\.com/"
-		to="https://$1whatsuccesstakes.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Globus.xml
+++ b/src/chrome/content/rules/Globus.xml
@@ -17,7 +17,6 @@
 	<securecookie host="^dev\.globus\.org$" name=".*" />
 
 
-	<rule from="^http://dev\.globus\.org/"
-		to="https://dev.globus.org/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Grassroots.org-mismatches.xml
+++ b/src/chrome/content/rules/Grassroots.org-mismatches.xml
@@ -11,7 +11,6 @@
 	<securecookie host="^tools\.grassroots\.org$" name=".*" />
 
 
-	<rule from="^http://tools\.grassroots\.org/"
-		to="https://tools.grassroots.org/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/GreenIT-BB.xml
+++ b/src/chrome/content/rules/GreenIT-BB.xml
@@ -16,7 +16,6 @@ Fetch error: http://benchmarking.greenit-bb.de/ => https://benchmarking.greenit-
 
 	<securecookie host="^benchmarking\.greenit-bb\.de$" name=".*"/>
 
-	<rule from="^http://benchmarking\.greenit-bb\.de/"
-		to="https://benchmarking.greenit-bb.de/"/>
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Grnh.se.xml
+++ b/src/chrome/content/rules/Grnh.se.xml
@@ -24,7 +24,6 @@
 	<securecookie host="^www\.grnh\.se$" name=".+" />
 
 
-	<rule from="^http://www\.grnh\.se/"
-		to="https://www.grnh.se/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/HMV.xml
+++ b/src/chrome/content/rules/HMV.xml
@@ -34,7 +34,7 @@
   <!--rule from="^http://www\.hmv\.com/" to="https://hmv.com/"/-->
   <!--rule from="^http://hmv\.co\.uk/" to="https://hmv.com/"/-->
   <!--rule from="^http://www\.hmv\.co\.uk/" to="https://hmv.com/"/-->
-  <rule from="^http://www3\.hmv\.co\.uk/" to="https://www3.hmv.co.uk/"/>
+  <rule from="^http:" to="https:" />
 
   <securecookie host="^hmv\.com$" name=".*"/>
 </ruleset>

--- a/src/chrome/content/rules/Host_One.xml
+++ b/src/chrome/content/rules/Host_One.xml
@@ -18,7 +18,6 @@ Fetch error: http://sugarcrm.hostone.com.au/ => https://sugarcrm.hostone.com.au/
 	<securecookie host="^sugarcrm\.hostone\.com\.au$" name=".+" />
 
 
-	<rule from="^http://sugarcrm\.hostone\.com\.au/"
-		to="https://sugarcrm.hostone.com.au/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/INDURE.xml
+++ b/src/chrome/content/rules/INDURE.xml
@@ -17,7 +17,6 @@ Fetch error: http://www.indure.org/ => https://www.indure.org/: (51, "SSL: no al
 	<securecookie host="^www\.indure\.org$" name=".+" />
 
 
-	<rule from="^http://www\.indure\.org/"
-		to="https://www.indure.org/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Ibiza-Rocks.xml
+++ b/src/chrome/content/rules/Ibiza-Rocks.xml
@@ -14,7 +14,6 @@ Fetch error: http://mrh.ibizarocks.com/ => https://mrh.ibizarocks.com/: (6, 'Cou
 	<securecookie host="^.*\.ibizarocks\.com$" name=".*" />
 
 
-	<rule from="^http://(bookings|mrh)\.ibizarocks\.com/"
-		to="https://$1.ibizarocks.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Indepnet.net.xml
+++ b/src/chrome/content/rules/Indepnet.net.xml
@@ -51,7 +51,6 @@ Fetch error: http://forge.indepnet.net/ => https://forge.indepnet.net/: (28, 'Co
 	<securecookie host="^forge\.indepnet\.net$" name=".+" />
 
 
-	<rule from="^http://forge\.indepnet\.net/"
-		to="https://forge.indepnet.net/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Informa_Healthcare-problematic.xml
+++ b/src/chrome/content/rules/Informa_Healthcare-problematic.xml
@@ -11,7 +11,6 @@
 	<securecookie host="^comms\.informahealthcare\.com$" name=".+" />
 
 
-	<rule from="^http://co(mms|ntact)\.informahealthcare\.com/"
-		to="https://co$1.informahealthcare.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Innometrics.com.xml
+++ b/src/chrome/content/rules/Innometrics.com.xml
@@ -21,7 +21,6 @@ Fetch error: http://customer.innometrics.com/ => https://customer.innometrics.co
 	<securecookie host="^customer\.innometrics\.com$" name=".+" />
 
 
-	<rule from="^http://customer\.innometrics\.com/"
-		to="https://customer.innometrics.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Interactive-Media-in-Retail-Group.xml
+++ b/src/chrome/content/rules/Interactive-Media-in-Retail-Group.xml
@@ -15,7 +15,6 @@
 	<securecookie host="^isisaccreditation\.imrg\.org$" name=".*" />
 
 
-	<rule from="^http://isisaccreditation\.imrg\.org/"
-		to="https://isisaccreditation.imrg.org/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Jaqpot.net.xml
+++ b/src/chrome/content/rules/Jaqpot.net.xml
@@ -19,7 +19,6 @@
 	<securecookie host="^www\.jaqpot\.net$" name=".+" />
 
 
-	<rule from="^http://www\.jaqpot\.net/"
-		to="https://www.jaqpot.net/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Johnson_Press.xml
+++ b/src/chrome/content/rules/Johnson_Press.xml
@@ -21,10 +21,6 @@ Fetch error: http://remote.jpress.co.uk/ => https://remote.jpress.co.uk/: (28, '
 	<securecookie host="^mobilecontrol\.jpress\.co\.uk$" name=".+" />
 
 
-	<rule from="^http://secure\.johnstonpress\.co\.uk/"
-		to="https://secure.johnstonpress.co.uk/" />
-
-	<rule from="^http://remote\.jpress\.co\.uk/"
-		to="https://remote.jpress.co.uk/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/JusticeMail.xml
+++ b/src/chrome/content/rules/JusticeMail.xml
@@ -9,5 +9,5 @@ Fetch error: http://mail.justice.com/ => https://mail.justice.com/: (51, "SSL: n
 <ruleset name="mail.justice.com" default_off='failed ruleset test'>
   <target host="mail.justice.com" />
   <securecookie host="^(?:.+\.)?justice\.com$" name=".*"/>
-  <rule from="^http://mail\.justice\.com/" to="https://mail.justice.com/"/>
+  <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Kachingle.xml
+++ b/src/chrome/content/rules/Kachingle.xml
@@ -20,6 +20,5 @@ Fetch error: http://assets.kachingle.com/ => https://assets.kachingle.com/: (60,
 
   <securecookie host="^(?:.+\.)?kachingle\.com$" name=".*"/>
 
-  <rule from="^http://kachingle\.com/" to="https://kachingle.com/"/>
-  <rule from="^http://(www|downloads|assets|medallion)\.kachingle\.com/" to="https://$1.kachingle.com/"/>
+  <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Kansas.com.xml
+++ b/src/chrome/content/rules/Kansas.com.xml
@@ -22,7 +22,6 @@ Fetch error: http://customercare.kansas.com/ => https://customercare.kansas.com/
 	<securecookie host="^customercare\.kansas\.com$" name=".+" />
 
 
-	<rule from="^http://customercare\.kansas\.com/"
-		to="https://customercare.kansas.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Kei.pl-mismatches.xml
+++ b/src/chrome/content/rules/Kei.pl-mismatches.xml
@@ -5,8 +5,7 @@
 	<target host="default.kei.pl"/>
 	<target host="kreator.kei.pl"/>
 
-	<rule from="^http://(default|kreator)\.kei\.pl/"
-		to="https://$1.kei.pl/"/>
+	<rule from="^http:" to="https:" />
 
 	<securecookie host="^kreator\.kei\.pl$" name=".*"/>
 

--- a/src/chrome/content/rules/Kryptronic-mismatches.xml
+++ b/src/chrome/content/rules/Kryptronic-mismatches.xml
@@ -4,7 +4,6 @@
 
 	<securecookie host="^forum\.kryptronic\.com$" name=".*"/>
 
-	<rule from="^http://forum\.kryptronic\.com/"
-		to="https://forum.kryptronic.com/"/>
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Labs.Chevronwp7.com.xml
+++ b/src/chrome/content/rules/Labs.Chevronwp7.com.xml
@@ -10,8 +10,7 @@ Fetch error: http://labs.chevronwp7.com/ => https://labs.chevronwp7.com/: (7, 'F
 <ruleset name="Chevronwp7 Labs" default_off='failed ruleset test'>
     <target host="labs.chevronwp7.com" />
 
-    <rule from="^http://labs\.chevronwp7\.com/"
-        to="https://labs.chevronwp7.com/" />
+    <rule from="^http:" to="https:" />
 
     <securecookie host="^labs\.chevronwp7\.com" name=".*" />
 </ruleset>

--- a/src/chrome/content/rules/LiftShare.xml
+++ b/src/chrome/content/rules/LiftShare.xml
@@ -6,6 +6,5 @@
 
   <securecookie host="^(?:.+\.)?liftshare\.com$" name=".*"/>
 
-  <rule from="^http://liftshare\.com/" to="https://liftshare.com/"/>
-  <rule from="^http://(images|www|scripts)\.liftshare\.com/" to="https://$1.liftshare.com/"/>
+  <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Lippincott_Williams_and_Wilkins_problematic.xml
+++ b/src/chrome/content/rules/Lippincott_Williams_and_Wilkins_problematic.xml
@@ -13,7 +13,6 @@
 	<!--	- Cert only matches ^journals
 		- Paths 404 when rewritten there
 							-->
-	<rule from="^http://images\.journals\.lww\.com/"
-		to="https://images.journals.lww.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Louisiana_State_University-problematic.xml
+++ b/src/chrome/content/rules/Louisiana_State_University-problematic.xml
@@ -10,7 +10,6 @@
 	<securecookie host="^my\.lsu\.edu$" name=".+" />
 
 
-	<rule from="^http://my\.lsu\.edu/"
-		to="https://my.lsu.edu/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/MBuy.com.xml
+++ b/src/chrome/content/rules/MBuy.com.xml
@@ -16,7 +16,6 @@ Fetch error: http://app.mbuy.com/ => https://app.mbuy.com/: (7, 'Failed to conne
 	<securecookie host="^app\.mbuy\.com$" name=".+" />
 
 
-	<rule from="^http://app\.mbuy\.com/"
-		to="https://app.mbuy.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Magentohotel.dk.xml
+++ b/src/chrome/content/rules/Magentohotel.dk.xml
@@ -10,7 +10,6 @@
 	<securecookie host="^prod6\.magentohotel\.dk$" name=".+" />
 
 
-	<rule from="^http://prod6\.magentohotel\.dk/"
-		to="https://prod6.magentohotel.dk/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Maricopa-Community-Colleges-self-signed.xml
+++ b/src/chrome/content/rules/Maricopa-Community-Colleges-self-signed.xml
@@ -18,7 +18,6 @@
 
 
 	<!--	//mcli.dist doesn't exist.	-->
-	<rule from="^http://((?:www\.mcli|web1)\.dist|my|webcal)\.maricopa\.edu/"
-		to="https://$1.maricopa.edu/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/McClatchy.com.xml
+++ b/src/chrome/content/rules/McClatchy.com.xml
@@ -23,7 +23,6 @@ Fetch error: http://subscriberservices.mcclatchy.com/ => https://subscriberservi
 	<securecookie host="^subscriberservices\.mcclatchy\.com$" name=".+" />
 
 
-	<rule from="^http://subscriberservices\.mcclatchy\.com/"
-		to="https://subscriberservices.mcclatchy.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Medialand.ru.xml
+++ b/src/chrome/content/rules/Medialand.ru.xml
@@ -25,7 +25,6 @@ Fetch error: http://mediamir.medialand.ru/ => https://mediamir.medialand.ru/: (6
 	<securecookie host="^mediamir\.medialand\.ru$" name=".+" />
 
 
-	<rule from="^http://mediamir\.medialand\.ru/"
-		to="https://mediamir.medialand.ru/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Mellanox-problematic.xml
+++ b/src/chrome/content/rules/Mellanox-problematic.xml
@@ -14,7 +14,6 @@
 	<securecookie host="^calc\.mellanox\.com$" name=".*" />
 
 
-	<rule from="^http://calc\.mellanox\.com/"
-		to="https://calc.mellanox.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Mephi.ru-problematic.xml
+++ b/src/chrome/content/rules/Mephi.ru-problematic.xml
@@ -10,7 +10,6 @@
 	<securecookie host="^voip\.mephi\.ru$" name=".+" />
 
 
-	<rule from="^http://voip\.mephi\.ru/"
-		to="https://voip.mephi.ru/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Milchkind.net.xml
+++ b/src/chrome/content/rules/Milchkind.net.xml
@@ -6,7 +6,6 @@
 	<securecookie host="^zwischenwelt\.milchkind\.net$" name=".*" />
 
 
-	<rule from="^http://zwischenwelt\.milchkind\.net/"
-		to="https://zwischenwelt.milchkind.net/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Minetest.ru.xml
+++ b/src/chrome/content/rules/Minetest.ru.xml
@@ -19,7 +19,6 @@ Fetch error: http://minetest.ru/ => https://minetest.ru/: (60, 'SSL certificate 
 	<securecookie host="^minetest\.ru$" name=".+" />
 
 
-	<rule from="^http://minetest\.ru/"
-		to="https://minetest.ru/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Musl-libc.org.xml
+++ b/src/chrome/content/rules/Musl-libc.org.xml
@@ -16,7 +16,6 @@
 	<securecookie host="^wiki\.musl-libc\.org$" name=".+" />
 
 
-	<rule from="^http://wiki\.musl-libc\.org/"
-		to="https://wiki.musl-libc.org/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Nativo.net.xml
+++ b/src/chrome/content/rules/Nativo.net.xml
@@ -27,10 +27,6 @@ Fetch error: http://beta.nativo.net/ => https://beta.nativo.net/: (6, 'Could not
 
 	<securecookie host="^(?:admin|beta)\.nativo\.net$" name=".+" />
 
-	<rule from="^http://(www\.)?nativo\.net/"
-		to="https://$1nativo.net/" />
-
-	<rule from="^http://(admin|beta)\.nativo\.net/"
-		to="https://$1.nativo.net/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/NetMile.co.jp.xml
+++ b/src/chrome/content/rules/NetMile.co.jp.xml
@@ -18,7 +18,6 @@ Fetch error: http://www.netmile.co.jp/ => https://www.netmile.co.jp/: (28, 'Oper
 	<securecookie host="^www\.netmile\.co\.jp$" name=".+" />
 
 
-	<rule from="^http://www\.netmile\.co\.jp/"
-		to="https://www.netmile.co.jp/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Ngage_ICS.xml
+++ b/src/chrome/content/rules/Ngage_ICS.xml
@@ -15,10 +15,6 @@
 	<securecookie host="^messenger\.ngageics\.com$" name=".+" />
 
 
-	<rule from="^http://messenger\.ngageics\.com/"
-		to="https://messenger.ngageics.com/" />
-
-	<rule from="^http://secure\.ngagelive\.com/"
-		to="https://secure.ngagelive.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Nik_Software.xml
+++ b/src/chrome/content/rules/Nik_Software.xml
@@ -12,7 +12,6 @@ Fetch error: http://shop.niksoftware.com/ => https://shop.niksoftware.com/: (28,
 	<securecookie host="^shop\.niksoftware\.com$" name=".+" />
 
 
-	<rule from="^http://shop\.niksoftware\.com/"
-		to="https://shop.niksoftware.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Nitro.dk.xml
+++ b/src/chrome/content/rules/Nitro.dk.xml
@@ -4,7 +4,6 @@
 
 	<securecookie host="^webmail\.nitro\.dk$" name=".*"/>
 
-	<rule from="^http://webmail\.nitro\.dk/"
-		to="https://webmail.nitro.dk/"/>
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Nordic_Academy.no.xml
+++ b/src/chrome/content/rules/Nordic_Academy.no.xml
@@ -18,7 +18,6 @@ Fetch error: http://vpn.nordicacademy.no/ => https://vpn.nordicacademy.no/: (60,
 	<securecookie host="^vpn\.nordicacademy\.no$" name=".+" />
 
 
-	<rule from="^http://vpn\.nordicacademy\.no/"
-		to="https://vpn.nordicacademy.no/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/NuStarz.com.xml
+++ b/src/chrome/content/rules/NuStarz.com.xml
@@ -34,7 +34,6 @@ Fetch error: http://customz.nustarz.com/ => https://customz.nustarz.com/: (51, "
 	<securecookie host="^customz\.nustarz\.com$" name=".+" />
 
 
-	<rule from="^http://customz\.nustarz\.com/"
-		to="https://customz.nustarz.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/OFFLINE.ee.xml
+++ b/src/chrome/content/rules/OFFLINE.ee.xml
@@ -12,7 +12,6 @@
 	<securecookie host="^mail\.offline\.ee$" name=".+" />
 
 
-	<rule from="^http://mail\.offline\.ee/"
-		to="https://mail.offline.ee/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/OLPC.xml
+++ b/src/chrome/content/rules/OLPC.xml
@@ -8,8 +8,7 @@ Fetch error: http://dev.laptop.org/ => https://dev.laptop.org/: (60, 'SSL certif
 
 	<target host="dev.laptop.org"/>
 
-	<rule from="^http://dev\.laptop\.org/"
-		to="https://dev.laptop.org/"/>
+	<rule from="^http:" to="https:" />
 
 	<securecookie host="^dev\.laptop\.org$" name=".*"/>
 

--- a/src/chrome/content/rules/Palm.com.xml
+++ b/src/chrome/content/rules/Palm.com.xml
@@ -20,7 +20,6 @@ Fetch error: http://developer.palm.com/ => https://developer.palm.com/: (28, 'Co
 	<securecookie host="^developer\.palm\.com$" name=".+" />
 
 
-	<rule from="^http://developer\.palm\.com/"
-		to="https://developer.palm.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Paysol.se.xml
+++ b/src/chrome/content/rules/Paysol.se.xml
@@ -10,7 +10,7 @@ Fetch error: http://secure.paysol.se/ => https://secure.paysol.se/: (60, 'SSL ce
   <target host="secure.paysol.se" />
 
   <!-- Subdomain www and secure hosts different pages. Cert is for secure.paysol.se. -->
-  <rule from="^http://secure\.paysol\.se/" to="https://secure.paysol.se/" />
+  <rule from="^http:" to="https:" />
 
   <securecookie host="^secure\.paysol\.se$" name=".*"/>
 </ruleset>

--- a/src/chrome/content/rules/Paytoll.xml
+++ b/src/chrome/content/rules/Paytoll.xml
@@ -14,7 +14,6 @@ Non-2xx HTTP code: http://secure.paytoll.eu/ (200) => https://secure.paytoll.eu/
 	<securecookie host="^secure\.paytoll\.eu$" name=".+" />
 
 
-	<rule from="^http://secure\.paytoll\.eu/"
-		to="https://secure.paytoll.eu/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Ponemon.xml
+++ b/src/chrome/content/rules/Ponemon.xml
@@ -16,7 +16,6 @@ Fetch error: http://rim.ponemon.org/ => https://rim.ponemon.org/: (60, 'SSL cert
 	<securecookie host="^rim\.ponemon\.org$" name=".+" />
 
 
-	<rule from="^http://rim\.ponemon\.org/"
-		to="https://rim.ponemon.org/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Preferred_Reservations.xml
+++ b/src/chrome/content/rules/Preferred_Reservations.xml
@@ -16,7 +16,6 @@ Fetch error: http://vr.preferred-reservations.com/ => https://vr.preferred-reser
 	<securecookie host="^vr\.preferred-reservations\.com$" name=".+" />
 
 
-	<rule from="^http://vr\.preferred-reservations\.com/"
-		to="https://vr.preferred-reservations.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/PriceGrabber-clients.xml
+++ b/src/chrome/content/rules/PriceGrabber-clients.xml
@@ -20,7 +20,6 @@ Fetch error: http://hothardware.pricegrabber.com/ => https://hothardware.pricegr
 	<!--	- Clients have unique subdomains
 		- Cert only matches www
 				-->
-	<rule from="^http://hothardware\.pricegrabber\.com/"
-		to="https://hothardware.pricegrabber.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Projectplace.com-problematic.xml
+++ b/src/chrome/content/rules/Projectplace.com-problematic.xml
@@ -10,7 +10,6 @@
 	<securecookie host="^intranet\.projectplace\.com$" name=".+" />
 
 
-	<rule from="^http://intranet\.projectplace\.com/"
-		to="https://intranet.projectplace.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Rice-University.xml
+++ b/src/chrome/content/rules/Rice-University.xml
@@ -24,7 +24,6 @@
 	<securecookie host="^(?:online\.alumni|staff)\.rice\.edu$" name=".*" />
 
 
-	<rule from="^http://(online\.alumni|staff)\.rice\.edu/"
-		to="https://$1.rice.edu/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Riyadonline.com.xml
+++ b/src/chrome/content/rules/Riyadonline.com.xml
@@ -16,7 +16,6 @@ Fetch error: http://corp.riyadonline.com/ => https://corp.riyadonline.com/: Cycl
 	<securecookie host="^corp\.riyadonline\.com$" name=".+" />
 
 
-	<rule from="^http://corp\.riyadonline\.com/"
-		to="https://corp.riyadonline.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/RubyGems.org-problematic.xml
+++ b/src/chrome/content/rules/RubyGems.org-problematic.xml
@@ -16,7 +16,6 @@
 	<securecookie host=".+\.rubygems\.org" name=".+" />
 
 
-	<rule from="^http://(help|m|status)\.rubygems\.org/"
-		to="https://$1.rubygems.org/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/SSAFA-mismatches.xml
+++ b/src/chrome/content/rules/SSAFA-mismatches.xml
@@ -2,8 +2,7 @@
 
 	<target host="www.ssafa.org.uk"/>
 
-	<rule from="^http://www\.ssafa\.org\.uk/"
-		to="https://www.ssafa.org.uk/"/>
+	<rule from="^http:" to="https:" />
 
 	<securecookie host="^www\.ssafa\.org\.uk$" name=".*"/>
 

--- a/src/chrome/content/rules/Sacramento_Bee.xml
+++ b/src/chrome/content/rules/Sacramento_Bee.xml
@@ -28,7 +28,6 @@ Fetch error: http://circulationportal.sacbee.com/ => https://circulationportal.s
 	<securecookie host="^circulationportal\.sacbee\.com$" name=".+" />
 
 
-	<rule from="^http://circulationportal\.sacbee\.com/"
-		to="https://circulationportal.sacbee.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/ScholarOne.xml
+++ b/src/chrome/content/rules/ScholarOne.xml
@@ -22,7 +22,6 @@ Fetch error: http://mc.manuscriptcentral.com/ => https://mc.manuscriptcentral.co
 	<securecookie host="^mc\.manuscriptcentral\.com$" name=".*" />
 
 
-	<rule from="^http://mc\.manuscriptcentral\.com/"
-		to="https://mc.manuscriptcentral.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Scottevest.xml
+++ b/src/chrome/content/rules/Scottevest.xml
@@ -4,6 +4,5 @@
 
   <securecookie host="^(?:.+\.)?scottevest\.com$" name=".*"/>
 
-  <rule from="^http://scottevest\.com/" to="https://scottevest.com/"/>
-  <rule from="^http://www\.scottevest\.com/" to="https://www.scottevest.com/"/>
+  <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Seafile.xml
+++ b/src/chrome/content/rules/Seafile.xml
@@ -21,7 +21,6 @@ Fetch error: http://cloud.seafile.com/ => https://cloud.seafile.com/: (51, "SSL:
 	<securecookie host="^cloud\.seafile\.com$" name=".+" />
 
 
-	<rule from="^http://cloud\.seafile\.com/"
-		to="https://cloud.seafile.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/ServeNets.com.xml
+++ b/src/chrome/content/rules/ServeNets.com.xml
@@ -36,7 +36,6 @@
 	<securecookie host="^domains\.servenets\.com$" name=".+" />
 
 
-	<rule from="^http://domains\.servenets\.com/"
-		to="https://domains.servenets.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/ServerCentral.xml
+++ b/src/chrome/content/rules/ServerCentral.xml
@@ -22,7 +22,6 @@ Fetch error: http://portal.servercentral.net/ => https://portal.servercentral.ne
 	<securecookie host="^portal\.servercentral\.net$" name=".+" />
 
 
-	<rule from="^http://portal\.servercentral\.net/"
-		to="https://portal.servercentral.net/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/SnackTools.com-problematic.xml
+++ b/src/chrome/content/rules/SnackTools.com-problematic.xml
@@ -10,7 +10,6 @@
 	<securecookie host="^stapi\.snacktools\.com$" name=".+" />
 
 
-	<rule from="^http://stapi\.snacktools\.com/"
-		to="https://stapi.snacktools.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Snafu.xml
+++ b/src/chrome/content/rules/Snafu.xml
@@ -17,7 +17,6 @@ Fetch error: http://service.snafu.de/ => https://service.snafu.de/: (7, 'Failed 
 	<securecookie host="^service\.snafu\.de$" name=".*" />
 
 
-	<rule from="^http://service\.snafu\.de/"
-		to="https://service.snafu.de/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/SpatialBuzz.com-problematic.xml
+++ b/src/chrome/content/rules/SpatialBuzz.com-problematic.xml
@@ -15,7 +15,6 @@
 	<securecookie host="^www\.spatialbuzz\.com$" name=".+" />
 
 
-	<rule from="^http://(ftp|git|logs|monitor|sbfs|www)\.spatialbuzz\.com/"
-		to="https://$1.spatialbuzz.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Star_Trek.xml
+++ b/src/chrome/content/rules/Star_Trek.xml
@@ -19,7 +19,6 @@ Fetch error: http://store.startrek.com/ => https://store.startrek.com/: (60, 'SS
 	<securecookie host="^store\.startrek\.com$" name=".+" />
 
 
-	<rule from="^http://store\.startrek\.com/"
-		to="https://store.startrek.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Sundtek.com.xml
+++ b/src/chrome/content/rules/Sundtek.com.xml
@@ -32,7 +32,6 @@
 	<securecookie host="^shop\.sundtek\.com$" name=".+" />
 
 
-	<rule from="^http://shop\.sundtek\.com/"
-		to="https://shop.sundtek.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/SunoSanuo.com.xml
+++ b/src/chrome/content/rules/SunoSanuo.com.xml
@@ -26,7 +26,6 @@ Fetch error: http://app.sunosunao.com/ => https://app.sunosunao.com/: (51, "SSL:
 	<securecookie host="^app\.sunosunao\.com$" name=".+" />
 
 
-	<rule from="^http://app\.sunosunao\.com/"
-		to="https://app.sunosunao.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Susliving.xml
+++ b/src/chrome/content/rules/Susliving.xml
@@ -19,7 +19,6 @@ Fetch error: http://forum.susliving.org/ => https://forum.susliving.org/: (51, "
 	<securecookie host="^forum\.susliving\.org$" name=".+" />
 
 
-	<rule from="^http://forum\.susliving\.org/"
-		to="https://forum.susliving.org/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/TCD.ie-problematic.xml
+++ b/src/chrome/content/rules/TCD.ie-problematic.xml
@@ -10,7 +10,6 @@
 	<securecookie host="^www\.dsg\.cs\.tcd\.ie$" name=".+" />
 
 
-	<rule from="^http://www\.dsg\.cs\.tcd\.ie/"
-		to="https://www.dsg.cs.tcd.ie/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/TNS-Sifo.xml
+++ b/src/chrome/content/rules/TNS-Sifo.xml
@@ -18,10 +18,6 @@
 	<securecookie host="^ssl\.sifomedia\.se$" name=".*" />
 
 
-	<rule from="^http://panel\.research-int\.se/"
-		to="https://panel.research-int.se/" />
-
-	<rule from="^http://ssl\.sifomedia\.se/"
-		to="https://ssl.sifomedia.se/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/TagMan.xml
+++ b/src/chrome/content/rules/TagMan.xml
@@ -24,7 +24,6 @@ Fetch error: http://admin.tagman.com/ => https://admin.tagman.com/: (60, 'SSL ce
 	<securecookie host="^admin\.tagman\.com$" name=".+" />
 
 
-	<rule from="^http://admin\.tagman\.com/"
-		to="https://admin.tagman.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/TechHouse.xml
+++ b/src/chrome/content/rules/TechHouse.xml
@@ -4,6 +4,5 @@
 
   <securecookie host="^(?:.+\.)?techhouse\.org$" name=".*"/>
 
-  <rule from="^http://techhouse\.org/" to="https://techhouse.org/"/>
-  <rule from="^http://(www)\.techhouse\.org/" to="https://$1.techhouse.org/"/>
+  <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/TechRepublic.com-problematic.xml
+++ b/src/chrome/content/rules/TechRepublic.com-problematic.xml
@@ -10,7 +10,6 @@
 	<securecookie host="^www\.techrepublic\.com$" name=".+" />
 
 
-	<rule from="^http://www\.techrepublic\.com/"
-		to="https://www.techrepublic.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Ticker_Madness.com.xml
+++ b/src/chrome/content/rules/Ticker_Madness.com.xml
@@ -18,7 +18,6 @@ Fetch error: http://www.tickermadness.com/ => https://www.tickermadness.com/: (6
 	<securecookie host="^www\.tickermadness\.com$" name=".+" />
 
 
-	<rule from="^http://www\.tickermadness\.com/"
-		to="https://www.tickermadness.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/TicketingNetworkEastMidlands.xml
+++ b/src/chrome/content/rules/TicketingNetworkEastMidlands.xml
@@ -16,7 +16,5 @@ Fetch error: http://www.ticketingnetworkeastmidlands.co.uk/ => https://www.ticke
 
   <securecookie host="^(?:.+\.)?(?:ticketingnetworkeastmidlands|ticketing\.trch)\.co\.uk$" name=".*"/>
 
-  <rule from="^http://ticketingnetworkeastmidlands\.co\.uk/" to="https://ticketingnetworkeastmidlands.co.uk/"/>
-  <rule from="^http://www\.ticketingnetworkeastmidlands\.co\.uk/" to="https://www.ticketingnetworkeastmidlands.co.uk/"/>
-  <rule from="^http://ticketing\.trch\.co\.uk/" to="https://ticketing.trch.co.uk/"/>
+  <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Tid.al-problematic.xml
+++ b/src/chrome/content/rules/Tid.al-problematic.xml
@@ -10,7 +10,6 @@
 	<securecookie host="^news\.tid\.al$" name=".+" />
 
 
-	<rule from="^http://news\.tid\.al/"
-		to="https://news.tid.al/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Tourism_and_Events_Queensland.xml
+++ b/src/chrome/content/rules/Tourism_and_Events_Queensland.xml
@@ -19,7 +19,6 @@ Fetch error: http://atdw.tq.com.au/ => https://atdw.tq.com.au/: (51, "SSL: no al
 	<securecookie host="^atdw\.tq\.com\.au$" name=".+" />
 
 
-	<rule from="^http://atdw\.tq\.com\.au/"
-		to="https://atdw.tq.com.au/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Travelmarket.com.xml
+++ b/src/chrome/content/rules/Travelmarket.com.xml
@@ -19,7 +19,6 @@ Fetch error: http://tmcomponents.travelmarket.com/ => https://tmcomponents.trave
 	<securecookie host="^tmcomponents\.travelmarket\.com$" name=".+" />
 
 
-	<rule from="^http://tmcomponents\.travelmarket\.com/"
-		to="https://tmcomponents.travelmarket.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Tri-CUE.xml
+++ b/src/chrome/content/rules/Tri-CUE.xml
@@ -11,7 +11,6 @@
 	<securecookie host="^www\.tricue\.com$" name=".+" />	
 
 
-	<rule from="^http://www\.tricue\.com/"
-		to="https://www.tricue.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Twisted4Life.xml
+++ b/src/chrome/content/rules/Twisted4Life.xml
@@ -11,5 +11,5 @@ Fetch error: http://www.twisted4life.com/ => https://www.twisted4life.com/: (60,
 
   <securecookie host="^(?:.+\.)?twisted4life\.com$" name=".*"/>
 
-  <rule from="^http://((?:www\.)?twisted4life\.com)/" to="https://$1/"/>
+  <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/UniStra.fr-falsemixed.xml
+++ b/src/chrome/content/rules/UniStra.fr-falsemixed.xml
@@ -12,7 +12,6 @@
 	<securecookie host="^(?:engees|typodun)\.unistra\.fr$" name=".+" />
 
 
-	<rule from="^http://(engees|typodun|www)\.unistra\.fr/"
-		to="https://$1.unistra.fr/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/University-of-Copenhagen.xml
+++ b/src/chrome/content/rules/University-of-Copenhagen.xml
@@ -42,7 +42,6 @@
 	<securecookie host="^\w.*\.ku\.dk$" name=".*" />
 
 
-	<rule from="^http://(www2\.adm|intranet)\.ku\.dk/"
-		to="https://$1.ku.dk/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Utopia-Web.xml
+++ b/src/chrome/content/rules/Utopia-Web.xml
@@ -12,7 +12,6 @@ Fetch error: http://secure.utopia-web.com/ => https://secure.utopia-web.com/: (6
 
 	<securecookie host="^secure\.utopia-web\.com$" name=".*"/>
 
-	<rule from="^http://secure\.utopia-web\.com/"
-		to="https://secure.utopia-web.com/"/>
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/VIRURL.xml
+++ b/src/chrome/content/rules/VIRURL.xml
@@ -19,10 +19,6 @@ Fetch error: http://spn.sr/ => https://spn.sr/: (6, 'Could not resolve host: rev
 	<securecookie host="^(?:www\.)?virurl\.com$" name=".+" />
 
 
-	<rule from="^http://spn\.sr/"
-		to="https://spn.sr/" />
-
-	<rule from="^http://(www\.)?virurl\.com/"
-		to="https://$1virurl.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Viddler.com-mismatches.xml
+++ b/src/chrome/content/rules/Viddler.com-mismatches.xml
@@ -10,7 +10,6 @@
 	<securecookie host="^blog\.viddler\.com$" name=".+" />
 
 
-	<rule from="^http://blog\.viddler\.com/"
-		to="https://blog.viddler.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Videoemail.com.xml
+++ b/src/chrome/content/rules/Videoemail.com.xml
@@ -14,7 +14,6 @@ Fetch error: http://sc.videoemail.com/ => https://sc.videoemail.com/: (60, 'SSL 
 	<securecookie host="^sc\.videoemail\.com$" name=".+" />
 
 
-	<rule from="^http://sc\.videoemail\.com/"
-		to="https://sc.videoemail.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/WP.pl-problematic.xml
+++ b/src/chrome/content/rules/WP.pl-problematic.xml
@@ -10,7 +10,6 @@
 	<securecookie host="^diety\.wp\.pl$" name=".+" />
 
 
-	<rule from="^http://diety\.wp\.pl/"
-		to="https://diety.wp.pl/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Website_Pipeline.xml
+++ b/src/chrome/content/rules/Website_Pipeline.xml
@@ -19,10 +19,6 @@ Fetch error: http://gweb03.webstorepackage.com/ => https://gweb03.webstorepackag
 	<securecookie host="^gweb03\.webstorepackage\.com$" name=".+" />
 
 
-	<rule from="^http://extranet\.websitepipeline\.com/"
-		to="https://extranet.websitepipeline.com/" />
-
-	<rule from="^http://gweb03\.webstorepackage\.com/"
-		to="https://gweb03.webstorepackage.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Wind.com.gr.xml
+++ b/src/chrome/content/rules/Wind.com.gr.xml
@@ -12,5 +12,5 @@ Fetch error: http://www.wind.com.gr/ => https://www.wind.com.gr/: (51, "SSL: no 
 
 	<securecookie host="^www\.wind\.com\.gr$" name=".*"/>
 
-  <rule from="^http://www\.wind\.com\.gr/" to="https://www.wind.com.gr/"/>
+  <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/World_Precision_Instruments.xml
+++ b/src/chrome/content/rules/World_Precision_Instruments.xml
@@ -15,7 +15,6 @@
 	<securecookie host="^store\.wpiinc\.com$" name=".+" />
 
 
-	<rule from="^http://store\.wpiinc\.com/"
-		to="https://store.wpiinc.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/utils/trivialize-rules/trivialize-rules.js
+++ b/utils/trivialize-rules/trivialize-rules.js
@@ -98,10 +98,6 @@ files.fork().zipAll([ sources.fork(), rules ]).map(([name, source, ruleset]) => 
   const info = createTag('INFO', chalk.green, console.info);
   const fail = createTag('FAIL', chalk.red, console.error);
 
-  if (ruleset.securecookie) {
-    return;
-  }
-
   let targets = ruleset.target.map(target => target.$.host);
   let rules = ruleset.rule.map(rule => rule.$);
 
@@ -183,15 +179,19 @@ files.fork().zipAll([ sources.fork(), rules ]).map(([name, source, ruleset]) => 
 
   if (!rules.every(isStatic)) return;
 
-  info`trivialized`;
-
   domains = Array.from(domains);
 
   if (domains.slice().sort().join('\n') !== targets.sort().join('\n')) {
+    if (ruleset.securecookie) {
+      return;
+    }
+
     source = replaceXML(source, 'target', domains.map(domain => `<target host="${domain}" />`));
   }
 
   source = replaceXML(source, 'rule', ['<rule from="^http:" to="https:" />']);
+
+  info`trivialized`;
 
   return writeFile(`${rulesDir}/${name}`, source);
 


### PR DESCRIPTION
A follow-up to https://github.com/EFForg/https-everywhere/pull/12294.

Figured that we can also safely rewrite rulesets with `securecookie` if list of targets wasn't changed at all - turns out this reveals another 138 rulesets that can be trivialized. cc @Hainish 