### PR TITLE
Report and remove overlapping targets

### DIFF
--- a/src/chrome/content/rules/16163.com.xml
+++ b/src/chrome/content/rules/16163.com.xml
@@ -8,10 +8,6 @@
 
 <ruleset name="16163.com">
 	<target host="16163.com" />
-	<target host="www.16163.com" />
-	<target host="app.16163.com" />
-	<target host="bbs.16163.com" />
-	<target host="m.16163.com" />
 
 	<rule from="^http://16163\.com/" to="https://www.16163.com/" />
 

--- a/src/chrome/content/rules/3min.xml
+++ b/src/chrome/content/rules/3min.xml
@@ -1,7 +1,6 @@
 <ruleset name="3min" default_off="Invalid Certificate">
   <target host="3min.de"/>
   <target host="*.3min.de"/>
-  <target host="www.3min.de"/>
 
   <securecookie host="^(?:.*\.)?3min\.de$" name=".*" />
 

--- a/src/chrome/content/rules/Acenet.xml
+++ b/src/chrome/content/rules/Acenet.xml
@@ -9,7 +9,6 @@
 	<target host="acenet-inc.net"/>
 	<target host="*.acenet-inc.net"/>
 	<!--	for cross-domain cookie	-->
-	<target host="*.esupport.acenet-inc.net"/>
 
 	<securecookie host="^(?:.*\.)?ace-host\.net$" name=".*"/>
 	<!--	no cookies needed for excluded pages	-->

--- a/src/chrome/content/rules/Advertising.com.xml
+++ b/src/chrome/content/rules/Advertising.com.xml
@@ -50,7 +50,6 @@
 
 	<!--	Direct rewrites:
 					-->
-	<target host="secure.ace.advertising.com" />
 	<target host="secure.ace-tag.advertising.com" />
 	<target host="sync.adaptv.advertising.com" />
 	<target host="secure.leadback.advertising.com" />

--- a/src/chrome/content/rules/African-Network-Information-Center.xml
+++ b/src/chrome/content/rules/African-Network-Information-Center.xml
@@ -3,7 +3,6 @@
 	<target host="afrinic.net" />
 	<target host="*.afrinic.net" />
 	<!--	* for cross-domain cookie.	-->
-	<target host="*.meeting.afrinic.net" />
 
 
 	<securecookie host="^(?:.*\.)?afrinic\.net$" name=".*" />

--- a/src/chrome/content/rules/Airtricity.xml
+++ b/src/chrome/content/rules/Airtricity.xml
@@ -1,5 +1,4 @@
 <ruleset name="Airtricity" platform="mixedcontent">
-  <target host="www.airtricity.com" />
   <target host="airtricity.com" />
   <target host="*.airtricity.com" />
 

--- a/src/chrome/content/rules/AliceDSL.xml
+++ b/src/chrome/content/rules/AliceDSL.xml
@@ -15,7 +15,6 @@ Fetch error: http://www.alice-dsl.de/ => https://www.alice-dsl.de/: (7, 'Failed 
   <target host="*.alice.de"/>
   <target host="alice-dsl.de"/>
   <target host="*.alice-dsl.de"/>
-  <target host="www.alice-dsl.de"/>
 
   <securecookie host="^(?:.*\.)?alice-dsl\.de$" name=".*" />
 

--- a/src/chrome/content/rules/American-University.xml
+++ b/src/chrome/content/rules/American-University.xml
@@ -13,7 +13,6 @@
 
 	<target host="american.edu" />
 	<target host="*.american.edu" />
-	<target host="*.wcl.american.edu" />
 
 
 	<!--	Doesn't work over https.

--- a/src/chrome/content/rules/American_Society_of_Media_Photographers.xml
+++ b/src/chrome/content/rules/American_Society_of_Media_Photographers.xml
@@ -8,7 +8,6 @@ Fetch error: http://www.admin.asmp.org/ => https://www.admin.asmp.org/: (51, "SS
 
 	<target host="asmp.org" />
 	<target host="*.asmp.org" />
-	<target host="www.admin.asmp.org" />
 
 
 	<securecookie host="^.*\.asmp\.org$" name=".+" />

--- a/src/chrome/content/rules/Argonne-National-Laboratory.xml
+++ b/src/chrome/content/rules/Argonne-National-Laboratory.xml
@@ -14,7 +14,6 @@
 <ruleset name="Argonne National Laboratory (partial)">
 
 	<target host="*.anl.gov" />
-	<target host="www.*.anl.gov" />
 
 
 	<!--	- cels: Cert only matches www.cels

--- a/src/chrome/content/rules/Argos.xml
+++ b/src/chrome/content/rules/Argos.xml
@@ -34,7 +34,6 @@ Fetch error: http://www.wearechoosy.com/ => https://www.wearechoosy.com/: (60, '
 
 	<target host="argos.co.uk" />
 	<target host="*.argos.co.uk" />
-	<target host="image.email.argos.co.uk" />
 	<target host="argos.ie" />
 	<target host="*.argos.ie" />
 	<target host="argoscareers.com" />

--- a/src/chrome/content/rules/Audiko.xml
+++ b/src/chrome/content/rules/Audiko.xml
@@ -9,8 +9,6 @@ Fetch error: http://jpg.st.audiko.net/ => https://s4.audiko.net/: (51, "SSL: no 
 
 	<target host="audiko.net" />
 	<target host="*.audiko.net" />
-	<target host="css.cdn.audiko.net" />
-	<target host="jpg.st.audiko.net" />
 
 
 	<rule from="^http://(s[45]\.|www\.)?audiko\.net/"

--- a/src/chrome/content/rules/Bauhaus-University_Weimar.xml
+++ b/src/chrome/content/rules/Bauhaus-University_Weimar.xml
@@ -10,7 +10,6 @@
 <ruleset name="Bauhaus-University Weimar (partial)">
 
 	<target host="*.uni-weimar.de" />
-	<target host="*.webmail.uni-weimar.de" />
 
 
 	<securecookie host="^.+\.uni-weimar\.de$" name=".+" />

--- a/src/chrome/content/rules/Bennetts.xml
+++ b/src/chrome/content/rules/Bennetts.xml
@@ -9,7 +9,6 @@ Fetch error: http://bennetts.co.uk/ => http://bennetts.co.uk/: Redirect for 'htt
 
 	<target host="bennetts.co.uk" />
 	<target host="*.bennetts.co.uk" />
-	<target host="*.quotes.bennetts.co.uk" />
 
 
 	<securecookie host="^\.?quotes\.bennets\.co\.uk$" name=".+" />

--- a/src/chrome/content/rules/BreNet.xml
+++ b/src/chrome/content/rules/BreNet.xml
@@ -17,7 +17,6 @@ Fetch error: http://brenet.de/ => https://brenet.de/: (60, 'SSL certificate prob
 		webmail if it's used over http, and in the case
 		that https is used and that ruleset is off, it'll
 		encrypt cookies anyway, which would be a good thing.	-->
-	<target host="*.webmail.brenet.de" />
 
 
 	<securecookie host="^(?:.*\.)?brenet\.de$" name=".*" />

--- a/src/chrome/content/rules/Caller.com.xml
+++ b/src/chrome/content/rules/Caller.com.xml
@@ -51,8 +51,6 @@
 <ruleset name="Caller.com (partial)">
 
 	<target host="caller.com" />
-	<target host="www.caller.com" />
-	<target host="login.caller.com" />
 	<target host="*.caller.com" />
 
 

--- a/src/chrome/content/rules/Catalog-of-Domestic-Federal-Assistance.xml
+++ b/src/chrome/content/rules/Catalog-of-Domestic-Federal-Assistance.xml
@@ -6,7 +6,6 @@
 	<target host="cfda.gov" />
 	<!--	*s for cross-domain cookies.	-->
 	<target host="*.cfda.gov" />
-	<target host="*.www.cfda.gov" />
 
 
 	<securecookie host="^.*\.cfda\.gov$" name=".*" />

--- a/src/chrome/content/rules/Champs_Sports.xml
+++ b/src/chrome/content/rules/Champs_Sports.xml
@@ -23,8 +23,6 @@
 
 	<target host="champssports.com" />
 	<target host="*.champssports.com" />
-	<target host="*.e.champssports.com" />
-	<target host="*.www.champssports.com" />
 
 
 	<securecookie host="^.*\.champssports\.com$" name=".+" />

--- a/src/chrome/content/rules/City_University_London.xml
+++ b/src/chrome/content/rules/City_University_London.xml
@@ -15,8 +15,6 @@ Fetch error: http://www.soi.city.ac.uk/ => https://www.soi.city.ac.uk/: (28, 'Co
 
 	<target host="city.ac.uk" />
 	<target host="*.city.ac.uk" />
-	<target host="www.soi.city.ac.uk" />
-	<target host="*.www.city.ac.uk" />
 
 
 	<securecookie host="^\.www\.city\.ac\.uk$" name=".+" />

--- a/src/chrome/content/rules/Claranet.xml
+++ b/src/chrome/content/rules/Claranet.xml
@@ -12,9 +12,6 @@ Fetch error: http://secure.claranetsoho.co.uk/ => https://secure.claranetsoho.co
 <ruleset name="Claranet (partial)" default_off='failed ruleset test'>
 
 	<target host="*.clara.net"/>
-	<target host="webmail.bln.de.clara.net"/>
-	<target host="nswebmail.uk.clara.net"/>
-	<target host="portal.uk.clara.net"/>
 	<target host="admin.clarahost.co.uk"/>
 	<target host="pop.claranet.de"/>
 	<target host="*.claranet.nl"/>

