### PR TITLE
Unbreak WebAssign

### DIFF
--- a/src/chrome/content/rules/WebAssign.xml
+++ b/src/chrome/content/rules/WebAssign.xml
@@ -1,7 +1,11 @@
+<!--
+	Invalid certificate:
+	- feedback.webassign.net
+-->
+
 <ruleset name="WebAssign">
   <target host="api.webassign.net" />
   <target host="demo.webassign.net" />
-  <target host="feedback.webassign.net" />
   <target host="webassign.net" />
   <target host="webassignwired.webassign.net" />
   <target host="www.webassign.net" />

--- a/src/chrome/content/rules/WebAssign.xml
+++ b/src/chrome/content/rules/WebAssign.xml
@@ -1,7 +1,10 @@
 <ruleset name="WebAssign">
-  <target host="www.webassign.net" />
+  <target host="api.webassign.net" />
   <target host="demo.webassign.net" />
+  <target host="feedback.webassign.net" />
   <target host="webassign.net" />
+  <target host="webassignwired.webassign.net" />
+  <target host="www.webassign.net" />
   <securecookie host="webassign\.net" name=".+" />
 
   <rule from="^http:" to="https:"/>

--- a/src/chrome/content/rules/WebAssign.xml
+++ b/src/chrome/content/rules/WebAssign.xml
@@ -4,6 +4,7 @@
   <target host="webassign.net" />
   <securecookie host="webassign\.net" name=".+" />
 
-  <rule from="^http://(?:www\.)?webassign\.net/" to="https://webassign.net/"/>
+  <rule from="^http://webassign\.net/" to="https://webassign.net/"/>
   <rule from="^http://demo\.webassign\.net/" to="https://demo.webassign.net/"/>
+  <rule from="^http://www.\.webassign\.net/" to="https://www.webassign.net/"/>
 </ruleset>

--- a/src/chrome/content/rules/WebAssign.xml
+++ b/src/chrome/content/rules/WebAssign.xml
@@ -4,7 +4,5 @@
   <target host="webassign.net" />
   <securecookie host="webassign\.net" name=".+" />
 
-  <rule from="^http://webassign\.net/" to="https://webassign.net/"/>
-  <rule from="^http://demo\.webassign\.net/" to="https://demo.webassign.net/"/>
-  <rule from="^http://www.\.webassign\.net/" to="https://www.webassign.net/"/>
+  <rule from="^http:" to="https:"/>
 </ruleset>


### PR DESCRIPTION
After logging in, the redirection from www.webassign.net to webassign.net breaks the site. Leaving the www in place fixes this.