### PR TITLE
Update chromium/incognito-cache-clearing.js

### DIFF
--- a/chromium/incognito-cache-clearing.js
+++ b/chromium/incognito-cache-clearing.js
@@ -16,13 +16,15 @@ function detect_incognito_creation(window) {
 }
 
 /**
- * Clear any caches we have.
+ * Clear any cache/ blacklist we have.
  * Called if an incognito session is destroyed.
  */
 function destroy_caches() {
   log(DBUG, "Destroying caches.");
   all_rules.cookieHostCache.clear();
   all_rules.ruleCache.clear();
+  domainBlacklist.clear();
+  urlBlacklist.clear();
 }
 
 /**


### PR DESCRIPTION
ping @Hainish @cowlicks To clear domainBlacklist and urlBlacklist when all incognito sessions are destroyed.

## Step to reproduce the leak

1. From chrome://extensions, open the "Inspect views" for HTTPS Everywhere in a new session.
2. Toggle "Block all unencrypted requests" and open an Incognito Session
3. In the console, type `domainBlacklist`. the console should output something like

```
Set(0) {} // Empty Set
```

4. Visit http://http.badssl.com/ (connection blocked because of too many redirects as expected)
5. Close all Incognito Sessions, repeat Step 3 and observe

```
Set(1) {"http.badssl.com"}
```

The same also hold true for urlBlacklist. 

P.S. IMHO, just a minor issue because this will require physical access to the browser console and specific types of connections to work. Thanks.