--- a/src/chrome/content/rules/Cloudhexa_Network.xml
+++ b/src/chrome/content/rules/Cloudhexa_Network.xml
@@ -5,7 +5,6 @@
 <ruleset name="Cloudhexa Network">
 
 	<target host="*.cloudhexa.com" />
-	<target host="*.www.cloudhexa.com" />
 
 
 	<securecookie host="^\.(?:www\.)?cloudhexa\.com$" name=".+" />

--- a/src/chrome/content/rules/Columbia_University-problematic.xml
+++ b/src/chrome/content/rules/Columbia_University-problematic.xml
@@ -14,7 +14,6 @@
 	<target host="www.cdrs.columbia.edu" />
 	<target host="bulletin.engineering.columbia.edu" />
 	<target host="*.hr.columbia.edu" />
-	<target host="*.managers.hr.columbia.edu" />
 	<target host="twiki.nevis.columbia.edu" />
 	<target host="www.nevis.columbia.edu" />
 	<target host="scholcomm.columbia.edu" />

--- a/src/chrome/content/rules/Compendium.xml
+++ b/src/chrome/content/rules/Compendium.xml
@@ -10,12 +10,9 @@
 	<!--	Direct rewrites:
 				-->
 	<target host="*.compendiumblog.com" />
-	<target host="cdn2.content.compendiumblog.com" />
 
 	<!--	Complications:
 				-->
-	<target host="cdn.content.compendiumblog.com" />
-	<target host="global.content.compendiumblog.com" />
 
 		<test url="http://www.compendiumblog.com/" />
 

--- a/src/chrome/content/rules/Council_on_Foreign_Relations.xml
+++ b/src/chrome/content/rules/Council_on_Foreign_Relations.xml
@@ -30,7 +30,6 @@
 	<target host="cfr.org" />
 	<target host="*.cfr.org" />
 		<exclusion pattern="^http://(?:www\.)?cfr\.org/(?!content/.+\.(?:gif|jpg|png)$|css/|i/|login\.html)" />
-	<target host="secure.www.cfr.org" />
 
 
 	<rule from="^http://(?:www\.)?cfr\.org/login\.html"

--- a/src/chrome/content/rules/Cox_Communications.xml
+++ b/src/chrome/content/rules/Cox_Communications.xml
@@ -47,9 +47,7 @@ Fetch error: http://cox.com/ => https://ww2.cox.com/: Cycle detected - URL alrea
 	<target host="cox.com" />
 	<target host="*.cox.com" />
 		<exclusion pattern="^http://(?:intercept|ww2)\.cox\.com/.+\.cox(?:$|\?)" />
-	<target host="*.store.cox.com" />
 	<target host="*.cox.net" />
-	<target host="idm.east.cox.net" />
 	<target host="coxbusiness.com" />
 	<target host="*.coxbusiness.com" />
 

--- a/src/chrome/content/rules/Crain-Communications.xml
+++ b/src/chrome/content/rules/Crain-Communications.xml
@@ -29,7 +29,6 @@ Fetch error: http://www.creativity-online.com/ => https://creativity-online.com/
 
 	<target host="adage.com" />
 	<target host="*.adage.com" />
-	<target host="www.amiga.adage.com" />
 	<target host="sec.crain.com" />
 	<target host="crainsnewyork.com" />
 	<!--	* for cross-domain cookies.	-->

--- a/src/chrome/content/rules/Dailymotion.xml
+++ b/src/chrome/content/rules/Dailymotion.xml
@@ -35,7 +35,6 @@
 			https://mail1.eff.org/pipermail/https-everywhere-rules/2012-July/001241.html
 													-->
 		<exclusion pattern="^http://(?:www\.)?dailymotion\.com/(?:cdn/[\w-]+/video/|crossdomain\.xml$)" />
-	<target host="ak2.static.dailymotion.com" />
 	<target host="*.dmcdn.net" />
 	<target host="dmcloud.net" />
 	<target host="*.dmcloud.net" />

--- a/src/chrome/content/rules/Digia.xml
+++ b/src/chrome/content/rules/Digia.xml
@@ -22,7 +22,6 @@ Fetch error: http://blog.qt.digia.com/ => https://blog.qt.digia.com/: (51, "SSL:
 
 	<target host="digia.com" />
 	<target host="*.digia.com" />
-	<target host="blog.qt.digia.com" />
 
 
 	<securecookie host="^(?:.+\.)?digia\.com$" name=".+" />

--- a/src/chrome/content/rules/Digital_Photography_Review.xml
+++ b/src/chrome/content/rules/Digital_Photography_Review.xml
@@ -41,7 +41,6 @@
 	<target host="dpreview.com" />
 	<target host="*.dpreview.com" />
 	<target host="*.img-dpreview.com" />
-	<target host="*.static.img-dpreview.com" />
 
 
 	<rule from="^http://(?:www\.)?dpreview\.com/(challenges/[iI]mages/|members/register|products_data/|resources/)"

--- a/src/chrome/content/rules/Digitaria.xml
+++ b/src/chrome/content/rules/Digitaria.xml
@@ -14,8 +14,6 @@ Fetch error: http://redmine.digitaria.com/ => https://redmine.digitaria.com/: (7
 
 	<target host="redmine.digitaria.com" />
 	<target host="*.insightmgr.com" />
-	<target host="*.digi.insightmgr.com" />
-	<target host="*.www.insightmgr.com" />
 
 
 	<securecookie host="^redmine\.digitaria\.com$" name=".+" />

--- a/src/chrome/content/rules/DotCOM-host.xml
+++ b/src/chrome/content/rules/DotCOM-host.xml
@@ -3,7 +3,6 @@
 	<target host="dotcomhost.com" />
 	<target host="*.dotcomhost.com" />
 	<!--	* for cross-domain cookie.	-->
-	<target host="*.webmail.dotcomhost.com" />
 
 
 	<securecookie host="^(?:.*\.)?dotcomhost\.com$" name=".*" />

--- a/src/chrome/content/rules/Eastbay.xml
+++ b/src/chrome/content/rules/Eastbay.xml
@@ -36,8 +36,6 @@ Fetch error: http://eastbay.com/ => https://www.eastbay.com/: Cycle detected - U
 
 	<target host="eastbay.com" />
 	<target host="*.eastbay.com" />
-	<target host="*.teamsales.eastbay.com" />
-	<target host="*.www.eastbay.com" />
 
 
 	<securecookie host="^.*\.eastbay\.com$" name=".+" />

--- a/src/chrome/content/rules/Economic-Policy-Institute.xml
+++ b/src/chrome/content/rules/Economic-Policy-Institute.xml
@@ -11,7 +11,6 @@
 
 	<target host="*.epi.org" />
 	<!--	* for cross-domain cookie.	-->
-	<target host="*.secure.epi.org" />
 
 
 	<securecookie host="^(?:my|\.?secure)\.epi\.org$" name=".*" />

--- a/src/chrome/content/rules/Electronic-Arts.xml
+++ b/src/chrome/content/rules/Electronic-Arts.xml
@@ -28,7 +28,6 @@
 	<target host="synergy-stage.eamobile.com"/>
 	<target host="thesims3.com"/>
 	<target host="*.thesims3.com"/>
-	<target host="*.store.thesims3.com"/>
 
 
 	<!--	incomplete

--- a/src/chrome/content/rules/Epson.xml
+++ b/src/chrome/content/rules/Epson.xml
@@ -36,7 +36,6 @@ Fetch error: http://www.epson.com.mx/ => https://global.latin.epson.com/mx: Redi
 		<exclusion pattern="^http://(?:www\.)?epson\.com/cgi-bin/Store/jsp/Product/(?:Overview|Photos)\.do"/>
 		<!--	URLs such as http://www.epson.com/snowleopard	-->
 		<exclusion pattern="^http://(?:www\.)?epson\.com/(?:[a-zA-Z][a-zA-Z\d]+){1}$"/>
-	<target host="global.latin.epson.com" />
 	<target host="epson.com.mx" />
 	<target host="www.epson.com.mx" />
 	<target host="*.epson.jp" />

--- a/src/chrome/content/rules/Eyeviewads.com.xml
+++ b/src/chrome/content/rules/Eyeviewads.com.xml
@@ -9,8 +9,6 @@
 -->
 <ruleset name="eyeviewads.com">
 
-	<target host="track.eyeviewads.com" />
-
 	<target host="*.eyeviewads.com" />
 
 

--- a/src/chrome/content/rules/Familie-redlich.xml
+++ b/src/chrome/content/rules/Familie-redlich.xml
@@ -4,7 +4,6 @@
 						-->
 	<target host="familie-redlich.de" />
 	<target host="*.familie-redlich.de" />
-	<target host="www.systeme.familie-redlich.de" />
 
 
 	<securecookie host="^(?:systeme\.)?familie-redlich\.de$" name=".+" />

--- a/src/chrome/content/rules/Federal_Business_Opportunities.xml
+++ b/src/chrome/content/rules/Federal_Business_Opportunities.xml
@@ -13,7 +13,6 @@
 
 	<target host="fbo.gov" />
 	<target host="*.fbo.gov" />
-	<target host="*.www.fbo.gov" />
 	<target host="fedbizopps.gov" />
 	<target host="www.fedbizopps.gov" />
 

--- a/src/chrome/content/rules/Film-Threat.xml
+++ b/src/chrome/content/rules/Film-Threat.xml
@@ -11,7 +11,6 @@ Fetch error: http://filmthreat.com/ => https://filmthreat.com/: (60, 'SSL certif
 	<target host="filmthreat.com"/>
 	<target host="*.filmthreat.com"/>
 	<!--	for cross-domain cookie		-->
