### PR TITLE
Check conflicting rulesets

### DIFF
--- a/test/rules/coverage.checker.config
+++ b/test/rules/coverage.checker.config
@@ -7,6 +7,7 @@ check_coverage = true
 check_target_validity = true
 check_nonmatch_groups = true
 check_test_formatting = true
+check_conflicting_rules = true
 include_default_off = false
 skiplist = utils/ruleset-whitelist.csv
 skipfield = 1


### PR DESCRIPTION
As mentioned in https://github.com/EFForg/https-everywhere/issues/12526, rulesets sometimes conflict with each other, resulting in different rewrites.

This PR adds an automated check that detects such cases by trying test URLs against all rulesets at once.

Currently found issues:

- [ ] `src/chrome/content/rules/Geocaching.com.xml`:
  - Test url http://www.geocaching.com/forums/default.aspx can be rewritten in several ways:
    * `src/chrome/content/rules/Geocaching.com-falsemixed.xml`: https://www.geocaching.com/forums/default.aspx
    * `src/chrome/content/rules/Geocaching.com.xml`: https://forums.groundspeak.com/GC/
  - Test url http://www.geocaching.com/forums/default.aspx? can be rewritten in several ways:
    * `src/chrome/content/rules/Geocaching.com-falsemixed.xml`: https://www.geocaching.com/forums/default.aspx?
    * `src/chrome/content/rules/Geocaching.com.xml`: https://forums.groundspeak.com/GC/
  - Test url http://www.geocaching.com/forums/default.aspx?f can be rewritten in several ways:
    * `src/chrome/content/rules/Geocaching.com-falsemixed.xml`: https://www.geocaching.com/forums/default.aspx?f
    * `src/chrome/content/rules/Geocaching.com.xml`: https://forums.groundspeak.com/GC/
  - Test url http://www.geocaching.com/forums/default.aspx?o can be rewritten in several ways:
    * `src/chrome/content/rules/Geocaching.com-falsemixed.xml`: https://www.geocaching.com/forums/default.aspx?o
    * `src/chrome/content/rules/Geocaching.com.xml`: https://forums.groundspeak.com/GC/
- [ ] `src/chrome/content/rules/Google.org.xml`: Test url http://google.org/ can be rewritten in several ways:
  * `src/chrome/content/rules/Google.xml`: https://www.google.org/
  * `src/chrome/content/rules/Google.org.xml`: https://google.org/
