### PR TITLE
Fix blocked mixed content on Asexuality.org

### DIFF
--- a/src/chrome/content/rules/asexuality.org.xml
+++ b/src/chrome/content/rules/asexuality.org.xml
@@ -2,7 +2,7 @@
 	Certificate mismatch:
 		ru.asexuality.org
 -->
-<ruleset name="Asexuality.org">
+<ruleset name="Asexuality.org" platform="mixedcontent">
 	<target host="asexuality.org" />
 	<target host="www.asexuality.org" />
 

--- a/src/chrome/content/rules/asexuality.org.xml
+++ b/src/chrome/content/rules/asexuality.org.xml
@@ -1,6 +1,13 @@
 <!--
+	Other asexuality.org rulesets:
+		asexuality.org_login.xml
+
 	Certificate mismatch:
 		ru.asexuality.org
+
+	Sept 2017: Due to mixedcontent issues, the site can only be redirected to HTTPS in mixedcontent-friendly
+	browsers, which is handled by this ruleset. The other ruleset redirects the target URL for the site's
+	login form to HTTPS in all browsers.
 -->
 <ruleset name="Asexuality.org" platform="mixedcontent">
 	<target host="asexuality.org" />

--- a/src/chrome/content/rules/asexuality.org.xml
+++ b/src/chrome/content/rules/asexuality.org.xml
@@ -5,21 +5,22 @@
 	Certificate mismatch:
 		ru.asexuality.org
 
-	Sept 2017: Due to mixedcontent issues, the site can only be redirected to HTTPS in mixedcontent-friendly
-	browsers, which is handled by this ruleset. The other ruleset redirects the target URL for the site's
-	login form to HTTPS in all browsers.
+	Sept 2017: Due to mixedcontent issues, the forum part of the site, located at "/en/", can only be redirected to HTTPS
+	in mixedcontent-friendly browsers, which is handled by this ruleset. The other ruleset attempts to secure as much as
+	possible in all browsers without breaking the site, such as redirecting the target URL for the forum's login form to
+	HTTPS as well as the non-forum part of the site.
 -->
-<ruleset name="Asexuality.org" platform="mixedcontent">
+<ruleset name="Asexuality.org (forums)" platform="mixedcontent">
 	<target host="asexuality.org" />
 	<target host="www.asexuality.org" />
-		<test url="https://www.asexuality.org/en/forum/87-site-info-center/" />
+		<test url="http://www.asexuality.org/en/forum/87-site-info-center/" />
 		<!-- Clicking page numbers triggers Uncaught DOMException only when on HTTPS. -->
-		<test url="https://www.asexuality.org/en/topic/19982-the-aven-terms-of-service-tos/" />
+		<test url="http://www.asexuality.org/en/topic/19982-the-aven-terms-of-service-tos/" />
 		<!-- Clicking page numbers triggers Uncaught DOMException only when on HTTPS. -->
-		<test url="https://www.asexuality.org/en/search/" />
+		<test url="http://www.asexuality.org/en/search/" />
 		<!-- Clicking on "Search By Author" then typing anything in the Search By Author
 			textbox triggers active mixed content blocking only when on HTTPS. -->
-		<test url="https://www.asexuality.org/en/search/?q=test&#x26;author=test" />
+		<test url="http://www.asexuality.org/en/search/?q=test&#x26;author=test" />
 		<!-- Clicking "More search options" then "Search Content" triggers Uncaught
 			DOMException only when on HTTPS. -->
 

--- a/src/chrome/content/rules/asexuality.org.xml
+++ b/src/chrome/content/rules/asexuality.org.xml
@@ -12,6 +12,16 @@
 <ruleset name="Asexuality.org" platform="mixedcontent">
 	<target host="asexuality.org" />
 	<target host="www.asexuality.org" />
