### PR TITLE
Fix wildcard-in-the-middle for US-military.xml

### DIFF
--- a/src/chrome/content/rules/US-military.xml
+++ b/src/chrome/content/rules/US-military.xml
@@ -22,7 +22,8 @@
 	<target host="dodlive.mil"/>
 	<target host="*.dodlive.mil"/>
 	<target host="reg.dtic.mil"/>
-	<target host="usarmy.*.llnwd.net" />
+	<target host="usarmy.hs.llnwd.net" />
+	<target host="usarmy.vo.llnwd.net" />
 	<target host="nrl.navy.mil" />
 
 	<securecookie host="^www\.pica\.army\.mil$" name=".*" />


### PR DESCRIPTION
See https://github.com/EFForg/https-everywhere/issues/4369. Only these subdomains seem to be matched by a regexp.