-	<target host="*.www.filmthreat.com"/>
 
 	<securecookie host="^(?:.*\.)?filmthreat\.com$" name=".*"/>
 

--- a/src/chrome/content/rules/Final-Score.xml
+++ b/src/chrome/content/rules/Final-Score.xml
@@ -18,8 +18,6 @@
 
 	<target host="final-score.com" />
 	<target host="*.final-score.com" />
-	<target host="*.e.final-score.com" />
-	<target host="*.www.final-score.com" />
 
 
 	<securecookie host="^.*\.final-score\.com$" name=".+" />

--- a/src/chrome/content/rules/Footaction_USA.xml
+++ b/src/chrome/content/rules/Footaction_USA.xml
@@ -19,7 +19,6 @@
 
 	<target host="footaction.com" />
 	<target host="*.footaction.com" />
-	<target host="*.www.footaction.com" />
 
 
 	<securecookie host="^.*\.footaction\.com$" name=".+" />

--- a/src/chrome/content/rules/FreeWheel.xml
+++ b/src/chrome/content/rules/FreeWheel.xml
@@ -22,7 +22,6 @@ Fetch error: http://mrm.freewheel.tv/ => https://mrm.freewhell.tv/: (6, 'Could n
 
 	<target host="mrm.freewheel.tv" />
 	<target host="*.fwmrm.net" />
-	<target host="2912a.v.fwmrm.net" />
 
 
 	<securecookie host="^.*\.fwmrm\.net$" name=".+" />

--- a/src/chrome/content/rules/Freelancer.xml
+++ b/src/chrome/content/rules/Freelancer.xml
@@ -16,10 +16,8 @@
 	<target host="freelancer.com" />
 	<target host="*.freelancer.com" />
 	<!--	*s for cross-domain cookies.	-->
-	<target host="*.www.freelancer.com" />
 	<target host="freelancer.co.uk" />
 	<target host="*.freelancer.co.uk" />
-	<target host="*.www.freelancer.co.uk" />
 
 
 	<securecookie host="^(?:.*\.)?freelancer\.co(?:m|\.uk)$" name=".*" />

--- a/src/chrome/content/rules/FutureQuest.net.xml
+++ b/src/chrome/content/rules/FutureQuest.net.xml
@@ -18,7 +18,6 @@ Fetch error: http://www.service.futurequest.net/ => https://www.service.futurequ
 <ruleset name="FutureQuest (partial)" default_off='failed ruleset test'>
 
 	<target host="*.futurequest.net" />
-	<target host="www.service.futurequest.net" />
 	<target host="questadmin.net" />
 	<target host="*.questadmin.net" />
 

--- a/src/chrome/content/rules/GaiaOnline.xml
+++ b/src/chrome/content/rules/GaiaOnline.xml
@@ -10,7 +10,6 @@
 <ruleset name="Gaia Online (breaks registration)" default_off="registration, avatar system not fully supported">
       <target host="gaiaonline.com" />
       <target host="*.gaiaonline.com" />
-      <target host="*.cdn.gaiaonline.com" />
       <target host="*.gaiaonlinehelp.com" />
       <target host="*.gaia.hs.llnwd.net" />
 

--- a/src/chrome/content/rules/Game-Show-Network.xml
+++ b/src/chrome/content/rules/Game-Show-Network.xml
@@ -10,7 +10,6 @@ Fetch error: http://www.tv.gsn.com/ => https://www.tv.gsn.com/: (60, 'SSL certif
 
 	<target host="gsn.com"/>
 	<target host="*.gsn.com"/>
-	<target host="www.tv.gsn.com"/>
 	<target host="worldwinner.com"/>
 	<target host="*.worldwinner.com"/>
 

--- a/src/chrome/content/rules/Gigaserver.xml
+++ b/src/chrome/content/rules/Gigaserver.xml
@@ -15,7 +15,6 @@
 			Seonet-Multimedia.xml	-->
 		<exclusion pattern="^http://(?:blog|kb)\." />
 	<!--	* for cross-subdomain cookie.	-->
-	<target host="*.www.gigaserver.cz" />
 
 
 	<securecookie host="^(?:.*\.)?gigaserver\.cz$" name=".*" />

--- a/src/chrome/content/rules/Gizmodo.com.xml
+++ b/src/chrome/content/rules/Gizmodo.com.xml
@@ -39,27 +39,9 @@
 
 		<!--	Direct rewrites:
 					-->
-		<target host="20khz.gizmodo.com" />
-		<target host="es.gizmodo.com" />
-		<target host="factually.gizmodo.com" />
-		<target host="fieldguide.gizmodo.com" />
-		<target host="homeofthefuture.gizmodo.com" />
-		<target host="indefinitelywild.gizmodo.com" />
-		<target host="io9.gizmodo.com" />
-		<target host="lego.gizmodo.com" />
-		<target host="offworld.gizmodo.com" />
-		<target host="paleofuture.gizmodo.com" />
-		<target host="reframe.gizmodo.com" />
-		<target host="space.gizmodo.com" />
-		<target host="sploid.gizmodo.com" />
-		<target host="throb.gizmodo.com" />
-		<target host="toyland.gizmodo.com" />
-		<target host="us.gizmodo.com" />
-		<target host="www.gizmodo.com" />
 
 		<!--	Complications:
 					-->
-		<target host="cache.gizmodo.com" />
 
 
 	<!--	Not secured by server:

--- a/src/chrome/content/rules/GoStats.xml
+++ b/src/chrome/content/rules/GoStats.xml
@@ -15,7 +15,6 @@ Fetch error: http://www.ssl.gostats.com/ => https://www.ssl.gostats.com/: (60, '
 
 	<target host="gostats.com" />
 	<target host="*.gostats.com" />
-	<target host="www.ssl.gostats.com" />
 	<target host="cdn.gsstatic.com" />
 
 

--- a/src/chrome/content/rules/GoogleImages.xml
+++ b/src/chrome/content/rules/GoogleImages.xml
@@ -8,8 +8,6 @@
 	<target host="google.co.*" />
 	<target host="images.google.co.*" />
 	<target host="www.google.co.*" />
-	<target host="google.com" />
-	<target host="images.google.com" />
 	<target host="google.com.*" />
 	<target host="images.google.com.*" />
 	<target host="www.google.com.*" />

--- a/src/chrome/content/rules/GoogleServices_Complex.xml
+++ b/src/chrome/content/rules/GoogleServices_Complex.xml
@@ -23,7 +23,6 @@
 	<target host="*.googlecode.com" />
 	<target host="*.googlesyndication.com" />
 	<target host="*.googleusercontent.com" />
-		<target host="*.corp.googleusercontent.com" />
 		<!--
 			Necessary for the Followers widget:
 

--- a/src/chrome/content/rules/GoogleVideos.xml
+++ b/src/chrome/content/rules/GoogleVideos.xml
@@ -1,6 +1,5 @@
 <ruleset name="Google Videos" default_off="Needs ruleset tests">
   <target host="*.google.com" />
-  <target host="google.com" />
   <target host="www.google.com.*" />
   <target host="google.com.*" />
   <target host="www.google.co.*" />

--- a/src/chrome/content/rules/Griffith-University.xml
+++ b/src/chrome/content/rules/Griffith-University.xml
@@ -2,7 +2,6 @@
 
 	<target host="griffith.edu.au" />
 	<target host="*.griffith.edu.au" />
-	<target host="*.secure.griffith.edu.au" />
 
 
 	<securecookie host="^www3\.secure\.griffith\.edu\.au$" name=".*" />

--- a/src/chrome/content/rules/HitBTC.com.xml
+++ b/src/chrome/content/rules/HitBTC.com.xml
@@ -18,12 +18,6 @@
 <ruleset name="HitBTC.com">
 
 	<target host="hitbtc.com" />
-	<target host="affiliate.hitbtc.com" />
-	<target host="auth.hitbtc.com" />
-	<target host="blog.hitbtc.com" />
-	<target host="demo.hitbtc.com" />
-	<target host="forum.hitbtc.com" />
-	<target host="www.hitbtc.com" />
 
 	<target host="*.hitbtc.com" />
 

--- a/src/chrome/content/rules/Home.pl.xml
+++ b/src/chrome/content/rules/Home.pl.xml
@@ -10,10 +10,6 @@
 
 	<target host="home.pl" />
 	<target host="*.home.pl" />
-	<target host="*.akcje.home.pl" />
-	<target host="*.panel.home.pl" />
-	<target host="*.poczta.home.pl" />
-	<target host="*.m.poczta.home.pl" />
 
 
 	<securecookie host="^(?:.+\.)?home\.pl$" name=".+" />

--- a/src/chrome/content/rules/Honest.com.xml
+++ b/src/chrome/content/rules/Honest.com.xml
@@ -23,9 +23,6 @@
 <ruleset name="Honest.com">
 
 	<target host="honest.com" />
-	<target host="blog.honest.com" />
-	<target host="img.honest.com" />
-	<target host="www.honest.com" />
 
 	<target host="*.honest.com" />
 

--- a/src/chrome/content/rules/Hot_Pics_Amateur.xml
+++ b/src/chrome/content/rules/Hot_Pics_Amateur.xml
@@ -6,7 +6,6 @@
 
 	<target host="hotpics-amateur.com" />
 	<target host="*.hotpics-amateur.com" />
-	<target host="www.collection.hotpics-amateur.com" />
 
 
 	<securecookie host="^(?:www\.)?hotpics-amateur\.com$" name=".+" />

--- a/src/chrome/content/rules/ImageShack.xml
+++ b/src/chrome/content/rules/ImageShack.xml
@@ -14,12 +14,8 @@
 	<target host="blog.imageshack.com" />
 
 	<target host="imageshack.us" />
