### PR TITLE
Measure and slightly improve memory usage

### DIFF
--- a/chromium/rules.js
+++ b/chromium/rules.js
@@ -1,19 +1,16 @@
-/* globals global: false */
 "use strict";
 
-(function(exports) {
-
-// Stubs so this runs under nodejs. They get overwritten later by util.js
-if (typeof util == 'undefined' || typeof global != 'undefined') {
-  Object.assign(global, {
-    util: {
-      DBUG: 2,
-      INFO: 3,
-      WARN: 5,
-      log: ()=>{},
-    }
-  });
+// Stubs so this runs under nodejs where util.js didn't define `util` globally.
+if (typeof util == 'undefined') {
+  var util = {
+    DBUG: 2,
+    INFO: 3,
+    WARN: 5,
+    log: ()=>{},
+  };
 }
+
+(function(exports) {
 
 let settings = {
   enableMixedRulesets: false,

--- a/chromium/rules.js
+++ b/chromium/rules.js
@@ -52,15 +52,6 @@ function getRule(from, to) {
 }
 
 /**
- * Regex-Compile a pattern
- * @param pattern The pattern to compile
- * @constructor
- */
-function Exclusion(pattern) {
-  this.pattern_c = new RegExp(pattern);
-}
-
-/**
  * Generates a CookieRule
  * @param host The host regex to compile
  * @param cookiename The cookie name Regex to compile
@@ -108,13 +99,9 @@ RuleSet.prototype = {
   apply: function(urispec) {
     var returl = null;
     // If we're covered by an exclusion, go home
-    if (this.exclusions !== null) {
-      for (let exclusion of this.exclusions) {
-        if (exclusion.pattern_c.test(urispec)) {
-          util.log(util.DBUG, "excluded uri " + urispec);
-          return null;
-        }
-      }
+    if (this.exclusions !== null && this.exclusions.test(urispec)) {
+      util.log(util.DBUG, "excluded uri " + urispec);
+      return null;
     }
 
     // Okay, now find the first rule that triggers
@@ -142,15 +129,15 @@ RuleSet.prototype = {
     }
 
     try {
-      var this_exclusions_length = this.exclusions.length;
+      var this_exclusions_source = this.exclusions.source;
     } catch(e) {
-      var this_exclusions_length = 0;
+      var this_exclusions_source = null;
     }
 
     try {
-      var ruleset_exclusions_length = ruleset.exclusions.length;
+      var ruleset_exclusions_source = ruleset.exclusions.source;
     } catch(e) {
-      var ruleset_exclusions_length = 0;
+      var ruleset_exclusions_source = null;
     }
 
     try {
@@ -165,17 +152,14 @@ RuleSet.prototype = {
       var ruleset_rules_length = 0;
     }
 
-    if(this_exclusions_length != ruleset_exclusions_length ||
-       this_rules_length != ruleset_rules_length) {
+    if(this_rules_length != ruleset_rules_length) {
       return false;
     }
-    if(this_exclusions_length > 0) {
-      for(let x = 0; x < this.exclusions.length; x++){
-        if(this.exclusions[x].pattern_c != ruleset.exclusions[x].pattern_c) {
-          return false;
-        }
-      }
+
+    if (this_exclusions_source != ruleset_exclusions_source) {
+      return false;
     }
+
     if(this_rules_length > 0) {
       for(let x = 0; x < this.rules.length; x++){
         if(this.rules[x].to != ruleset.rules[x].to) {
@@ -183,6 +167,7 @@ RuleSet.prototype = {
         }
       }
     }
+
     return true;
   }
 
@@ -269,14 +254,7 @@ RuleSets.prototype = {
 
     var exclusions = ruletag["exclusion"];
     if (exclusions != null) {
-      for (let exclusion of exclusions) {
-        if (exclusion != null) {
-          if (!rule_set.exclusions) {
-            rule_set.exclusions = [];
-          }
-          rule_set.exclusions.push(new Exclusion(exclusion));
-        }
-      }
+      rule_set.exclusions = new RegExp(exclusions)
     }
 
     var cookierules = ruletag["securecookie"];
@@ -389,11 +367,11 @@ RuleSets.prototype = {
 
     var exclusions = ruletag.getElementsByTagName("exclusion");
     if (exclusions.length > 0) {
-      rule_set.exclusions = [];
-      for (let exclusion of exclusions) {
-        rule_set.exclusions.push(
-          new Exclusion(exclusion.getAttribute("pattern")));
-      }
+      rule_set.exclusions = new RegExp(
+        exclusions
+          .map(exclusion => exclusion.getAttribute("pattern"))
+          .join("|")
+      );
     }
 
     var cookierules = ruletag.getElementsByTagName("securecookie");

--- a/utils/memusage.js
+++ b/utils/memusage.js
@@ -1,0 +1,50 @@
+/* eslint-env es6, node */
+/* globals gc */
+
+'use strict';
+
+if (typeof gc !== 'function') {
+	throw new Error('Please re-run with `node --expose-gc utils/memusage.js`');
+}
+
+const { RuleSets } = require('../chromium/rules');
+const { readFileSync } = require('fs');
+const json = JSON.parse(readFileSync(`${__dirname}/../rules/default.rulesets`, 'utf-8'));
+
+function memUsage() {
+	gc(); // don't measure garbage
+	return process.memoryUsage().heapUsed;
+}
+
+function memToString(before, after) {
+	return (Math.round((after - before) / (1 << 20) * 10) / 10).toLocaleString() + ' MB';
+}
+
+const start = memUsage();
+let middle, end;
+
+{
+	const ruleSets = new RuleSets(Object.create(null));
+	ruleSets.addFromJson(json);
+	middle = memUsage();
+}
+
+{
+	const oldRegExp = RegExp;
+
+	global.RegExp = function (...args) {
+		let r = new oldRegExp(...args);
+		r.test(''); // force engine to compile RegExp
+		return r;
+	};
+
+	const ruleSets = new RuleSets(Object.create(null));
+	ruleSets.addFromJson(json);
+	end = memUsage();
+}
+
+// rulesets loaded but regexps are not compiled
+console.log('Initial usage:', memToString(start, middle));
+
+// with all regexps compiled
+console.log('Maximum usage:', memToString(middle, end));

--- a/utils/merge-rulesets.py
+++ b/utils/merge-rulesets.py
@@ -48,12 +48,12 @@ print(" * Parsing XML ruleset and constructing JSON library...")
 for filename in sorted(files):
 	tree = xml.etree.ElementTree.parse(filename)
 	root = tree.getroot()
-	
+
 	ruleset = {}
 
 	for attr in root.attrib:
 		ruleset[attr] = root.attrib[attr]
-	
+
 	for child in root:
 		if child.tag in ["target", "rule", "securecookie", "exclusion"]:
 			if child.tag not in ruleset:
@@ -81,6 +81,9 @@ for filename in sorted(files):
 		elif child.tag == "exclusion":
 			ruleset["exclusion"].append(child.attrib["pattern"])
 
+	if "exclusion" in ruleset:
+		ruleset["exclusion"] = "|".join(ruleset["exclusion"])
+
 	library.append(ruleset);
 
 # Write to default.rulesets
@@ -89,7 +92,7 @@ outfile = open(ofn, "w")
 outfile.write(json.dumps(library))
 outfile.close()
 
-# We make default.rulesets at build time, 
+# We make default.rulesets at build time,
 # but it shouldn't have a variable timestamp
 subprocess.call(["touch", "-r", "src/install.rdf", ofn])
 


### PR DESCRIPTION
Added a simple script for measuring memory usage of the ruleset in "cold" and "hot" states from the console with Node.js.

Also implemented two small optimisations to see how it works.

Results with Node.js 8.5.0 on MacOS (kernel 16.7.0):

**Initial usage** *(rulesets just parsed and ready)*: 42.1 MB -> 40.4 MB
**Maximum usage** *(all the regexps force-compiled)*: 80.2 MB -> 78.1 MB

Note that this includes commit from https://github.com/EFForg/https-everywhere/pull/12556 as it depends on it.

Related issue: https://github.com/EFForg/https-everywhere/issues/12232