### PR TITLE
Move videos.google.com to Google.com_Subdomains.xml

### DIFF
--- a/src/chrome/content/rules/Google.com_Subdomains.xml
+++ b/src/chrome/content/rules/Google.com_Subdomains.xml
@@ -121,6 +121,7 @@
 	<!-- See the complex ruleset for tbn\d -->
 	<target host="tools.google.com" />
 	<target host="trends.google.com" />
+	<target host="videos.google.com" />
 	<target host="wallet.google.com" />
 
 	<securecookie host="^(?:\.code|login\.corp|developers|docs|\d\.docs|fiber|mail|plus|\.?productforums|support)\.google\.[\w.]{2,6}$" name=".+" />

--- a/src/chrome/content/rules/GoogleVideos.xml
+++ b/src/chrome/content/rules/GoogleVideos.xml
@@ -1,5 +1,4 @@
 <ruleset name="Google Videos" default_off="Needs ruleset tests">
-  <target host="*.google.com" />
   <target host="www.google.com.*" />
   <target host="google.com.*" />
   <target host="www.google.co.*" />
@@ -67,8 +66,5 @@
           to="https://www.google.com/videohp?hl=pt-BR&#38;" />
   <rule from="^http://(?:www\.)?google\.se/videohp\?"
           to="https://www.google.com/videohp?hl=sv&#38;" />
-
-	<rule from="^http://video\.google\.com/ThumbnailServer2"
-		to="https://video.google.com/ThumbnailServer2" />
 
 </ruleset>


### PR DESCRIPTION
It looks like many rules in `GoogleVideos.xml` are outdated because of the [end of Google Videos](https://en.wikipedia.org/wiki/Google_Video).