-	<target host="www.imageshack.us" />
-	<target host="imagizer.imageshack.us" />
-	<target host="post.imageshack.us" />
 
 	<!-- Show 404 page: -->
-	<target host="a.imageshack.us" />
 		<test url="http://a.imageshack.us/img254/8219/40789751.png" />
 	<target host="*.imageshack.us" />
 		<test url="http://img5.imageshack.us/img5/133/homeworld.jpg" />

--- a/src/chrome/content/rules/KIXEYE.xml
+++ b/src/chrome/content/rules/KIXEYE.xml
@@ -20,7 +20,6 @@
 
 	<target host="cdn.casualcollective.com" />
 	<target host="*.kixeye.com" />
-	<target host="*.cdn.kixeye.com" />
 
 
 	<rule from="^http://cdn\.casualcollective\.com/"

--- a/src/chrome/content/rules/Kids_Foot_Locker.xml
+++ b/src/chrome/content/rules/Kids_Foot_Locker.xml
@@ -19,7 +19,6 @@
 
 	<target host="kidsfootlocker.com" />
 	<target host="*.kidsfootlocker.com" />
-	<target host="*.www.kidsfootlocker.com" />
 
 
 	<securecookie host="^.*\.kidsfootlocker\.com$" name=".+" />

--- a/src/chrome/content/rules/Lady_Foot_Locker.xml
+++ b/src/chrome/content/rules/Lady_Foot_Locker.xml
@@ -19,7 +19,6 @@
 
 	<target host="ladyfootlocker.com" />
 	<target host="*.ladyfootlocker.com" />
-	<target host="*.www.ladyfootlocker.com" />
 
 
 	<securecookie host="^.*\.ladyfootlocker\.com$" name=".+" />

--- a/src/chrome/content/rules/LastPass.com.xml
+++ b/src/chrome/content/rules/LastPass.com.xml
@@ -21,25 +21,6 @@
 <ruleset name="LastPass.com">
 
 	<target host="lastpass.com" />
-	<target host="www.lastpass.com" />
-	<target host="0.lastpass.com" />
-	<target host="account.lastpass.com" />
-	<target host="accounts.lastpass.com" />
-	<target host="blog.lastpass.com" />
-	<target host="download.lastpass.com" />
-	<target host="enterprise.lastpass.com" />
-	<target host="forums.lastpass.com" />
-	<target host="helpdesk.lastpass.com" />
-	<target host="localvault.lastpass.com" />
-	<target host="m.lastpass.com" />
-	<target host="manda.lastpass.com" />
-	<target host="pollserver.lastpass.com" />
-	<target host="portable.lastpass.com" />
-	<target host="rodan.lastpass.com" />
-	<target host="service.lastpass.com" />
-	<target host="teams.lastpass.com" />
-	<target host="uber.lastpass.com" />
-	<target host="vaul.lastpass.com" />
 	<target host="*.lastpass.com" />
 
 	<securecookie host=".+" name=".+"/>

--- a/src/chrome/content/rules/Linux-New-Media.xml
+++ b/src/chrome/content/rules/Linux-New-Media.xml
@@ -12,9 +12,7 @@
 
 	<target host="*.linuxnewmedia.com" />
 	<!--	* for cross-domain cookie.	-->
-	<target host="*.shop.linuxnewmedia.com" />
 	<target host="*.linuxnewmedia.de" />
-	<target host="*.shop.linuxnewmedia.de" />
 
 
 	<securecookie host="^.*\.linuxnewmedia\.(?:com|de)$" name=".*" />

--- a/src/chrome/content/rules/Liquid-Web.xml
+++ b/src/chrome/content/rules/Liquid-Web.xml
@@ -2,7 +2,6 @@
 
 	<target host="liquidweb.com"/>
 	<target host="*.liquidweb.com"/>
-	<target host="media.cdn.liquidweb.com"/>
 
 	<securecookie host="^(?:.*\.)?liquidweb\.com$" name=".*"/>
 

--- a/src/chrome/content/rules/London-2012.xml
+++ b/src/chrome/content/rules/London-2012.xml
@@ -15,9 +15,6 @@ Fetch error: http://tickets.london2012.com/ => https://www.tickets.london2012.co
 	<target host="london2012.com"/>
 	<target host="*.london2012.com"/>
 		<exclusion pattern="^http://getset\.london2012\.com/(?:(?:cy|en)/(?:home)?)?$"/>
-	<target host="www.festival.london2012.com"/>
-	<target host="tickets.london2012.com"/>
-	<target host="www.tickets.london2012.com"/>
 
 	<securecookie host="^(?:(?:festival|www)?\.)?london2012\.com$" name=".*"/>
 

--- a/src/chrome/content/rules/Loopia.xml
+++ b/src/chrome/content/rules/Loopia.xml
@@ -13,7 +13,6 @@ Fetch error: http://loopiasecure.com/ => https://www.loopia.se/: (60, 'SSL certi
 		<!--	blogg times out.	-->
 		<exclusion pattern="^http://blogg\." />
 	<!--	* for cross-domain cookie.	-->
-	<target host="*.www.loopia.se" />
 	<target host="loopiasecure.com" />
 
 

--- a/src/chrome/content/rules/Lumosity.xml
+++ b/src/chrome/content/rules/Lumosity.xml
@@ -8,7 +8,6 @@
 
 	<target host="lumosity.com" />
 	<target host="*.lumosity.com" />
-	<target host="static.sl.lumosity.com" />
 
 
 	<!--	Many pages redirect to http.	-->

--- a/src/chrome/content/rules/MIC-Gadget.xml
+++ b/src/chrome/content/rules/MIC-Gadget.xml
@@ -12,7 +12,6 @@
 <ruleset name="M.I.C. Gadget (partial)">
 
 	<target host="*.micgadget.com" />
-	<target host="*.store.micgadget.com" />
 
 
 	<securecookie host="^\.store\.micgadget\.com$" name=".+" />

--- a/src/chrome/content/rules/MSN-mismatches.xml
+++ b/src/chrome/content/rules/MSN-mismatches.xml
@@ -22,7 +22,6 @@
 						-->
 
 	<target host="*.msnbc.msn.com" />
-	<target host="*.today.msnbc.msn.com" />
 	<target host="my.msn.com" />
 	<target host="eb.my.msn.com" />
 	<target host="m.now.msn.com" />

--- a/src/chrome/content/rules/Mail.ru.xml
+++ b/src/chrome/content/rules/Mail.ru.xml
@@ -199,7 +199,6 @@
 	<target host="dwar.mail.ru" />
 	<!--target host="d2.dwar.mail.ru" /-->
 	<target host="filin.mail.ru" />
-	<target host="avt.foto.mail.ru" />
 	<target host="*.foto.mail.ru" />
 	<target host="games.mail.ru" />
 
@@ -230,10 +229,7 @@
 	<target host="my.mail.ru" />
 
 	<target host="*.my.mail.ru" />
-	<target host="content.foto.my.mail.ru" />
 	<!--target host="*.foto.my.mail.ru" /-->
-	<target host="stat.my.mail.ru" />
-	<target host="videoapi.my.mail.ru" />
 
 	<target host="news.mail.ru" />
 
@@ -281,7 +277,6 @@
 				-->
 	<target host="blogs.mail.ru" />
 	<target host="cdn.connect.mail.ru" />
-	<target host="content.foto.mail.ru" />
 	<target host="img.pre.realty.mail.ru" />
 	<target host="*.top.mail.ru" />
 	<target host="wap.mail.ru" />

--- a/src/chrome/content/rules/Maricopa-Community-Colleges.xml
+++ b/src/chrome/content/rules/Maricopa-Community-Colleges.xml
@@ -12,7 +12,6 @@
 	<target host="maricopa.edu" />
 	<target host="*.maricopa.edu" />
 	<!--	* for cross-domain cookie.	-->
-	<target host="*.sis.maricopa.edu" />
 
 
 	<securecookie host="^ecourses\.maricopa\.edu$" name=".*" />

--- a/src/chrome/content/rules/Maxymiser.xml
+++ b/src/chrome/content/rules/Maxymiser.xml
@@ -12,7 +12,6 @@ Fetch error: http://maxymiser.com/ => https://maxymiser.com/: Too many redirects
 
 	<target host="maxymiser.com" />
 	<target host="*.maxymiser.com" />
-	<target host="*.www.maxymiser.com" />
 	<target host="service.maxymiser.net" />
 
 

--- a/src/chrome/content/rules/MediaFire.com.xml
+++ b/src/chrome/content/rules/MediaFire.com.xml
@@ -20,14 +20,10 @@
 
 <ruleset name="MediaFire.com">
 	<!-- Mismatch: -->
-	<target host="staticcdn.mediafire.com" />
 	<rule from="^http://staticcdn\.mediafire\.com/" to="https://static-cdn.mediafire.com/" />
 		<test url="http://staticcdn.mediafire.com/images/buttons/btn_twitter_connect.png" />
 
 	<!-- Redirect to http: -->
-	<target host="www.mediafire.com" />
-	<target host="www1.mediafire.com" />
-	<target host="www2.mediafire.com" />
 		<test url="http://www.mediafire.com/asuswrt-merlin/" />
 		<test url="http://www1.mediafire.com/asuswrt-merlin/" />
 		<test url="http://www2.mediafire.com/asuswrt-merlin/" />
@@ -53,9 +49,6 @@
 
 	<!-- Directly: -->
 	<target host="mediafire.com" />
-	<target host="cdn.mediafire.com" />
-	<target host="cdnssl.mediafire.com" />
-	<target host="m.mediafire.com" />
 
 	<target host="*.mediafire.com" />
 		<test url="http://mediafire.com/asuswrt-merlin/" />

