### PR TITLE
Fixes for small bugs and annoyances

### DIFF
--- a/chromium/background.js
+++ b/chromium/background.js
@@ -142,10 +142,9 @@ function updateState () {
     if (!tabs || tabs.length === 0) {
       return;
     }
-
     const activeCount = getActiveRulesetCount(tabs[0].id);
 
-    chrome.browserAction.setBadgeBackgroundColor({ color: '#666666' });
+    chrome.browserAction.setBadgeBackgroundColor({ color: '#666666', tabId: tabs[0].id });
 
     const showBadge = activeCount > 0 && isExtensionEnabled && showCounter;
 

--- a/chromium/background.js
+++ b/chromium/background.js
@@ -135,7 +135,7 @@ function updateState () {
   });
 
   chrome.browserAction.setTitle({
-    title: 'HTTPS Everywhere' + (iconState === 'active') ? '' : ' (' + iconState + ')'
+    title: 'HTTPS Everywhere' + ((iconState === 'active') ? '' : ' (' + iconState + ')')
   });
 
   chrome.tabs.query({ active: true, currentWindow: true }, function(tabs) {

--- a/chromium/background.js
+++ b/chromium/background.js
@@ -142,13 +142,14 @@ function updateState () {
     if (!tabs || tabs.length === 0) {
       return;
     }
-    const activeCount = getActiveRulesetCount(tabs[0].id);
+    const tabId = tabs[0].id;
+    const activeCount = getActiveRulesetCount(tabId);
 
-    chrome.browserAction.setBadgeBackgroundColor({ color: '#666666', tabId: tabs[0].id });
+    chrome.browserAction.setBadgeBackgroundColor({ color: '#666666', tabId });
 
     const showBadge = activeCount > 0 && isExtensionEnabled && showCounter;
 
-    chrome.browserAction.setBadgeText({ text: showBadge ? String(activeCount) : '', tabId: tabs[0].id });
+    chrome.browserAction.setBadgeText({ text: showBadge ? String(activeCount) : '', tabId });
   });
 }
 


### PR DESCRIPTION
46bc17f fixes the icon text so it now say `HTTPS Everywhere`, `HTTPS Everywhere (blocking)`, or `HTTPS Everywhere (disabled)`. 

720fd78 ensures we only set the badge background color on the correct tab, this isn't really a bug since we only use one color anyway.

869b31f fixes the an error on start up