+		<test url="https://www.asexuality.org/en/forum/87-site-info-center/" />
+		<!-- Clicking page numbers triggers Uncaught DOMException only when on HTTPS. -->
+		<test url="https://www.asexuality.org/en/topic/19982-the-aven-terms-of-service-tos/" />
+		<!-- Clicking page numbers triggers Uncaught DOMException only when on HTTPS. -->
+		<test url="https://www.asexuality.org/en/search/" />
+		<!-- Clicking on "Search By Author" then typing anything in the Search By Author
+			textbox triggers active mixed content blocking only when on HTTPS. -->
+		<test url="https://www.asexuality.org/en/search/?q=test&#x26;author=test" />
+		<!-- Clicking "More search options" then "Search Content" triggers Uncaught
+			DOMException only when on HTTPS. -->
 
 	<securecookie host="^www\.asexuality\.org$" name=".+" />
 

--- a/src/chrome/content/rules/asexuality.org_login.xml
+++ b/src/chrome/content/rules/asexuality.org_login.xml
@@ -12,12 +12,10 @@
 -->
 <ruleset name="Asexuality.org (partial)">
 	<target host="asexuality.org" />
-		<test url="http://asexuality.org/en/" />
 		<test url="http://asexuality.org/en/login/" />
 		<test url="http://asexuality.org/?q=about.html" />
 		<test url="http://asexuality.org/?q=contact.html" />
 	<target host="www.asexuality.org" />
-		<test url="http://www.asexuality.org/en/" />
 		<test url="http://www.asexuality.org/en/login/" />
 		<test url="http://www.asexuality.org/?q=about.html" />
 		<test url="http://www.asexuality.org/?q=contact.html" />

--- a/src/chrome/content/rules/asexuality.org_login.xml
+++ b/src/chrome/content/rules/asexuality.org_login.xml
@@ -22,9 +22,6 @@
 		<test url="http://www.asexuality.org/?q=about.html" />
 		<test url="http://www.asexuality.org/?q=contact.html" />
 
-	<exclusion pattern="^http://(www\.)?asexuality\.org/en/(?!login)" />
-		<!-- Exclude all areas of the forum except the login form target URL. -->
-
 	<rule from="^http://(www\.)?asexuality\.org/en/login"
 			to="https://www.asexuality.org/en/login/" />
 		<!-- Secure the login form target URL. -->

--- a/src/chrome/content/rules/asexuality.org_login.xml
+++ b/src/chrome/content/rules/asexuality.org_login.xml
@@ -12,8 +12,10 @@
 <ruleset name="Asexuality.org (login form)">
 	<target host="asexuality.org" />
 		<test url="http://asexuality.org/en/login/" />
+		<exclusion pattern="^http://asexuality\.org/$" />
 	<target host="www.asexuality.org" />
 		<test url="http://www.asexuality.org/en/login/" />
+		<exclusion pattern="^http://www\.asexuality\.org/$" />
 
 	<rule from="^http://(www\.)?asexuality\.org/en/login/"
 			to="https://www.asexuality.org/en/login/"/>

--- a/src/chrome/content/rules/asexuality.org_login.xml
+++ b/src/chrome/content/rules/asexuality.org_login.xml
@@ -10,7 +10,7 @@
 	HTTPS in all browsers. Due to mixedcontent issues, the rest of the forum can't be redirected to HTTPS except in
 	mixedcontent-friendly browsers, which is handled by the other ruleset file.
 -->
-<ruleset name="Asexuality.org">
+<ruleset name="Asexuality.org (partial)">
 	<target host="asexuality.org" />
 		<test url="http://asexuality.org/en/" />
 		<test url="http://asexuality.org/en/login/" />

--- a/src/chrome/content/rules/asexuality.org_login.xml
+++ b/src/chrome/content/rules/asexuality.org_login.xml
@@ -12,19 +12,23 @@
 -->
 <ruleset name="Asexuality.org">
 	<target host="asexuality.org" />
+		<test url="http://asexuality.org/en/" />
 		<test url="http://asexuality.org/en/login/" />
 		<test url="http://asexuality.org/?q=about.html" />
+		<test url="http://asexuality.org/?q=contact.html" />
 	<target host="www.asexuality.org" />
+		<test url="http://www.asexuality.org/en/" />
 		<test url="http://www.asexuality.org/en/login/" />
 		<test url="http://www.asexuality.org/?q=about.html" />
