### PR TITLE
Update rewriter.js for JSON rulesets (#12273).

### DIFF
--- a/rewriter/rewriter.js
+++ b/rewriter/rewriter.js
@@ -95,9 +95,9 @@ function processFile(filename) {
 function loadRuleSets() {
   console.log("Loading rules...");
   var fileContents = fs.readFileSync(path.join(__dirname, '../pkg/crx/rules/default.rulesets'), 'utf8');
-  var xml = new DOMParser().parseFromString(fileContents, 'text/xml');
+  var json = JSON.parse(fileContents);
   ruleSets = new rules.RuleSets({});
-  ruleSets.addFromXml(xml);
+  ruleSets.addFromJson(json);
 }
 
 function usage() {


### PR DESCRIPTION
This is the error message that was being displayed:

```
Loading rules...
source code out of document root
@#[line:0,col:undefined]
chromium/rules.js:197
    for (let s of sets) {
                  ^

TypeError: undefined is not a function
    at Object.RuleSets.addFromXml (chromium/rules.js:197:19)
    at loadRuleSets (rewriter/rewriter.js:100:12)
    at Object.<anonymous> (rewriter/rewriter.js:123:1)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Function.Module.runMain (module.js:441:10)
    at startup (node.js:140:18)
    at node.js:1043:3
```