### PR TITLE
Re-add problematic Pirate Bay proxies from #12481.

### DIFF
--- a/src/chrome/content/rules/pbproxy.tech.xml
+++ b/src/chrome/content/rules/pbproxy.tech.xml
@@ -1,0 +1,8 @@
+<ruleset name="pbproxy.tech">
+	<target host="pbproxy.tech" />	
+	<target host="www.pbproxy.tech" />
+
+	<securecookie host=".+" name=".+" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/proxxy.site.xml
+++ b/src/chrome/content/rules/proxxy.site.xml
@@ -1,0 +1,8 @@
+<ruleset name="proxxy.site">
+	<target host="proxxy.site" />
+	<target host="www.proxxy.site" />
+
+	<securecookie host=".+" name=".+" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/thepirateproxy.tech.xml
+++ b/src/chrome/content/rules/thepirateproxy.tech.xml
@@ -1,0 +1,8 @@
+<ruleset name="thepirateproxy.tech">
+	<target host="thepirateproxy.tech" />
+	<target host="www.thepirateproxy.tech" />
+
+	<securecookie host=".+" name=".+" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/thepirateproxy.website.xml
+++ b/src/chrome/content/rules/thepirateproxy.website.xml
@@ -1,0 +1,8 @@
+<ruleset name="thepirateproxy.website">
+	<target host="thepirateproxy.website" />
+	<target host="www.thepirateproxy.website" />
+
+	<securecookie host=".+" name=".+" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/theproxybay.website.xml
+++ b/src/chrome/content/rules/theproxybay.website.xml
@@ -1,0 +1,8 @@
+<ruleset name="theproxybay.website">
+	<target host="theproxybay.website" />
+	<target host="www.theproxybay.website" />
+
+	<securecookie host=".+" name=".+" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>


### PR DESCRIPTION
This should pass the rules test once #12481 is merged, but I still don't know why the fetch test works locally by fails on Travis. Are Travis containers run somewhere with censored internet?