### PR TITLE
Use Map instead of Object for redirectCounter and Fix Memory Leak

### DIFF
--- a/chromium/background.js
+++ b/chromium/background.js
@@ -573,10 +573,10 @@ wr.onBeforeRequest.addListener(onBeforeRequest, {urls: ["*://*/*"]}, ["blocking"
 wr.onBeforeRedirect.addListener(onBeforeRedirect, {urls: ["https://*/*"]});
 
 // Cleanup redirectCounter if neccessary
-wr.onCompleted.addListener(onCompleted, {urls: ["https://*/*"]});
+wr.onCompleted.addListener(onCompleted, {urls: ["*://*/*"]});
 
 // Cleanup redirectCounter if neccessary
-wr.onErrorOccurred.addListener(onErrorOccurred, {urls: ["https://*/*"]})
+wr.onErrorOccurred.addListener(onErrorOccurred, {urls: ["*://*/*"]})
 
 // Listen for cookies set/updated and secure them if applicable. This function is async/nonblocking.
 chrome.cookies.onChanged.addListener(onCookieChanged);

--- a/chromium/background.js
+++ b/chromium/background.js
@@ -544,6 +544,26 @@ function onBeforeRedirect(details) {
   }
 }
 
+/**
+ * handle webrequest.onCompleted, cleanup redirectCounter
+ * @param details details for the chrome.webRequest (see chrome doc)
+ */
+function onCompleted(details) {
+  if (redirectCounter.has(details.requestId)) {
+    redirectCounter.delete(details.requestId);
+  }
+}
+
+/**
+ * handle webrequest.onErrorOccurred, cleanup redirectCounter
+ * @param details details for the chrome.webRequest (see chrome doc)
+ */
+function onErrorOccurred(details) {
+  if (redirectCounter.has(details.requestId)) {
+    redirectCounter.delete(details.requestId);
+  }
+}
+
 // Registers the handler for requests
 // See: https://github.com/EFForg/https-everywhere/issues/10039
 wr.onBeforeRequest.addListener(onBeforeRequest, {urls: ["*://*/*"]}, ["blocking"]);
@@ -552,6 +572,11 @@ wr.onBeforeRequest.addListener(onBeforeRequest, {urls: ["*://*/*"]}, ["blocking"
 // Try to catch redirect loops on URLs we've redirected to HTTPS.
 wr.onBeforeRedirect.addListener(onBeforeRedirect, {urls: ["https://*/*"]});
 
+// Cleanup redirectCounter if neccessary
+wr.onCompleted.addListener(onCompleted, {urls: ["https://*/*"]});
+
+// Cleanup redirectCounter if neccessary
+wr.onErrorOccurred.addListener(onErrorOccurred, {urls: ["https://*/*"]})
 
 // Listen for cookies set/updated and secure them if applicable. This function is async/nonblocking.
 chrome.cookies.onChanged.addListener(onCookieChanged);


### PR DESCRIPTION
## Step to reproduce the memory leak

1. From chrome://extensions, open the "Inspect views" for HTTPS Everywhere in a new session.
2. In the console, type `redirectCounter`. the console should output something like

```
Object {} // Empty Object
```

3. Visit https://www.nytimes.com/
4. Repeat Step 2, observe 

```
Object {440: 1, 444, 1}
```
5. Repeat Step 3-4, observe `redirectCounter` keep growing without sign of removing previous items
```
Object {440: 1, 444: 1, 598: 1, 601: 1, 632: 1, 635: 1}
```

This affect long lasting browsing sessions. 

**UPDATE** On Mixed Content pages, HTTP request are blocked by MCB from the browser. It is necessary to listen on both HTTP & HTTPS connection to resolve the memory leak (Assuming no "Block all unencrypted requests"). thanks.

P.S. I expected browser to handle redirect loops automatically, however, I am not really sure about the case when an extension rewrite URLs. 