### PR TITLE
re-enable Ruhr-Uni-Bochum.de / remove www.rz.ruhr-uni-bochum.de

### DIFF
--- a/src/chrome/content/rules/Ruhr-Uni-Bochum.de.xml
+++ b/src/chrome/content/rules/Ruhr-Uni-Bochum.de.xml
@@ -15,9 +15,11 @@
 
 		- aktuell.ruhr-uni-bochum.de ¹
 		- ruhr-uni-bochum.de ²
+		- www.rz.ruhr-uni-bochum.de ³
 
 	¹ Mismatched, CN: www5.rz.ruhr-uni-bochum.de
 	² Mismatched
+	³ Incomplete certificate chain, fails fetch test
 
 
 	Partially covered subdomains:

--- a/src/chrome/content/rules/Ruhr-Uni-Bochum.de.xml
+++ b/src/chrome/content/rules/Ruhr-Uni-Bochum.de.xml
@@ -1,8 +1,4 @@
-
 <!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://www.rz.ruhr-uni-bochum.de/ => https://www.rz.ruhr-uni-bochum.de/: (60, 'SSL certificate problem: unable to get local issuer certificate')
-
 	Ruhr-Universitaet Bochum
 
 	For rules causing false/broken MCB, see Ruhr-Uni-Bochum.de-falsemixed.xml.
@@ -41,7 +37,6 @@ Fetch error: http://www.rz.ruhr-uni-bochum.de/ => https://www.rz.ruhr-uni-bochum
 		- Images, on:
 
 			- www.cits, www.lps from www.rz ¹
-			- www.rz from aktuell.rub.de
 			- www5.rz from www.rz ¹
 			- www5.rz from www ¹
 			- www from aktuell.rub.de ²
@@ -51,7 +46,7 @@ Fetch error: http://www.rz.ruhr-uni-bochum.de/ => https://www.rz.ruhr-uni-bochum
 	² Not secured by us <= mismatched
 
 -->
-<ruleset name="Ruhr-Uni-Bochum.de (partial)" default_off='failed ruleset test'>
+<ruleset name="Ruhr-Uni-Bochum.de (partial)">
 
 	<!--	Direct rewrites:
 				-->
@@ -62,7 +57,6 @@ Fetch error: http://www.rz.ruhr-uni-bochum.de/ => https://www.rz.ruhr-uni-bochum
 	<target host="res.mobsec.ruhr-uni-bochum.de" />
 	<target host="helpdesk.rz.ruhr-uni-bochum.de" />
 	<target host="linux.rz.ruhr-uni-bochum.de" />
-	<target host="www.rz.ruhr-uni-bochum.de" />
 	<target host="www.ruhr-uni-bochum.de" />
 	<target host="fn2.flexnow.ruhr-uni-bochum.de" />
 	<target host="www.flexnow.ruhr-uni-bochum.de" />


### PR DESCRIPTION
The entire ruleset was disabled due to the broken www.rz.ruhr-uni-bochum.de in 9bf49cbeb4696cdea76df23f685da1d11031f693