--- a/src/chrome/content/rules/MeiTuan.com.xml
+++ b/src/chrome/content/rules/MeiTuan.com.xml
@@ -27,33 +27,16 @@
 
 <ruleset name="MeiTuan.com">
 	<!--Directly:-->
-	<target host="www.meituan.com"/>
-	<target host="analytics.meituan.com"/>
-	<target host="b.meituan.com"/>
-	<target host="daili.meituan.com"/>
-	<target host="hotel.meituan.com"/>
-	<target host="mos.meituan.com"/>
-	<target host="p0.meituan.com"/>
-	<target host="p1.meituan.com"/>
-	<target host="passport.meituan.com"/>
-	<target host="report.meituan.com"/>
-	<target host="s0.meituan.com"/>
-	<target host="s1.meituan.com"/>
 		<test url="http://s1.meituan.com/bs/js/?f=mta-js:mta.min.js" />
-	<target host="waimaie.meituan.com"/>
 
 	<!--MCB:-->
-	<target host="i.meituan.com"/>
 		<exclusion pattern="^http://i\.meituan\.com/mobile/" />
 		<test url="http://i.meituan.com/mobile/down/meituan" />
-
-	<target host="waimai.meituan.com"/>
 		<exclusion pattern="^http://waimai\.meituan\.com/(?!static/)" />
 		<test url="http://waimai.meituan.com/static/img/logos/small_3.png" />
 		<test url="http://waimai.meituan.com/mobile/download/default" />
 
 	<!--For Cities:-->
-	<target host="kaidian.waimai.meituan.com"/>
 	<rule from="^http://kaidian\.waimai\.meituan\.com/"
 			to="https://kaidian.waimai.meituan.com/" />
 		<test url="http://kaidian.waimai.meituan.com/images/welcome/step1.png" />

--- a/src/chrome/content/rules/Mentor-Graphics.xml
+++ b/src/chrome/content/rules/Mentor-Graphics.xml
@@ -15,7 +15,6 @@
 		<!--
 			* for cross-domain cookie.
 							-->
-		<target host="*.store1.mentor.com" />
 
 
 	<securecookie host="^\.store1\.mentor\.com$" name=".*" />

--- a/src/chrome/content/rules/NAVTEQ.xml
+++ b/src/chrome/content/rules/NAVTEQ.xml
@@ -32,7 +32,6 @@ Fetch error: http://www.navteqmedia.com/ => https://primeplace.nokia.com/: (51, 
 
 	<target host="navteq.com" />
 	<target host="*.navteq.com" />
-	<target host="css.mapreporter.navteq.com" />
 	<target host="navteqmedia.com" />
 	<target host="www.navteqmedia.com" />
 

--- a/src/chrome/content/rules/National_Park_Service.xml
+++ b/src/chrome/content/rules/National_Park_Service.xml
@@ -56,7 +56,6 @@ Fetch error: http://www.npssa.nps.gov/ => https://www.npssa.nps.gov/: (6, 'Could
 	<target host="irmafiles.nps.gov" /><!--	for future commit -->
 	<target host="nature.nps.gov" /><!--	for future commit -->
 	<target host="*.nature.nps.gov" /><!--	for future commit -->
-	<target host="science.nature.nps.gov" />
 	<target host="ncptt.nps.gov" />
 	<target host="www.ncptt.nps.gov" /><!--	for future commit -->
 	<target host="npssa.nps.gov" />

--- a/src/chrome/content/rules/NetMediaEurope.xml
+++ b/src/chrome/content/rules/NetMediaEurope.xml
@@ -21,8 +21,6 @@
 
 -->
 <ruleset name="NetMediaEurope" default_off="expired, mismatch">
-
-	<target host="quiz.itespresso.fr"/>
 	<!--	plesk	-->
 	<target host="itespresso.fr"/>
 	<target host="*.itespresso.fr"/>

--- a/src/chrome/content/rules/ONEsite.xml
+++ b/src/chrome/content/rules/ONEsite.xml
@@ -18,7 +18,6 @@
 <ruleset name="ONEsite (partial)">
 
 	<target host="*.onesite.com" />
-	<target host="*.admin.onesite.com" />
 
 
 	<securecookie host="^\.admin\.onesite\.com$" name=".+" />

--- a/src/chrome/content/rules/Oberlin_College.xml
+++ b/src/chrome/content/rules/Oberlin_College.xml
@@ -37,8 +37,6 @@ Fetch error: http://oncampus.csr.oberlin.edu/ => https://oncampus.csr.oberlin.ed
 <ruleset name="Oberlin College (partial)" default_off='failed ruleset test'>
 
 	<target host="*.oberlin.edu" />
-	<target host="*.cs.oberlin.edu" />
-	<target host="oncampus.csr.oberlin.edu" />
 
 
 	<securecookie host="^.+\.oberlin\.edu$" name=".+" />

--- a/src/chrome/content/rules/OnSugar.xml
+++ b/src/chrome/content/rules/OnSugar.xml
@@ -12,8 +12,6 @@
 			301s back to www.
 						-->
 		<exclusion pattern="^http://www\.onsugar\.com/(?:$|\?)" />
-	<target host="secure.*.onsugar.com" />
-	<target host="www.*.onsugar.com" />
 
 
 	<securecookie host="^.*\.onsugar\.com$" name=".*" />

--- a/src/chrome/content/rules/Pair-Networks.xml
+++ b/src/chrome/content/rules/Pair-Networks.xml
@@ -15,7 +15,6 @@
 	<target host="www.eliminatejunkemail.com" />
 	<target host="pair.com" />
 	<target host="*.pair.com" />
-	<target host="*.webmail.pair.com" />
 	<target host="pairlite.com" />
 	<target host="*.pairlite.com" />
 	<target host="pairnic.com" />

--- a/src/chrome/content/rules/Polytechnic-University-of-Catalonia.xml
+++ b/src/chrome/content/rules/Polytechnic-University-of-Catalonia.xml
@@ -2,7 +2,6 @@
 
 	<target host="upc.edu"/>
 	<target host="*.upc.edu"/>
-	<target host="*.blog.upc.edu"/>
 	<target host="upc.es"/>
 	<target host="*.upc.es"/>
 

--- a/src/chrome/content/rules/Poppy-Sports.xml
+++ b/src/chrome/content/rules/Poppy-Sports.xml
@@ -8,7 +8,6 @@ Fetch error: http://poppysports.com/ => https://www.poppysports.com/: (51, "SSL:
 
 	<target host="poppysports.com" />
 	<target host="*.poppysports.com" />
-	<target host="*.www.poppysports.com" />
 
 	<rule from="^http://(?:www\.)?poppysports\.com/"
 		to="https://www.poppysports.com/" />

--- a/src/chrome/content/rules/Prxy.com.xml
+++ b/src/chrome/content/rules/Prxy.com.xml
@@ -16,7 +16,6 @@
 <ruleset name="prxy.com" default_off="missing certificate chain">
 
 	<target host="prxy.com" />
-	<target host="www.prxy.com" />
 
 	<target host="*.prxy.com" />
 

--- a/src/chrome/content/rules/RTEMS.xml
+++ b/src/chrome/content/rules/RTEMS.xml
@@ -9,13 +9,6 @@
 	<target host="rtems.org" />
 	<target host="*.rtems.org" />
 
-		<target host="devel.rtems.org" />
-		<target host="docs.rtems.org" />
-		<target host="git.rtems.org" />
-		<target host="lists.rtems.org" />
-		<target host="wiki.rtems.org" />
-		<target host="www.rtems.org" />
-
 
 	<!--	Not secured by server:
 					-->

--- a/src/chrome/content/rules/Radboud-University-Nijmegen.xml
+++ b/src/chrome/content/rules/Radboud-University-Nijmegen.xml
@@ -16,10 +16,7 @@ Fetch error: http://ru.nl/ => https://www.ru.nl/: Cycle detected - URL already e
 	<target host="*.radboudnet.nl" />
 	<target host="ru.nl" />
 	<target host="*.ru.nl" />
-	<target host="*.cmbi.ru.nl" />
-	<target host="*.hosting.ru.nl" />
 	<!--	* for cross-domain cookie.	-->
-	<target host="*.portalhelp.hosting.ru.nl" />
 
 
 	<securecookie host="^www(?:-acc)?\.radboudnet\.nl$" name=".*" />

--- a/src/chrome/content/rules/Royal_Mail.xml
+++ b/src/chrome/content/rules/Royal_Mail.xml
@@ -10,7 +10,6 @@
 
 	<target host="royalmail.com" />
 	<target host="*.royalmail.com" />
-	<target host="*.shop.royalmail.com" />
 
 
 	<securecookie host="^(?:\.?shop|www2)\.royalmail\.com$" name=".+" />

--- a/src/chrome/content/rules/Secunet.xml
+++ b/src/chrome/content/rules/Secunet.xml
@@ -2,7 +2,6 @@
 
 	<target host="secunet.com" />
 	<target host="*.secunet.com" />
-	<target host="www.secunet.com" />
 
 
 	<!--	Tracking cookies:

--- a/src/chrome/content/rules/SexNarod.xml
+++ b/src/chrome/content/rules/SexNarod.xml
@@ -4,10 +4,8 @@
 	<target host="www.sexnarod.ru"/>
 	<target host="superforum.org"/>
 	<target host="*.superforum.org"/>
-	<target host="*.dating.superforum.org"/>
 	<target host="sxnarod.com"/>
 	<target host="*.sxnarod.com"/>
