### PR TITLE
[F-droid.org] Add targets

### DIFF
--- a/src/chrome/content/rules/F-Droid.xml
+++ b/src/chrome/content/rules/F-Droid.xml
@@ -2,14 +2,11 @@
 
 	<target host="f-droid.org" />
 	<target host="www.f-droid.org" />
+	<target host="forum.f-droid.org" />
+	<target host="test.f-droid.org" />
+	<target host="verification.f-droid.org" />
 
-
-	<!--	Secured by server:
-					-->
-	<!--securecookie host="^(www\.)?f-droid\.org$" name="^fdroidwiki_session$" /-->
-
-	<securecookie host="^\w" name="." />
-
+	<securecookie host=".+" name=".+" />
 
 	<rule from="^http:"
 		to="https:" />


### PR DESCRIPTION
Domain preloaded: https://hstspreload.org/?domain=f-droid.org

It should be removed in the next `HSTS-prune` iteration.