### PR TITLE
Remove duplicated target gdata.youtube.com

### DIFF
--- a/src/chrome/content/rules/GoogleAPIs.xml
+++ b/src/chrome/content/rules/GoogleAPIs.xml
@@ -61,8 +61,6 @@
 			- ssl
 			- t\d
 
-		- gdata.youtube.com
-
 
 	ssl.google-analytics.com/ga.js sets __utm\w wildcard
 	cookies on whichever domain it is loaded from.
@@ -96,7 +94,6 @@
 
 	<target host="gstatic.com" />
 	<target host="*.gstatic.com" />
-	<target host="gdata.youtube.com" />
 
 	<!--	Captive portal detection redirects to this URL, and many captive
 		portals break TLS, so exempt this redirect URL.
@@ -105,9 +102,6 @@
 	<exclusion pattern="^http://www\.gstatic\.com/generate_204" />
 		<test url="http://www.gstatic.com/generate_204" />
 
-	<exclusion pattern="^http://gdata\.youtube\.com/crossdomain\.xml" />
-		<test url="http://gdata.youtube.com/crossdomain.xml" />
-	
 	<!--	Breaks digitalattackmap.com, cf.
 		https://trac.torproject.org/projects/tor/ticket/15154
 			-->
@@ -170,6 +164,4 @@
 		<test url="http://t2.gstatic.com/" />
 		<test url="http://t3.gstatic.com/" />
 
-	<rule from="^http://gdata\.youtube\.com/"
-		to="https://gdata.youtube.com/" />
 </ruleset>

--- a/src/chrome/content/rules/YouTube.xml
+++ b/src/chrome/content/rules/YouTube.xml
@@ -1,6 +1,7 @@
 <!--
 	Time out over both http and https:
 		youtube.tn
+		youtube.com.tn
 
 	Insecure cookies are set for these domains:
 
@@ -216,7 +217,7 @@
 	<target host="www.youtube.co.th"/>
 	<!--target host="youtube.tn"/-->
 	<target host="www.youtube.tn"/>
-	<target host="youtube.com.tn"/>
+	<!--target host="youtube.com.tn"/-->
 	<target host="www.youtube.com.tn"/>
 	<target host="youtube.com.tr"/>
 	<target host="www.youtube.com.tr"/>

--- a/src/chrome/content/rules/YouTube.xml
+++ b/src/chrome/content/rules/YouTube.xml
@@ -12,6 +12,8 @@
         <!-- Main domains -->
 	<target host="youtube.com" />
 	<target host="*.youtube.com" />
+		<test url="http://gdata.youtube.com/" />
+		<test url="http://gdata.youtube.com/crossdomain.xml" />
 		<test url="http://m.youtube.com/feed/trending" />
 		<test url="http://www.youtube.com/opensearch?locale=en_US" />
 		<test url="http://www.youtube.com/yts/img/pixel-vfl3z5WfW.gif" />

--- a/src/chrome/content/rules/YouTube.xml
+++ b/src/chrome/content/rules/YouTube.xml
@@ -2,6 +2,7 @@
 	Time out over both http and https:
 		youtube.tn
 		youtube.com.tn
+		www.youtube.com.tn
 
 	Insecure cookies are set for these domains:
 
@@ -218,7 +219,7 @@
 	<!--target host="youtube.tn"/-->
 	<target host="www.youtube.tn"/>
 	<!--target host="youtube.com.tn"/-->
-	<target host="www.youtube.com.tn"/>
+	<!--target host="www.youtube.com.tn"/-->
 	<target host="youtube.com.tr"/>
 	<target host="www.youtube.com.tr"/>
 	<target host="youtube.com.tw"/>


### PR DESCRIPTION
Already covered by the wildcard in [YouTube.xml](https://github.com/EFForg/https-everywhere/blob/release/src/chrome/content/rules/YouTube.xml).