-	<target host="wap.dating.sxnarod.com"/>
 
 	<rule from="^http://(?:www\.)?(sexnarod\.ru|superforum\.org|sxnarod\.com)/"
 		to="https://www.$1/"/>

--- a/src/chrome/content/rules/Sheet-Music-Plus.xml
+++ b/src/chrome/content/rules/Sheet-Music-Plus.xml
@@ -4,7 +4,6 @@
 
 	<target host="sheetmusicplus.com"/>
 	<target host="*.sheetmusicplus.com"/>
-	<target host="ssl.assets.sheetmusicplus.com"/>
 
 	<rule from="^http://sheetmusicplus\.com/"
 		to="https://www.sheetmusicplus.com/"/>

--- a/src/chrome/content/rules/Skrill.com.xml
+++ b/src/chrome/content/rules/Skrill.com.xml
@@ -26,10 +26,6 @@ Fetch error: http://sso.skrill.com/ => https://sso.skrill.com/: (7, 'Failed to c
 <ruleset name="Skrill.com" default_off='failed ruleset test'>
 
 	<target host="skrill.com" />
-	<target host="account.skrill.com" />
-	<target host="help.skrill.com" />
-	<target host="sso.skrill.com" />
-	<target host="www.skrill.com" />
 
 	<target host="*.skrill.com" />
 

--- a/src/chrome/content/rules/Snagajob.xml
+++ b/src/chrome/content/rules/Snagajob.xml
@@ -1,6 +1,5 @@
 <ruleset name="snagajob" platform="mixedcontent">
   <target host="snagajob.com"/>
-  <target host="www.snagajob.com"/>
   <target host="*.snagajob.com"/>
 
   <securecookie host="^(?:.*\.)?snagajob.com$" name=".*" />

--- a/src/chrome/content/rules/Spoki.xml
+++ b/src/chrome/content/rules/Spoki.xml
@@ -3,7 +3,6 @@
 	<target host="spoki.lv"/>
 	<!--	* for cross-domain cookies	-->
 	<target host="*.spoki.lv"/>
-	<target host="*.www.spoki.lv"/>
 
 	<securecookie host="^.*\.spoki\.lv$" name=".*"/>
 

--- a/src/chrome/content/rules/StumbleUpon.xml
+++ b/src/chrome/content/rules/StumbleUpon.xml
@@ -26,7 +26,6 @@
 	<target host="sustatic.com" />
 	<target host="*.sustatic.com" />
 	<!--	* for cross-domain cookie.	-->
-	<target host="*.b9.stumbleupon.com" />
 
 
 	<securecookie host="^.*\.s(?:tumbleupon|ustatic)\.com$" name=".*" />

--- a/src/chrome/content/rules/Symantec.xml
+++ b/src/chrome/content/rules/Symantec.xml
@@ -139,11 +139,6 @@ Fetch error: http://static3.symanteccloud.com/ => https://static3.symanteccloud.
 	<target host="customersupport.symantec.com" />
 	<target host="liveupdate.symantec.com" />
 	<target host="securityresponse.symantec.com" />
-	<target host="buy.symanteccloud.com" />
-	<target host="static.symanteccloud.com" />
-	<target host="static1.symanteccloud.com" />
-	<target host="static2.symanteccloud.com" />
-	<target host="static3.symanteccloud.com" />
 
 		<!--	These redirect to http.
 						-->

--- a/src/chrome/content/rules/Target_Performance.xml
+++ b/src/chrome/content/rules/Target_Performance.xml
@@ -1,6 +1,5 @@
 <ruleset name="Targeting Performance">
 <target host="*.ad-srv.net"/>
-<target host="*.ad.ad-srv.net"/>
 
 <rule from="^http://ad\.ad-srv\.net/" to="https://ad.ad-srv.net/"/>
 <rule from="^http://(n2|n34)\.ad\.ad-srv\.net/" to="https://$1.ad-srv.net/"/>

--- a/src/chrome/content/rules/Telefonica.xml
+++ b/src/chrome/content/rules/Telefonica.xml
@@ -58,7 +58,6 @@ Fetch error: http://www.o2.sk/ => https://www.o2.sk/: (18, 'transfer closed with
 	<target host="www.cz.o2.com"/>
 	<target host="o2.cz"/>
 	<target host="*.o2.cz"/>
-	<target host="*.www.o2.cz"/>
 	<target host="*.o2.de" />
 	<target host="i.o2active.cz"/>
 	<target host="mail.o2active.cz"/>

--- a/src/chrome/content/rules/Textbooks.com.xml
+++ b/src/chrome/content/rules/Textbooks.com.xml
@@ -3,7 +3,6 @@
 	<target host="textbooks.com" />
 	<target host="*.textbooks.com" />
 	<!--	* for cross-domain cookie	-->
-	<target host="*.www.textbooks.com" />
 
 
 	<securecookie host="^.*\.textbooks\.com$" name=".*" />

--- a/src/chrome/content/rules/The-Escapist-Expo.xml
+++ b/src/chrome/content/rules/The-Escapist-Expo.xml
@@ -14,7 +14,6 @@ Fetch error: http://www.sec.escapistexpo.com/ => https://www.sec.escapistexpo.co
 
 	<target host="escapistexpo.com" />
 	<target host="*.escapistexpo.com" />
-	<target host="www.sec.escapistexpo.com" />
 
 
 	<!--	Cert only matches (www.)sec.	-->

--- a/src/chrome/content/rules/UBS.xml
+++ b/src/chrome/content/rules/UBS.xml
@@ -83,7 +83,6 @@ Fetch error: http://grs.ubs.com/ => https://grs.ubs.com/: (35, 'Unknown SSL prot
 <ruleset name="UBS.com (partial)" default_off='failed ruleset test'>
 	<target host="ubs.com" />
 	<target host="*.ubs.com" />
-	<target host="*.ibb.ubs.com" />
 
 		<exclusion pattern="^http://ebanking-us\.ubs\.com/" />
 

--- a/src/chrome/content/rules/UCSD.edu.xml
+++ b/src/chrome/content/rules/UCSD.edu.xml
@@ -367,87 +367,22 @@ Fetch error: http://www.mytritonlink.ucsd.edu/ => https://act.ucsd.edu/myTritonl
      I haven't yet verified the (non-)existence of www subdomains for all cases.
 -->
 <!-- normally https only; protect against sslstripping -->
-   <target host="a4.ucsd.edu" />
-   <target host="acs-webmail.ucsd.edu" />
-   <target host="altng.ucsd.edu" />
-   <target host="aventeur.ucsd.edu" />
-   <target host="cinfo.ucsd.edu" />
-   <target host="facilities.ucsd.edu" />
-   <target host="gradapply.ucsd.edu" />
-   <target host="graduateapp.ucsd.edu" />
-   <target host="jacobsstudent.ucsd.edu" />
-   <target host="myucsdchart.ucsd.edu" />
-   <target host="sdacs.ucsd.edu" />
-   <target host="shs.ucsd.edu" />
-   <target host="ted.ucsd.edu" />
-   <target host="ucsdbkst.ucsd.edu" />
 <!-- supports https but doesn't enforce it on all pages
 
      CSE, ECE, Mechanical and Aerospace Engineering, Nanoengineering, Structural Engineering depts share one server.
      Its SubjectAltName also mentions the following domains, but I've not written rules for them because they're for private use:
      oec-vmweb03.ucsd.edu, ece-internal.ucsd.edu, t (unqualified!)
-     There is usually mixed content from www.jacobsschool.ucsd.edu -->
-   <target host="a.ucsd.edu" />
-   <target host="acms.ucsd.edu" />
-   <target host="bookstore.ucsd.edu" />
-   <target host="www.bookstore.ucsd.edu" /><!-- cert mismatch, rule redirects it to domain without www -->
-   <target host="cs.ucsd.edu" />
-   <target host="www.cs.ucsd.edu" />
-   <target host="cse.ucsd.edu" />
-   <target host="www.cse.ucsd.edu" />
-   <target host="ece.ucsd.edu" />
-   <target host="www.ece.ucsd.edu" />
-   <target host="hdh.ucsd.edu" />
-   <target host="www.hdh.ucsd.edu" />
-   <target host="hds.ucsd.edu" />
-   <target host="www.hds.ucsd.edu" /><!-- cert mismatch, rule redirects it to domain without www -->
-   <target host="maeweb.ucsd.edu" />
-   <target host="nanoengineering.ucsd.edu" />
-   <target host="www.nanoengineering.ucsd.edu" />
-   <target host="ne-web.ucsd.edu" />
-   <target host="ne.ucsd.edu" />
-   <target host="neweb.ucsd.edu" />
-   <target host="roger.ucsd.edu" />
-   <target host="se.ucsd.edu" />
-   <target host="structures.ucsd.edu" />
-   <target host="www.structures.ucsd.edu" />
-   <target host="uxt.ucsd.edu" />
-   <target host="www-cs.ucsd.edu" />
-   <target host="www-cse.ucsd.edu" />
-   <target host="www-ne.ucsd.edu" />
-   <target host="www-structures.ucsd.edu" />
+     There is usually mixed content from www.jacobsschool.ucsd.edu --><!-- cert mismatch, rule redirects it to domain without www --><!-- cert mismatch, rule redirects it to domain without www -->
 <!-- only some features known to support https; protect them against sslstripping (not Firesheep) -->
-   <target host="act.ucsd.edu" />
-   <target host="health.ucsd.edu" />
 		<!--
 			Redurects to http, along with:
 
 				- news/Pages/
 				- news/releases/Pages/
 								-->
