### PR TITLE
[Google.com_Subdomains] Fix securecookie regex

### DIFF
--- a/src/chrome/content/rules/Google.com_Subdomains.xml
+++ b/src/chrome/content/rules/Google.com_Subdomains.xml
@@ -124,7 +124,7 @@
 	<target host="videos.google.com" />
 	<target host="wallet.google.com" />
 
-	<securecookie host="^(?:\.code|login\.corp|developers|docs|\d\.docs|fiber|mail|plus|\.?productforums|support)\.google\.[\w.]{2,6}$" name=".+" />
+	<securecookie host="^(\.code|login\.corp|developers|docs|\d\.docs|fiber|mail|plus|\.?productforums|support)\.google\.com$" name=".+" />
 
 	<rule from="^http:"
 		to="https:" />


### PR DESCRIPTION
This ruleset doesn't handle ccTLDs so the securecookie regex is unnecessarily complex.