### PR TITLE
Remove preloaded domain goo.gl

### DIFF
--- a/src/chrome/content/rules/GoogleServices_Complex.xml
+++ b/src/chrome/content/rules/GoogleServices_Complex.xml
@@ -3,7 +3,6 @@
 
 	Problematic domains:
 
-		- www.goo.gl		(404; mismatched, CN: *.google.com)
 		- *-opensocial.googleusercontent.com ***
 
 	*** Breaks followers widget - https://trac.torproject.org/projects/tor/ticket/7294
@@ -45,11 +44,6 @@
 		<test url="http://lh4.ggpht.com/" />
 		<test url="http://lh5.ggpht.com/" />
 		<test url="http://lh6.ggpht.com/" />
-
-	<rule from="^http://(www\.)?goo\.gl/"
-		to="https://goo.gl/" />
-		<test url="http://www.goo.gl/" />
-		<test url="http://goo.gl/" />
 
 	<!-- wildcards -->
 


### PR DESCRIPTION
- preloaded
- broken rule (there is no target for it)