-		<exclusion pattern="^http://health\.ucsd\.edu/_layouts/spsredirect\.aspx" />
-   <target host="libraries.ucsd.edu" />
-   <target host="studenthealth.ucsd.edu" /><!-- XXX: Does this still use ipsCA? -->
-   <target host="www-act.ucsd.edu" />
+		<exclusion pattern="^http://health\.ucsd\.edu/_layouts/spsredirect\.aspx" /><!-- XXX: Does this still use ipsCA? -->
 <!-- redirectors
      TODO: full Link Family list at http://blink.ucsd.edu/technology/help-desk/applications/link-family/list.html -->
-   <target host="accesslink.ucsd.edu" />
-   <target host="acs.ucsd.edu" />
-   <target host="cri.ucsd.edu" />
-   <target host="desktop.ucsd.edu" />
-   <target host="financiallink.ucsd.edu" />
-   <target host="iwdc.ucsd.edu" />
-   <target host="marketplace.ucsd.edu" />
-   <target host="mytritonlink.ucsd.edu" />
-   <target host="www.mytritonlink.ucsd.edu" />
-   <target host="resnet.ucsd.edu" />
-   <target host="software.ucsd.edu" />
-   <target host="sysstaff.ucsd.edu" />
-   <target host="tritonlink.ucsd.edu" />
-   <target host="www.tritonlink.ucsd.edu" />
-   <target host="uclearning.ucsd.edu" />
-   <target host="webmail.ucsd.edu" />
-   <target host="www-acs.ucsd.edu" />
 
 	<target host="ucsd.edu" />
 	<target host="*.ucsd.edu" />

--- a/src/chrome/content/rules/US-Dept-of-Veterans-Affairs.xml
+++ b/src/chrome/content/rules/US-Dept-of-Veterans-Affairs.xml
@@ -101,9 +101,7 @@ Fetch error: http://www.va.gov/ => https://www.va.gov/: (28, 'Operation timed ou
 	<target host="www.insurance.va.gov" />
 	<target host="vaforvets.va.gov" />
 	<target host="*.vaforvets.va.gov" />
-	<target host="www.*.vaforvets.va.gov" />
 	<target host="*.vba.va.gov" />
-	<target host="www.*.vba.va.gov" />
 
 	<target host="va.gov" />
 	<target host="www.va.gov" />

--- a/src/chrome/content/rules/US_State_Department.xml
+++ b/src/chrome/content/rules/US_State_Department.xml
@@ -316,7 +316,6 @@ Fetch error: http://uk.state.gov/ => https://uk.state.gov/: (35, 'Unknown SSL pr
 	<target host="campususa.state.gov" />
 	<target host="www.careers.state.gov" />
 	<target host="ghaznitowers.state.gov" />
-	<target host="www.history.state.gov" />
 	<target host="www.infocentral.state.gov" />
 	<target host="www.oig.state.gov" />
 	<target host="www.passports.state.gov" />

--- a/src/chrome/content/rules/United-States-Department-of-Energy.xml
+++ b/src/chrome/content/rules/United-States-Department-of-Energy.xml
@@ -12,7 +12,6 @@
 <ruleset name="United States Department of Energy (partial)">
 
 	<target host="*.doe.gov" />
-	<target host="www.*.doe.gov" />
 
 
 	<securecookie host="^(?:www\.)?directives\.doe\.gov$" name=".*" />

--- a/src/chrome/content/rules/UniversalSubtitles.xml
+++ b/src/chrome/content/rules/UniversalSubtitles.xml
@@ -9,7 +9,6 @@ Fetch error: http://universalsubtitles.org/ => https://www.universalsubtitles.or
 <ruleset name="Universal Subtitles" default_off='failed ruleset test'>
   <target host="universalsubtitles.org" />
   <target host="*.universalsubtitles.org" />
-  <target host="s3.www.universalsubtitles.org" />
 
   <rule from="^http://universalsubtitles\.org/"
           to="https://www.universalsubtitles.org/" />

--- a/src/chrome/content/rules/University-of-Alaska.xml
+++ b/src/chrome/content/rules/University-of-Alaska.xml
@@ -24,10 +24,6 @@ Fetch error: http://biotech.inbre.alaska.edu/ => https://biotech.inbre.alaska.ed
 
 	<target host="alaska.edu" />
 	<target host="*.alaska.edu" />
-	<target host="www.*.alaska.edu" />
-	<target host="biotech.inbre.alaska.edu" />
-	<target host="lib.uaa.alaska.edu" />
-	<target host="*.vpn.alaska.edu" />
 
 
 	<securecookie host="^www\.uaa\.alaska\.edu$" name=".+" />

--- a/src/chrome/content/rules/University-of-Bern.xml
+++ b/src/chrome/content/rules/University-of-Bern.xml
@@ -13,7 +13,6 @@
 <ruleset name="University of Bern (partial)">
 
 	<target host="*.unibe.ch" />
-	<target host="www.*.unibe.ch" />
 
 
 	<securecookie host="^.*\.unibe\.ch$" name=".*" />

--- a/src/chrome/content/rules/University-of-Delaware.xml
+++ b/src/chrome/content/rules/University-of-Delaware.xml
@@ -2,8 +2,6 @@
 
 	<target host="udel.edu" />
 	<target host="*.udel.edu" />
-	<target host="*.facilities.udel.edu" />
-	<target host="*.nss.udel.edu" />
 
 
 	<securecookie host="^(?:extension|.*\.nss)\.udel\.edu$" name=".+" />

--- a/src/chrome/content/rules/University-of-Groningen.xml
+++ b/src/chrome/content/rules/University-of-Groningen.xml
@@ -6,7 +6,6 @@ Fetch error: http://www.astro.rug.nl/ => https://www.astro.rug.nl/: (60, 'SSL ce
 
 	<target host="rug.nl"/>
 	<target host="*.rug.nl"/>
-	<target host="www.astro.rug.nl"/>
 
 	<rule from="^http://(www\.)?rug\.nl/(_definition/|sterrenkunde/([!_]css|_shared/|onderwijs/index!login))"
 		to="https://$1rug.nl/$2"/>

--- a/src/chrome/content/rules/University-of-Idaho.xml
+++ b/src/chrome/content/rules/University-of-Idaho.xml
@@ -29,8 +29,6 @@ Fetch error: http://www2.sites.uidaho.edu/ => https://www2.sites.uidaho.edu/: (6
 	<!--
 		^dfa, ^its, ^sci, ^sites, ^uiweb, & ^webedit don't exist.
 					-->
-	<target host="www.*.uidaho.edu" />
-	<target host="www2.sites.uidaho.edu" />
 
 
 	<securecookie host="^\w.*\.uidaho\.edu$" name=".+" />

--- a/src/chrome/content/rules/University-of-Massachusetts-Amherst.xml
+++ b/src/chrome/content/rules/University-of-Massachusetts-Amherst.xml
@@ -24,10 +24,7 @@
 	<target host="umassathletics.cstv.com" />
 	<target host="umass.edu" />
 	<target host="*.umass.edu" />
-	<target host="*.oit.umass.edu" />
-	<target host="*.spire.umass.edu" />
 	<!--	* for cross-domain cookie.	-->
-	<target host="*.umii.umass.edu" />
 	<target host="umassulearn.net" />
 	<target host="www.umassulearn.net" />
 

--- a/src/chrome/content/rules/University-of-South-Florida.xml
+++ b/src/chrome/content/rules/University-of-South-Florida.xml
@@ -24,7 +24,6 @@ Fetch error: http://usfsp.edu/ => https://usfsp.edu/: (51, "SSL: no alternative 
 <ruleset name="University of South Florida (partial)" default_off='failed ruleset test'>
 
 	<target host="*.usf.edu" />
-	<target host="*.stpete.usf.edu" />
 	<target host="usfsp.edu" />
 	<target host="*.usfsp.edu" />
 

--- a/src/chrome/content/rules/University-of-Southampton.xml
+++ b/src/chrome/content/rules/University-of-Southampton.xml
@@ -13,7 +13,6 @@
 	<target host="*.noc.ac.uk" />
 	<target host="soton.ac.uk" />
 	<target host="*.soton.ac.uk" />
-	<target host="www.*.soton.ac.uk" />
 	<target host="www.southampton.ac.uk" />
 
 

--- a/src/chrome/content/rules/University_of_Houston.xml
+++ b/src/chrome/content/rules/University_of_Houston.xml
@@ -45,9 +45,6 @@
 <ruleset name="University of Houston (partial)">
 
 	<target host="*.uh.edu" />
-	<target host="www.*.uh.edu" />
-	<target host="fp.my.uh.edu" />
-	<target host="*.nsm.uh.edu" />
 
 
 	<securecookie host="^.+\.uh\.edu$" name=".+" />

--- a/src/chrome/content/rules/University_of_Maine.xml
+++ b/src/chrome/content/rules/University_of_Maine.xml
@@ -26,7 +26,6 @@
 
 	<target host="umaine.edu" />
 	<target host="*.umaine.edu" />
-	<target host="www.*.umaine.edu" />
 	<target host="*.umext.maine.edu" />
 
 

--- a/src/chrome/content/rules/University_of_Salford.xml
+++ b/src/chrome/content/rules/University_of_Salford.xml
@@ -13,7 +13,6 @@
 <ruleset name="University of Salford (partial)">
 
 	<target host="*.salford.ac.uk" />
-	<target host="*.www.salford.ac.uk" />
 
 
 	<securecookie host="^\.www\.salford\.ac\.uk$" name=".+" />

--- a/src/chrome/content/rules/University_of_Waikato.xml
+++ b/src/chrome/content/rules/University_of_Waikato.xml
@@ -32,8 +32,6 @@
 
 	<target host="waikato.ac.nz" />
 	<target host="*.waikato.ac.nz" />