+		<test url="http://www.asexuality.org/?q=contact.html" />
 
 	<exclusion pattern="^http://(www\.)?asexuality\.org/en/(?!login)" />
 		<!-- Exclude all areas of the forum except the login form target URL. -->
 
-	<rule from="^http://(www\.)?asexuality\.org/en/login/"
-			to="https://www.asexuality.org/en/login/"/>
+	<rule from="^http://(www\.)?asexuality\.org/en/login"
+			to="https://www.asexuality.org/en/login/" />
 		<!-- Secure the login form target URL. -->
-	<rule from="^http://(www\.)?asexuality\.org/$"
-		  	to="https://$1asexuality.org/" />
+	<rule from="^http://(www\.)?asexuality\.org/($|\?q=)"
+		  	to="https://$1asexuality.org/$2" />
 		<!-- Secure the non-forum part of the site. -->
 </ruleset>

--- a/src/chrome/content/rules/asexuality.org_login.xml
+++ b/src/chrome/content/rules/asexuality.org_login.xml
@@ -5,18 +5,26 @@
 	Certificate mismatch:
 		ru.asexuality.org
 
-	Sept 2017: This ruleset simply redirects the target URL for the site's login form to HTTPS in all
-	browsers. Due to mixedcontent issues, the rest of the site can only be redirected to HTTPS in
+	Sept 2017: This ruleset has 2 functions. First, it redirects the non-forum part of the site, located at "/", to HTTPS
+	in all browsers. The forum is located at "/en/". Second, it redirects the target URL for the forum's login form to
+	HTTPS in all browsers. Due to mixedcontent issues, the rest of the forum can't be redirected to HTTPS except in
 	mixedcontent-friendly browsers, which is handled by the other ruleset file.
 -->
-<ruleset name="Asexuality.org (login form)">
+<ruleset name="Asexuality.org">
 	<target host="asexuality.org" />
 		<test url="http://asexuality.org/en/login/" />
-		<exclusion pattern="^http://asexuality\.org/$" />
+		<test url="http://asexuality.org/?q=about.html" />
 	<target host="www.asexuality.org" />
 		<test url="http://www.asexuality.org/en/login/" />
-		<exclusion pattern="^http://www\.asexuality\.org/$" />
+		<test url="http://www.asexuality.org/?q=about.html" />
+
+	<exclusion pattern="^http://(www\.)?asexuality\.org/en/(?!login)" />
+		<!-- Exclude all areas of the forum except the login form target URL. -->
 
 	<rule from="^http://(www\.)?asexuality\.org/en/login/"
 			to="https://www.asexuality.org/en/login/"/>
+		<!-- Secure the login form target URL. -->
+	<rule from="^http://(www\.)?asexuality\.org/$"
+		  	to="https://$1asexuality.org/" />
+		<!-- Secure the non-forum part of the site. -->
 </ruleset>

--- a/src/chrome/content/rules/asexuality.org_login.xml
+++ b/src/chrome/content/rules/asexuality.org_login.xml
@@ -11,8 +11,10 @@
 -->
 <ruleset name="Asexuality.org (login form)">
 	<target host="asexuality.org" />
+		<test url="http://asexuality.org/en/login/" />
 	<target host="www.asexuality.org" />
+		<test url="http://www.asexuality.org/en/login/" />
 
-	<rule from="^http://(?:www\.)?asexuality\.org/(\w{2})/login/"
-			to="https://www.asexuality.org/$1/login/"/>
+	<rule from="^http://(www\.)?asexuality\.org/en/login/"
+			to="https://www.asexuality.org/en/login/"/>
 </ruleset>

