### PR TITLE
re-work #12556

### DIFF
--- a/chromium/background.js
+++ b/chromium/background.js
@@ -38,7 +38,7 @@ all_rules = new rules.RuleSets(ls);
 
 // Allow users to enable `platform="mixedcontent"` rulesets
 store.get({enableMixedRulesets: false}, function(item) {
-  rules.enableMixedRulesets = item.enableMixedRulesets;
+  rules.settings.enableMixedRulesets = item.enableMixedRulesets;
   all_rules.addFromJson(loadExtensionFile('rules/default.rulesets', 'json'));
 });
 
@@ -354,7 +354,7 @@ function onBeforeRequest(details) {
     util.log(util.NOTE, "Redirect counter hit for " + canonical_url);
     urlBlacklist.add(canonical_url);
     var hostname = uri.hostname;
-    rules.domainBlacklist.add(hostname);
+    rules.settings.domainBlacklist.add(hostname);
     util.log(util.WARN, "Domain blacklisted " + hostname);
     return {cancel: shouldCancel};
   }

--- a/chromium/background.js
+++ b/chromium/background.js
@@ -37,9 +37,8 @@ try{
 all_rules = new rules.RuleSets(ls);
 
 // Allow users to enable `platform="mixedcontent"` rulesets
-var enableMixedRulesets = false;
 store.get({enableMixedRulesets: false}, function(item) {
-  enableMixedRulesets = item.enableMixedRulesets;
+  rules.enableMixedRulesets = item.enableMixedRulesets;
   all_rules.addFromJson(loadExtensionFile('rules/default.rulesets', 'json'));
 });
 
@@ -215,11 +214,11 @@ function updateState () {
  * */
 var addNewRule = function(params, cb) {
   if (all_rules.addUserRule(params)) {
-    // If we successfully added the user rule, save it in local 
-    // storage so it's automatically applied when the extension is 
+    // If we successfully added the user rule, save it in local
+    // storage so it's automatically applied when the extension is
     // reloaded.
     var oldUserRules = getStoredUserRules();
-    // TODO: there's a race condition here, if this code is ever executed from multiple 
+    // TODO: there's a race condition here, if this code is ever executed from multiple
     // client windows in different event loops.
     oldUserRules.push(params);
     // TODO: can we exceed the max size for storage?
@@ -287,7 +286,6 @@ AppliedRulesets.prototype = {
 var activeRulesets = new AppliedRulesets();
 
 var urlBlacklist = new Set();
-var domainBlacklist = new Set();
 
 // redirect counter workaround
 // TODO: Remove this code if they ever give us a real counter
@@ -339,7 +337,11 @@ function onBeforeRequest(details) {
 
   var canonical_url = uri.href;
   if (details.url != canonical_url && !using_credentials_in_url) {
+<<<<<<< HEAD
     util.log(util.INFO, "Original url " + details.url +
+=======
+    log(INFO, "Original url " + details.url +
+>>>>>>> Add few more missing vars to rules.js
         " changed before processing to " + canonical_url);
   }
   if (urlBlacklist.has(canonical_url)) {
@@ -356,7 +358,7 @@ function onBeforeRequest(details) {
     util.log(util.NOTE, "Redirect counter hit for " + canonical_url);
     urlBlacklist.add(canonical_url);
     var hostname = uri.hostname;
-    domainBlacklist.add(hostname);
+    rules.domainBlacklist.add(hostname);
     util.log(util.WARN, "Domain blacklisted " + hostname);
     return {cancel: shouldCancel};
   }
@@ -709,10 +711,8 @@ async function import_settings(settings) {
 }
 
 Object.assign(exports, {
-  enableMixedRulesets,
   all_rules,
   initializeStoredGlobals,
-  domainBlacklist,
   urlBlacklist,
 });
 

--- a/chromium/background.js
+++ b/chromium/background.js
@@ -337,11 +337,7 @@ function onBeforeRequest(details) {
 
   var canonical_url = uri.href;
   if (details.url != canonical_url && !using_credentials_in_url) {
-<<<<<<< HEAD
     util.log(util.INFO, "Original url " + details.url +
-=======
-    log(INFO, "Original url " + details.url +
->>>>>>> Add few more missing vars to rules.js
         " changed before processing to " + canonical_url);
   }
   if (urlBlacklist.has(canonical_url)) {

--- a/chromium/incognito.js
+++ b/chromium/incognito.js
@@ -26,7 +26,7 @@ function destroy_caches() {
   util.log(util.DBUG, "Destroying caches.");
   background.all_rules.cookieHostCache.clear();
   background.all_rules.ruleCache.clear();
-  rules.domainBlacklist.clear();
+  rules.settings.domainBlacklist.clear();
   background.urlBlacklist.clear();
 }
 

--- a/chromium/incognito.js
+++ b/chromium/incognito.js
@@ -26,7 +26,7 @@ function destroy_caches() {
   util.log(util.DBUG, "Destroying caches.");
   background.all_rules.cookieHostCache.clear();
   background.all_rules.ruleCache.clear();
-  background.domainBlacklist.clear();
+  rules.domainBlacklist.clear();
   background.urlBlacklist.clear();
 }
 

--- a/chromium/manifest.json
+++ b/chromium/manifest.json
@@ -8,9 +8,9 @@
     "author": "eff.software.projects@gmail.com",
     "background": {
         "scripts": [
+            "util.js",
             "rules.js",
             "store.js",
-            "util.js",
             "background.js",
             "incognito.js"
         ]

--- a/chromium/rules.js
+++ b/chromium/rules.js
@@ -103,7 +103,7 @@ RuleSet.prototype = {
     if (this.exclusions !== null) {
       for (let exclusion of this.exclusions) {
         if (exclusion.pattern_c.test(urispec)) {
-          log(DBUG, "excluded uri " + urispec);
+          util.log(util.DBUG, "excluded uri " + urispec);
           return null;
         }
       }
@@ -210,7 +210,7 @@ RuleSets.prototype = {
       try {
         this.parseOneXmlRuleset(s);
       } catch (e) {
-        log(WARN, 'Error processing ruleset:' + e);
+        util.log(util.WARN, 'Error processing ruleset:' + e);
       }
     }
   },
@@ -220,7 +220,7 @@ RuleSets.prototype = {
       try {
         this.parseOneJsonRuleset(ruleset);
       } catch(e) {
-        log(WARN, 'Error processing ruleset:' + e);
+        util.log(util.WARN, 'Error processing ruleset:' + e);
       }
     }
   },
@@ -300,7 +300,7 @@ RuleSets.prototype = {
    * @returns {boolean}
    */
   addUserRule : function(params) {
-    log(INFO, 'adding new user rule for ' + JSON.stringify(params));
+    util.log(util.INFO, 'adding new user rule for ' + JSON.stringify(params));
     var new_rule_set = new RuleSet(params.host, true, "user rule");
     var new_rule = new Rule(params.urlMatcher, params.redirectTo);
     new_rule_set.rules.push(new_rule);
@@ -313,7 +313,7 @@ RuleSets.prototype = {
     if (new_rule_set.name in this.ruleActiveStates) {
       new_rule_set.active = (this.ruleActiveStates[new_rule_set.name] == "true");
     }
-    log(INFO, 'done adding rule');
+    util.log(util.INFO, 'done adding rule');
     return true;
   },
 
@@ -323,7 +323,7 @@ RuleSets.prototype = {
    * @returns {boolean}
    */
   removeUserRule: function(ruleset) {
-    log(INFO, 'removing user rule for ' + JSON.stringify(ruleset));
+    util.log(util.INFO, 'removing user rule for ' + JSON.stringify(ruleset));
     this.ruleCache.delete(ruleset.name);
 
 
@@ -336,7 +336,7 @@ RuleSets.prototype = {
       this.targets.delete(ruleset.name);
     }
 
-    log(INFO, 'done removing rule');
+    util.log(util.INFO, 'done removing rule');
     return true;
   },
 
@@ -417,10 +417,10 @@ RuleSets.prototype = {
     // Have we cached this result? If so, return it!
     var cached_item = this.ruleCache.get(host);
     if (cached_item !== undefined) {
-      log(DBUG, "Ruleset cache hit for " + host + " items:" + cached_item.length);
+      util.log(util.DBUG, "Ruleset cache hit for " + host + " items:" + cached_item.length);
       return cached_item;
     }
-    log(DBUG, "Ruleset cache miss for " + host);
+    util.log(util.DBUG, "Ruleset cache miss for " + host);
 
     var results = [];
     if (this.targets.has(host)) {
@@ -430,7 +430,7 @@ RuleSets.prototype = {
 
     // Ensure host is well-formed (RFC 1035)
     if (host.indexOf("..") != -1 || host.length > 255) {
-      log(WARN,"Malformed host passed to potentiallyApplicableRulesets: " + host);
+      util.log(util.WARN,"Malformed host passed to potentiallyApplicableRulesets: " + host);
       return null;
     }
 
@@ -453,12 +453,12 @@ RuleSets.prototype = {
     var resultSet = new Set(results);
     resultSet.delete(undefined);
 
-    log(DBUG,"Applicable rules for " + host + ":");
+    util.log(util.DBUG,"Applicable rules for " + host + ":");
     if (resultSet.size == 0) {
-      log(DBUG, "  None");
+      util.log(util.DBUG, "  None");
     } else {
       for (let target of resultSet.values()) {
-        log(DBUG, "  " + target.name);
+        util.log(util.DBUG, "  " + target.name);
       }
     }
 
@@ -523,15 +523,15 @@ RuleSets.prototype = {
     // flagged as secure.
 
     if (domainBlacklist.has(domain)) {
-      log(INFO, "cookies for " + domain + "blacklisted");
+      util.log(util.INFO, "cookies for " + domain + "blacklisted");
       return false;
     }
     var cached_item = this.cookieHostCache.get(domain);
     if (cached_item !== undefined) {
-      log(DBUG, "Cookie host cache hit for " + domain);
+      util.log(util.DBUG, "Cookie host cache hit for " + domain);
       return cached_item;
     }
-    log(DBUG, "Cookie host cache miss for " + domain);
+    util.log(util.DBUG, "Cookie host cache miss for " + domain);
 
     // If we passed that test, make up a random URL on the domain, and see if
     // we would HTTPSify that.
@@ -545,19 +545,19 @@ RuleSets.prototype = {
       this.cookieHostCache.delete(this.cookieHostCache.keys().next().value);
     }
 
-    log(INFO, "Testing securecookie applicability with " + test_uri);
+    util.log(util.INFO, "Testing securecookie applicability with " + test_uri);
     var potentiallyApplicable = this.potentiallyApplicableRulesets(domain);
     for (let ruleset of potentiallyApplicable) {
       if (!ruleset.active) {
         continue;
       }
       if (ruleset.apply(test_uri)) {
-        log(INFO, "Cookie domain could be secured.");
+        util.log(util.INFO, "Cookie domain could be secured.");
         this.cookieHostCache.set(domain, true);
         return true;
       }
     }
-    log(INFO, "Cookie domain could NOT be secured.");
+    util.log(util.INFO, "Cookie domain could NOT be secured.");
     this.cookieHostCache.set(domain, false);
     return false;
   },

--- a/chromium/rules.js
+++ b/chromium/rules.js
@@ -1,3 +1,4 @@
+/* globals global: false */
 "use strict";
 
 (function(exports) {

--- a/chromium/rules.js
+++ b/chromium/rules.js
@@ -3,10 +3,17 @@
 (function(exports) {
 
 // Stubs so this runs under nodejs. They get overwritten later by util.js
-var DBUG = 2;
-var INFO = 3;
-var WARN = 5;
-function log(){}
+if (typeof util == 'undefined') {
+  let base = typeof window == 'undefined' ? global : window; // eslint-disable-line
+  Object.assign(base, {
+    util: {
+      DBUG: 2,
+      INFO: 3,
+      WARN: 5,
+      log: ()=>{},
+    }
+  });
+}
 
 // Set default values for the same reason. Later modified by background.js
 var enableMixedRulesets = false;

--- a/chromium/rules.js
+++ b/chromium/rules.js
@@ -3,9 +3,8 @@
 (function(exports) {
 
 // Stubs so this runs under nodejs. They get overwritten later by util.js
-if (typeof util == 'undefined') {
-  let base = typeof window == 'undefined' ? global : window; // eslint-disable-line
-  Object.assign(base, {
+if (typeof util == 'undefined' || typeof global != 'undefined') {
+  Object.assign(global, {
     util: {
       DBUG: 2,
       INFO: 3,

--- a/chromium/rules.js
+++ b/chromium/rules.js
@@ -15,9 +15,10 @@ if (typeof util == 'undefined') {
   });
 }
 
-// Set default values for the same reason. Later modified by background.js
-var enableMixedRulesets = false;
-var domainBlacklist = new Set();
+let settings = {
+  enableMixedRulesets: false,
+  domainBlacklist: new Set(),
+};
 
 // To reduce memory usage for the numerous rules/cookies with trivial rules
 const trivial_rule_to = "https:";
@@ -239,7 +240,7 @@ RuleSets.prototype = {
     var platform = ruletag["platform"]
     if (platform) {
       default_state = false;
-      if (platform == "mixedcontent" && enableMixedRulesets) {
+      if (platform == "mixedcontent" && settings.enableMixedRulesets) {
         default_state = true;
       }
       note += "Platform(s): " + platform + "\n";
@@ -358,7 +359,7 @@ RuleSets.prototype = {
     var platform = ruletag.getAttribute("platform");
     if (platform) {
       default_state = false;
-      if (platform == "mixedcontent" && enableMixedRulesets) {
+      if (platform == "mixedcontent" && settings.enableMixedRulesets) {
         default_state = true;
       }
       note += "Platform(s): " + platform + "\n";
@@ -522,7 +523,7 @@ RuleSets.prototype = {
     // observed and the domain blacklisted, a cookie might already have been
     // flagged as secure.
 
-    if (domainBlacklist.has(domain)) {
+    if (settings.domainBlacklist.has(domain)) {
       util.log(util.INFO, "cookies for " + domain + "blacklisted");
       return false;
     }
@@ -581,8 +582,7 @@ RuleSets.prototype = {
 };
 
 Object.assign(exports, {
-  enableMixedRulesets,
-  domainBlacklist,
+  settings,
   RuleSets,
 });
 

--- a/chromium/rules.js
+++ b/chromium/rules.js
@@ -8,6 +8,10 @@ var INFO = 3;
 var WARN = 5;
 function log(){}
 
+// Set default values for the same reason. Later modified by background.js
+var enableMixedRulesets = false;
+var domainBlacklist = new Set();
+
 // To reduce memory usage for the numerous rules/cookies with trivial rules
 const trivial_rule_to = "https:";
 const trivial_rule_from_c = new RegExp("^http:");
@@ -209,7 +213,7 @@ RuleSets.prototype = {
       try {
         this.parseOneJsonRuleset(ruleset);
       } catch(e) {
-        log(WARN, 'Error processing ruleset:' + e);	
+        log(WARN, 'Error processing ruleset:' + e);
       }
     }
   },
@@ -228,7 +232,7 @@ RuleSets.prototype = {
     var platform = ruletag["platform"]
     if (platform) {
       default_state = false;
-      if (platform == "mixedcontent" && background.enableMixedRulesets) {
+      if (platform == "mixedcontent" && enableMixedRulesets) {
         default_state = true;
       }
       note += "Platform(s): " + platform + "\n";
@@ -347,7 +351,7 @@ RuleSets.prototype = {
     var platform = ruletag.getAttribute("platform");
     if (platform) {
       default_state = false;
-      if (platform == "mixedcontent" && background.enableMixedRulesets) {
+      if (platform == "mixedcontent" && enableMixedRulesets) {
         default_state = true;
       }
       note += "Platform(s): " + platform + "\n";
@@ -511,7 +515,7 @@ RuleSets.prototype = {
     // observed and the domain blacklisted, a cookie might already have been
     // flagged as secure.
 
-    if (background.domainBlacklist.has(domain)) {
+    if (domainBlacklist.has(domain)) {
       log(INFO, "cookies for " + domain + "blacklisted");
       return false;
     }
@@ -570,6 +574,8 @@ RuleSets.prototype = {
 };
 
 Object.assign(exports, {
+  enableMixedRulesets,
+  domainBlacklist,
   RuleSets,
 });
 

--- a/chromium/util.js
+++ b/chromium/util.js
@@ -7,7 +7,6 @@ var DBUG = 2;
 var INFO = 3;
 var NOTE = 4;
 var WARN = 5;
-//
 // FYI: Logging everything is /very/ slow. Chrome will log & buffer
 // these console logs even when the debug tools are closed. :(
 

--- a/chromium/util.js
+++ b/chromium/util.js
@@ -7,6 +7,7 @@ var DBUG = 2;
 var INFO = 3;
 var NOTE = 4;
 var WARN = 5;
+//
 // FYI: Logging everything is /very/ slow. Chrome will log & buffer
 // these console logs even when the debug tools are closed. :(
 


### PR DESCRIPTION
Fixes some issues from #12586 with some work from #12556 by @RReverser 

Lets rules.js use `enableMixedRulesets` and `domainBlacklist` by moving them into rules.js from background.js.

Stubs out `util.*` so they work normally in the browser again, this was broken in #12556.