-	<target host="tools.its.waikato.ac.nz" />
-	<target host="www.mngt.waikato.ac.nz" />
 
 
 	<securecookie host="^.+\.waikato\.ac\.nz$" name=".+" />

--- a/src/chrome/content/rules/University_of_Wisconsin-Madison.xml
+++ b/src/chrome/content/rules/University_of_Wisconsin-Madison.xml
@@ -78,7 +78,6 @@ Fetch error: http://wayf.wisc.edu/ => https://wayf.wisc.edu/: (6, 'Could not res
 <ruleset name="University of Wisconsin-Madison" default_off='failed ruleset test'>
 
 	<target host="*.wisc.edu" />
-	<target host="*.library.wisc.edu" />
 
 	<!-- 404: Individual users must enable SSL for their personal pages. -->
 	<exclusion pattern="^http://pages\.cs\.wisc\.edu/+~" />

--- a/src/chrome/content/rules/UserEcho.com.xml
+++ b/src/chrome/content/rules/UserEcho.com.xml
@@ -9,9 +9,6 @@
 <ruleset name="UserEcho.com">
 
 	<target host="userecho.com"/>
-	<target host="www.userecho.com"/>
-	<target host="blog.userecho.com" />
-	<target host="feedback.userecho.com"/>
 
 	<target host="*.userecho.com"/>
 		<test url="http://imgur.userecho.com/" />

--- a/src/chrome/content/rules/Vdopia.xml
+++ b/src/chrome/content/rules/Vdopia.xml
@@ -50,7 +50,6 @@ Fetch error: http://mobile.sb.vdopia.com/ => https://mobile.sb.vdopia.com/: (28,
 	<target host="vdopia.com" />
 	<target host="*.vdopia.com" />
 		<exclusion pattern="^http://i2\.vdopia\.com/(?!js/)" />
-	<target host="mobile.sb.vdopia.com" />
 
 
 	<securecookie host="^(?:.+\.)?vdopia\.com$" name=".+" />

--- a/src/chrome/content/rules/Wikidot.xml
+++ b/src/chrome/content/rules/Wikidot.xml
@@ -4,15 +4,6 @@
 
 	<target host="wdfiles.com"/>
 	<target host="*.wdfiles.com"/>
-	<target host="1.*.wdfiles.com"/>
-	<target host="2.*.wdfiles.com"/>
-	<target host="3.*.wdfiles.com"/>
-	<target host="4.*.wdfiles.com"/>
-	<target host="5.*.wdfiles.com"/>
-	<target host="6.*.wdfiles.com"/>
-	<target host="7.*.wdfiles.com"/>
-	<target host="8.*.wdfiles.com"/>
-	<target host="9.*.wdfiles.com"/>
 	<target host="wikidot.com"/>
 	<target host="*.wikidot.com"/>
 		<exclusion pattern="^http://blog\.wikidot\.com/(?:$|blog:.+[^/].*)"/>

--- a/src/chrome/content/rules/Wikinvest.xml
+++ b/src/chrome/content/rules/Wikinvest.xml
@@ -2,7 +2,6 @@
 
 	<target host="wikinvest.com" />
 	<target host="*.wikinvest.com" />
-	<target host="*.www.wikinvest.com" />
 
 
 	<securecookie host="^\.www\.wikinvest\.com$" name=".+" />

--- a/src/chrome/content/rules/Wiley.xml
+++ b/src/chrome/content/rules/Wiley.xml
@@ -24,8 +24,6 @@ Non-2xx HTTP code: http://sp.onlinelibrary.wiley.com/ (200) => https://sp.online
 
 	<target host="wiley.com"/>
 	<target host="*.wiley.com"/>
-	<target host="onlinelibrarystatic.wiley.com"/>
-	<target host="sp.onlinelibrary.wiley.com" />
 
 
 	<securecookie host="^sp\.onlinelibrary\.wiley\.com$" name=".*" />

--- a/src/chrome/content/rules/Wolfram_Alpha.xml
+++ b/src/chrome/content/rules/Wolfram_Alpha.xml
@@ -26,24 +26,6 @@ Timeout:
 	<target host="*.wolframalpha.com" />
 	<test url="http://www10.wolframalpha.com/" />
 	<test url="http://www20.wolframalpha.com/" />
-	<target host="api.wolframalpha.com" />
-	<target host="api-cn.wolframalpha.com" />
-	<target host="api-maps.wolframalpha.com" />
-	<target host="api-tw.wolframalpha.com" />
-	<target host="developer.wolframalpha.com" />
-	<target host="m.wolframalpha.com" />
-	<target host="preview.wolframalpha.com" />
-	<target host="products.wolframalpha.com" />
-	<target host="volunteer.wolframalpha.com" />
-	<target host="wc.wolframalpha.com" />
-	<target host="www1.wolframalpha.com" />
-	<target host="www3.wolframalpha.com" />
-	<target host="www4b.wolframalpha.com" />
-	<target host="www4c.wolframalpha.com" />
-	<target host="www4d.wolframalpha.com" />
-	<target host="www4f.wolframalpha.com" />
-	<target host="www5a.wolframalpha.com" />
-	<target host="www5b.wolframalpha.com" />
 
 	<rule from="^http://api-(cn|maps|tw)\.wolframalpha\.com/" to="https://www.wolframalpha.com/" />
 	<rule from="^http://volunteer\.wolframalpha\.com/" to="https://www.wolframalpha.com/" />

--- a/src/chrome/content/rules/Woot.xml
+++ b/src/chrome/content/rules/Woot.xml
@@ -17,8 +17,6 @@ Non-2xx HTTP code: http://images.deals.woot.com/ (200) => https://s3.amazonaws.c
 	<target host="woot.com" />
 	<target host="*.woot.com" />
 		<!--exclusion pattern="^http://www\.woot\.com/(forums|(jobs|recalls|sponsorus|terms|writeus)\.aspx|User)" /-->
-	<target host="images.deals.woot.com" />
-	<target host="gzip.static.woot.com" />
 
 
 	<!--	403s :(

--- a/src/chrome/content/rules/dpfile.com.xml
+++ b/src/chrome/content/rules/dpfile.com.xml
@@ -13,9 +13,6 @@
 
 <ruleset name="dpfile.com">
 
-	<target host="qcloud.dpfile.com" />
-	<target host="www.dpfile.com" />
-
 	<rule from="^http://(qcloud|www)\.dpfile\.com/" to="https://$1.dpfile.com/" />
 		<test url="http://qcloud.dpfile.com/pc/xgj785KvGaskMqMkEijIVI3qV67QyBeWSmzHlLUmvqAW2o0Pn5aTguX_PQEudt5rtOnd3gXQdDYlAqlaVaAFeZ0rYYyiRo_EhzufqWWjTjs.jpg" />
 		<test url="http://www.dpfile.com/sc/image/31010502000052.png" />

--- a/src/chrome/content/rules/garmin.xml
+++ b/src/chrome/content/rules/garmin.xml
@@ -1,5 +1,4 @@
 <ruleset name="Garmin">
-	<target host="www.garmin.com" />
 	<target host="garmin.com" />
   <target host="*.garmin.com" />
 

--- a/src/chrome/content/rules/kantonalbanken.xml
+++ b/src/chrome/content/rules/kantonalbanken.xml
@@ -43,7 +43,6 @@ Fetch error: http://tradedirect.ch/ => https://tradedirect.ch/: (51, "SSL: no al
 	<target host="*.bekb.ch"/>
 	<target host="bkb.ch"/>
 	<target host="*.bkb.ch"/>
-	<target host="integration.quotes.bkb.ch"/>
 	<target host="blkb.ch"/>
 	<target host="*.blkb.ch"/>
 	<target host="gkb.ch"/>

--- a/src/chrome/content/rules/mytalkdesk.com.xml
+++ b/src/chrome/content/rules/mytalkdesk.com.xml
@@ -1,6 +1,5 @@
 <ruleset name="mytalkdesk.com">
 	<target host=    "mytalkdesk.com" />
-	<target host="www.mytalkdesk.com" />
 	<target host=  "*.mytalkdesk.com" />
 
   	<securecookie host="^.*\.mytalkdesk\.com$" name=".+" />

--- a/src/chrome/content/rules/uptodown.com.xml
+++ b/src/chrome/content/rules/uptodown.com.xml
@@ -14,16 +14,7 @@
 
 <ruleset name="uptodown.com">
 	<target host="uptodown.com" />
-	<target host="www.uptodown.com" />
-	<target host="api.uptodown.com" />
-	<target host="blog.uptodown.com" />
-	<target host="dw.uptodown.com" />
-	<target host="feeds.uptodown.com" />
-	<target host="gstatic.uptodown.com" />
 		<test url="http://gstatic.uptodown.com/css/v10.86.css" />
-	<target host="img.uptodown.com" />
-	<target host="stat.uptodown.com" />
-	<target host="stc.uptodown.com" />
 
 	<target host="*.uptodown.com" />
 		<exclusion pattern="^http://\S+\.downloads\.uptodown\.com/" />

--- a/test/rules/manual.checker.config
+++ b/test/rules/manual.checker.config
@@ -6,6 +6,7 @@ rulesdir = src/chrome/content/rules
 check_coverage = true
 auto_disable = false
 include_default_off = true
+check_target_validity = true
 
 [certificates]
 # Certificate trust anchors for checking chains in HTTPS connections


### PR DESCRIPTION
I've noticed many XML have targets that actually overlap and so unnecessarily duplicate each other.

I've extended target checks to test and report this automatically as reducing them might partially help with https://github.com/EFForg/https-everywhere/issues/12232.