--- a/src/chrome/content/rules/asexuality.org_login.xml
+++ b/src/chrome/content/rules/asexuality.org_login.xml
@@ -1,0 +1,18 @@
+<!--
+	Other asexuality.org rulesets:
+		asexuality.org.xml
+
+	Certificate mismatch:
+		ru.asexuality.org
+
+	Sept 2017: This ruleset simply redirects the target URL for the site's login form to HTTPS in all
+	browsers. Due to mixedcontent issues, the rest of the site can only be redirected to HTTPS in
+	mixedcontent-friendly browsers, which is handled by the other ruleset file.
+-->
+<ruleset name="Asexuality.org (login form)">
+	<target host="asexuality.org" />
+	<target host="www.asexuality.org" />
+
+	<rule from="^http://(?:www\.)?asexuality\.org/(\w{2})/login/"
+			to="https://www.asexuality.org/$1/login/"/>
+</ruleset>

--- a/src/chrome/content/rules/asexuality.org_login.xml
+++ b/src/chrome/content/rules/asexuality.org_login.xml
@@ -5,24 +5,30 @@
 	Certificate mismatch:
 		ru.asexuality.org
 
-	Sept 2017: This ruleset has 2 functions. First, it redirects the non-forum part of the site, located at "/", to HTTPS
-	in all browsers. The forum is located at "/en/". Second, it redirects the target URL for the forum's login form to
-	HTTPS in all browsers. Due to mixedcontent issues, the rest of the forum can't be redirected to HTTPS except in
-	mixedcontent-friendly browsers, which is handled by the other ruleset file.
+	Sept 2017: This ruleset has 2 functions. First, it redirects the non-forum part of the site, located at "/",
+	to HTTPS in all browsers. The forum is located at "/en/". Second, it redirects the target URLs for the forum's
+	account registration and login forms to HTTPS in all browsers. Due to mixedcontent issues, the rest of the
+	forum can't be redirected to HTTPS except in mixedcontent-friendly browsers, which is handled by the other
+	ruleset file.
 -->
 <ruleset name="Asexuality.org (partial)">
 	<target host="asexuality.org" />
 		<test url="http://asexuality.org/en/login/" />
+		<test url="http://asexuality.org/en/register/" />
 		<test url="http://asexuality.org/?q=about.html" />
 		<test url="http://asexuality.org/?q=contact.html" />
 	<target host="www.asexuality.org" />
 		<test url="http://www.asexuality.org/en/login/" />
+		<test url="http://www.asexuality.org/en/register/" />
 		<test url="http://www.asexuality.org/?q=about.html" />
 		<test url="http://www.asexuality.org/?q=contact.html" />
 
 	<rule from="^http://(www\.)?asexuality\.org/en/login"
 			to="https://www.asexuality.org/en/login/" />
 		<!-- Secure the login form target URL. -->
+	<rule from="^http://(www\.)?asexuality\.org/en/register"
+			to="https://www.asexuality.org/en/register/" />
+		<!-- Secure the signup form target URL. -->
 	<rule from="^http://(www\.)?asexuality\.org/($|\?q=)"
 		  	to="https://$1asexuality.org/$2" />
 		<!-- Secure the non-forum part of the site. -->


### PR DESCRIPTION
Forum users on asexuality.org are having issues caused by this ruleset, such as broken page number links at the bottom of forum threads, search forms not submitting, broken like buttons on posts, etc.

There are lots of mixed content ajax requests getting blocked:
```
Mixed Content: The page at 'https://www.asexuality.org/en/search/' was loaded over HTTPS, but requested an insecure XMLHttpRequest endpoint 'http://www.asexuality.org/en/index.php?app=core&module=system&controller=ajax&do=findMember&input=test&csrfKey=a4fd372821ea00cf4b5209116cd35183'. This request has been blocked; the content must be served over HTTPS.
```

Disabling the ruleset checkbox in the HTTPSE popup or altogether disabling HTTPSE makes the issues go away when using the site over http.

This PR makes the ruleset active only on Tor Browser with `platform="mixedcontent"`. There are users who access this site only with Tor Browser and they have few issues with the ruleset because TB doesn't block mixed content.

Additionally, the site's login form targets the insecure endpoint `http://www.asexuality.org/en/login/`. In the interest of securing Chrome and Firefox users' passwords, this PR also adds a new ruleset that's active in all browsers for the sole purpose of redirecting the login form target to https. This doesn't secure auth tokens after users have logged in, but it's a small improvement over logging in with plain http.