### PR TITLE
Add few more missing vars to rules.js

### DIFF
--- a/chromium/background.js
+++ b/chromium/background.js
@@ -34,7 +34,6 @@ try{
 all_rules = new RuleSets(ls);
 
 // Allow users to enable `platform="mixedcontent"` rulesets
-var enableMixedRulesets = false;
 storage.get({enableMixedRulesets: false}, function(item) {
   enableMixedRulesets = item.enableMixedRulesets;
   all_rules.addFromJson(loadExtensionFile('rules/default.rulesets', 'json'));
@@ -211,11 +210,11 @@ function updateState () {
  * */
 var addNewRule = function(params, cb) {
   if (all_rules.addUserRule(params)) {
-    // If we successfully added the user rule, save it in local 
-    // storage so it's automatically applied when the extension is 
+    // If we successfully added the user rule, save it in local
+    // storage so it's automatically applied when the extension is
     // reloaded.
     var oldUserRules = getStoredUserRules();
-    // TODO: there's a race condition here, if this code is ever executed from multiple 
+    // TODO: there's a race condition here, if this code is ever executed from multiple
     // client windows in different event loops.
     oldUserRules.push(params);
     // TODO: can we exceed the max size for storage?
@@ -283,7 +282,6 @@ AppliedRulesets.prototype = {
 var activeRulesets = new AppliedRulesets();
 
 var urlBlacklist = new Set();
-var domainBlacklist = new Set();
 
 // redirect counter workaround
 // TODO: Remove this code if they ever give us a real counter
@@ -333,7 +331,7 @@ function onBeforeRequest(details) {
 
   var canonical_url = uri.href;
   if (details.url != canonical_url && !using_credentials_in_url) {
-    log(INFO, "Original url " + details.url + 
+    log(INFO, "Original url " + details.url +
         " changed before processing to " + canonical_url);
   }
   if (urlBlacklist.has(canonical_url)) {

--- a/chromium/rules.js
+++ b/chromium/rules.js
@@ -1,11 +1,22 @@
 "use strict";
-// Stubs so this runs under nodejs. They get overwritten later by util.js
-var VERB=1;
-var DBUG=2;
-var INFO=3;
-var NOTE=4;
-var WARN=5;
-function log(){}
+
+// Stubs so this runs under nodejs. Also used by util.js
+const VERB=1;
+const DBUG=2;
+const INFO=3;
+const NOTE=4;
+const WARN=5;
+
+function log(level, str) {
+  if (level === WARN) {
+    // Stub as error for nodejs usage; util.js overrides with pure logging
+    throw new Error(str);
+  }
+}
+
+// Set default values for the same reason. Later modified by background.js
+var enableMixedRulesets = false;
+var domainBlacklist = new Set();
 
 // To reduce memory usage for the numerous rules/cookies with trivial rules
 const trivial_rule_to = "https:";
@@ -208,7 +219,7 @@ RuleSets.prototype = {
       try {
         this.parseOneJsonRuleset(ruleset);
       } catch(e) {
-        log(WARN, 'Error processing ruleset:' + e);	
+        log(WARN, 'Error processing ruleset:' + e);
       }
     }
   },
@@ -410,7 +421,6 @@ RuleSets.prototype = {
     }
     log(DBUG, "Ruleset cache miss for " + host);
 
-    var tmp;
     var results = [];
     if (this.targets.has(host)) {
       // Copy the host targets so we don't modify them.

--- a/chromium/util.js
+++ b/chromium/util.js
@@ -1,10 +1,5 @@
 "use strict";
 
-var VERB = 1;
-var DBUG = 2;
-var INFO = 3;
-var NOTE = 4;
-var WARN = 5;
 // FYI: Logging everything is /very/ slow. Chrome will log & buffer
 // these console logs even when the debug tools are closed. :(
 


### PR DESCRIPTION
Following https://github.com/EFForg/https-everywhere/pull/4298, few more variables appeared that are used by rules.js but defined later in other files.

This commit moves missing variables to rules.js so that it can be used standalone as before.

Also, changes var to const for logging levels, removed their duplications from util.js and changed the log stub to fail with error on WARN level (since in rules.js this is used mostly for reporting bad errors, so makes sense to throw when used as Node.js module). In browser, util.js will still override function with proper logging as before.