### PR TITLE
Initialize the rulesets only after we are sure which storage engine w…

### DIFF
--- a/chromium/background.js
+++ b/chromium/background.js
@@ -572,7 +572,8 @@ chrome.runtime.onMessage.addListener(function(message, sender, sendResponse){
     ruleset.active = message.object.active;
     sendResponse(true);
   } else if (message.type == "add_new_rule") {
-    all_rules.addNewRuleAndStore(message.object).then(sendResponse);
+    all_rules.addNewRuleAndStore(message.object);
+    sendResponse(true);
     return true;
   } else if (message.type == "remove_rule") {
     all_rules.removeRuleAndStore(message.object);

--- a/chromium/background.js
+++ b/chromium/background.js
@@ -24,30 +24,6 @@ function initialize(){
   });
 }
 
-/**
- * Load a file packaged with the extension
- *
- * @param url: a relative URL to local file
- */
-function loadExtensionFile(url, returnType) {
-  var xhr = new XMLHttpRequest();
-  // Use blocking XHR to ensure everything is loaded by the time
-  // we return.
-  xhr.open("GET", chrome.extension.getURL(url), false);
-  xhr.send(null);
-  // Get file contents
-  if (xhr.readyState != 4) {
-    return;
-  }
-  if (returnType === 'xml') {
-    return xhr.responseXML;
-  }
-  if (returnType === 'json') {
-    return JSON.parse(xhr.responseText);
-  }
-  return xhr.responseText;
-}
-
 
 // Load in the legacy custom rulesets, if any
 function load_legacy_custom_rulesets(legacy_custom_rulesets){

--- a/chromium/background.js
+++ b/chromium/background.js
@@ -4,14 +4,15 @@
 
 let all_rules = new rules.RuleSets();
 
-function initialize(){
-  initializeStoredGlobals().then(() => {
-    all_rules.initialize();
+async function initialize(){
+  await store.initialize();
+  await initializeStoredGlobals();
+  all_rules.initialize();
 
-    // Send a message to the embedded webextension bootstrap.js to get settings to import
-    chrome.runtime.sendMessage("import-legacy-data", import_settings);
-  });
+  // Send a message to the embedded webextension bootstrap.js to get settings to import
+  chrome.runtime.sendMessage("import-legacy-data", import_settings);
 }
+initialize();
 
 
 // Load in the legacy custom rulesets, if any

--- a/chromium/background.js
+++ b/chromium/background.js
@@ -4,7 +4,7 @@
 
 let all_rules = new rules.RuleSets();
 
-async function initialize(){
+async function initialize() {
   await store.initialize();
   await initializeStoredGlobals();
   all_rules.initialize();

--- a/chromium/background.js
+++ b/chromium/background.js
@@ -612,8 +612,7 @@ async function import_settings(settings) {
 
 Object.assign(exports, {
   all_rules,
-  urlBlacklist,
-  initialize,
+  urlBlacklist
 });
 
 })(typeof exports == 'undefined' ? window.background = {} : exports);

--- a/chromium/background.js
+++ b/chromium/background.js
@@ -95,7 +95,6 @@ var switchPlannerEnabledFor = {};
 // rw / nrw stand for "rewritten" versus "not rewritten"
 var switchPlannerInfo = {};
 
-var wr = chrome.webRequest;
 function getActiveRulesetCount(id) {
   const applied = activeRulesets.getRulesets(id);
 
@@ -492,17 +491,17 @@ function onErrorOccurred(details) {
 
 // Registers the handler for requests
 // See: https://github.com/EFForg/https-everywhere/issues/10039
-wr.onBeforeRequest.addListener(onBeforeRequest, {urls: ["*://*/*"]}, ["blocking"]);
+chrome.webRequest.onBeforeRequest.addListener(onBeforeRequest, {urls: ["*://*/*"]}, ["blocking"]);
 
 
 // Try to catch redirect loops on URLs we've redirected to HTTPS.
-wr.onBeforeRedirect.addListener(onBeforeRedirect, {urls: ["https://*/*"]});
+chrome.webRequest.onBeforeRedirect.addListener(onBeforeRedirect, {urls: ["https://*/*"]});
 
 // Cleanup redirectCounter if neccessary
-wr.onCompleted.addListener(onCompleted, {urls: ["*://*/*"]});
+chrome.webRequest.onCompleted.addListener(onCompleted, {urls: ["*://*/*"]});
 
 // Cleanup redirectCounter if neccessary
-wr.onErrorOccurred.addListener(onErrorOccurred, {urls: ["*://*/*"]})
+chrome.webRequest.onErrorOccurred.addListener(onErrorOccurred, {urls: ["*://*/*"]})
 
 // Listen for cookies set/updated and secure them if applicable. This function is async/nonblocking.
 chrome.cookies.onChanged.addListener(onCookieChanged);

--- a/chromium/rules.js
+++ b/chromium/rules.js
@@ -352,7 +352,7 @@ RuleSets.prototype = {
   },
   
   /**
-  * Load stored user rules
+  * Retrieve stored user rules from localStorage
   **/
   getStoredUserRules: function() {
     const oldUserRuleString = store.localStorage.getItem(this.USER_RULE_KEY);
@@ -364,7 +364,7 @@ RuleSets.prototype = {
   },
 
   /**
-  * Load all stored user rules
+  * Load all stored user rules into this RuleSet object
   */
   loadStoredUserRules: function() {
     const user_rules = this.getStoredUserRules();

--- a/chromium/rules.js
+++ b/chromium/rules.js
@@ -380,22 +380,17 @@ RuleSets.prototype = {
   * @param cb: Callback to call after success/fail
   * */
   addNewRuleAndStore: function(params) {
-    return new Promise(resolve => {
-      if (this.addUserRule(params)) {
-        // If we successfully added the user rule, save it in local
-        // storage so it's automatically applied when the extension is
-        // reloaded.
-        var oldUserRules = this.getStoredUserRules();
-        // TODO: there's a race condition here, if this code is ever executed from multiple
-        // client windows in different event loops.
-        oldUserRules.push(params);
-        // TODO: can we exceed the max size for storage?
-        store.localStorage.setItem(this.USER_RULE_KEY, JSON.stringify(oldUserRules));
-        resolve(true);
-      } else {
-        resolve(false);
-      }
-    });
+    if (this.addUserRule(params)) {
+      // If we successfully added the user rule, save it in local
+      // storage so it's automatically applied when the extension is
+      // reloaded.
+      var oldUserRules = this.getStoredUserRules();
+      // TODO: there's a race condition here, if this code is ever executed from multiple
+      // client windows in different event loops.
+      oldUserRules.push(params);
+      // TODO: can we exceed the max size for storage?
+      store.localStorage.setItem(this.USER_RULE_KEY, JSON.stringify(oldUserRules));
+    }
   },
 
   /**

--- a/chromium/rules.js
+++ b/chromium/rules.js
@@ -186,7 +186,7 @@ RuleSet.prototype = {
  * @param ruleActiveStates default state for rules
  * @constructor
  */
-function RuleSets(ruleActiveStates) {
+function RuleSets() {
   // Load rules into structure
   this.targets = new Map();
 
@@ -197,11 +197,21 @@ function RuleSets(ruleActiveStates) {
   this.cookieHostCache = new Map();
 
   // A hash of rule name -> active status (true/false).
-  this.ruleActiveStates = ruleActiveStates;
+  this.ruleActiveStates = {};
+
+  // The key to retrieve user rules from localStorage
+  this.USER_RULE_KEY = 'userRules';
 }
 
 
 RuleSets.prototype = {
+
+  initialize: function() {
+    this.addFromJson(util.loadExtensionFile('rules/default.rulesets', 'json'));
+    this.loadStoredUserRules();
+    this.ruleActiveStates = store.localStorage;
+  },
+
   /**
    * Iterate through data XML and load rulesets
    */
@@ -339,6 +349,70 @@ RuleSets.prototype = {
 
     util.log(util.INFO, 'done removing rule');
     return true;
+  },
+  
+  /**
+  * Load stored user rules
+  **/
+  getStoredUserRules: function() {
+    const oldUserRuleString = store.localStorage.getItem(this.USER_RULE_KEY);
+    let oldUserRules = [];
+    if (oldUserRuleString) {
+      oldUserRules = JSON.parse(oldUserRuleString);
+    }
+    return oldUserRules;
+  },
+
+  /**
+  * Load all stored user rules
+  */
+  loadStoredUserRules: function() {
+    const user_rules = this.getStoredUserRules();
+    for (let user_rule of user_rules) {
+      this.addUserRule(user_rule);
+    }
+    util.log(util.INFO, 'loaded ' + user_rules.length + ' stored user rules');
+  },
+
+  /**
+  * Adds a new user rule
+  * @param params: params defining the rule
+  * @param cb: Callback to call after success/fail
+  * */
+  addNewRuleAndStore: function(params) {
+    return new Promise(resolve => {
+      if (this.addUserRule(params)) {
+        // If we successfully added the user rule, save it in local
+        // storage so it's automatically applied when the extension is
+        // reloaded.
+        var oldUserRules = this.getStoredUserRules();
+        // TODO: there's a race condition here, if this code is ever executed from multiple
+        // client windows in different event loops.
+        oldUserRules.push(params);
+        // TODO: can we exceed the max size for storage?
+        store.localStorage.setItem(this.USER_RULE_KEY, JSON.stringify(oldUserRules));
+        resolve(true);
+      } else {
+        resolve(false);
+      }
+    });
+  },
+
+  /**
+  * Removes a user rule
+  * @param ruleset: the ruleset to remove
+  * */
+  removeRuleAndStore: function(ruleset) {
+    if (this.removeUserRule(ruleset)) {
+      // If we successfully removed the user rule, remove it in local storage too
+      var userRules = this.getStoredUserRules();
+      userRules = userRules.filter(r =>
+        !(r.host == ruleset.name &&
+          r.redirectTo == ruleset.rules[0].to &&
+          String(RegExp(r.urlMatcher)) == String(ruleset.rules[0].from_c))
+      );
+      store.localStorage.setItem(this.USER_RULE_KEY, JSON.stringify(userRules));
+    }
   },
 
   /**
@@ -583,7 +657,7 @@ RuleSets.prototype = {
 
 Object.assign(exports, {
   settings,
-  RuleSets,
+  RuleSets
 });
 
 })(typeof exports == 'undefined' ? window.rules = {} : exports);

--- a/chromium/store.js
+++ b/chromium/store.js
@@ -9,14 +9,18 @@ function setStorage(store) {
   });
 }
 
-setStorage(chrome.storage.local);
 if (chrome.storage.sync) {
   chrome.storage.sync.set({"sync-set-test": true}, () => {
-    if(!chrome.runtime.lastError){
+    if(chrome.runtime.lastError){
+      setStorage(chrome.storage.local);
+    } else {
       setStorage(chrome.storage.sync);
-      background.initializeStoredGlobals();
     }
+    background.initialize();
   });
+} else {
+  setStorage(chrome.storage.local);
+  background.initialize();
 }
 
 })(typeof exports == 'undefined' ? window.store = {} : exports);

--- a/chromium/store.js
+++ b/chromium/store.js
@@ -4,13 +4,13 @@
 
 let ls;
 
-try{
+try {
   ls = localStorage;
 } catch(e) {
   ls = {setItem: () => {}, getItem: () => {}};
 }
 
-function initialize(){
+function initialize() {
   return new Promise(resolve => {
     if (chrome.storage.sync) {
       chrome.storage.sync.set({"sync-set-test": true}, () => {
@@ -33,12 +33,12 @@ function setStorage(store) {
     get: store.get,
     set: store.set,
     localStorage: ls,
-    initialize: initialize
+    initialize
   });
 }
 
 Object.assign(exports, {
-  initialize: initialize
+  initialize
 });
 
 })(typeof exports == 'undefined' ? window.store = {} : exports);

--- a/chromium/store.js
+++ b/chromium/store.js
@@ -2,10 +2,19 @@
 
 (function(exports) {
 
+let ls;
+
+try{
+  ls = localStorage;
+} catch(e) {
+  ls = {setItem: () => {}, getItem: () => {}};
+}
+
 function setStorage(store) {
   Object.assign(exports, {
     get: store.get,
     set: store.set,
+    localStorage: ls
   });
 }
 

--- a/chromium/store.js
+++ b/chromium/store.js
@@ -10,26 +10,35 @@ try{
   ls = {setItem: () => {}, getItem: () => {}};
 }
 
+function initialize(){
+  return new Promise(resolve => {
+    if (chrome.storage.sync) {
+      chrome.storage.sync.set({"sync-set-test": true}, () => {
+        if(chrome.runtime.lastError){
+          setStorage(chrome.storage.local);
+        } else {
+          setStorage(chrome.storage.sync);
+        }
+        resolve();
+      });
+    } else {
+      setStorage(chrome.storage.local);
+      resolve();
+    }
+  });
+}
+
 function setStorage(store) {
   Object.assign(exports, {
     get: store.get,
     set: store.set,
-    localStorage: ls
+    localStorage: ls,
+    initialize: initialize
   });
 }
 
-if (chrome.storage.sync) {
-  chrome.storage.sync.set({"sync-set-test": true}, () => {
-    if(chrome.runtime.lastError){
-      setStorage(chrome.storage.local);
-    } else {
-      setStorage(chrome.storage.sync);
-    }
-    background.initialize();
-  });
-} else {
-  setStorage(chrome.storage.local);
-  background.initialize();
-}
+Object.assign(exports, {
+  initialize: initialize
+});
 
 })(typeof exports == 'undefined' ? window.store = {} : exports);

--- a/chromium/util.js
+++ b/chromium/util.js
@@ -40,7 +40,7 @@ function loadExtensionFile(url, returnType) {
   xhr.open("GET", chrome.extension.getURL(url), false);
   xhr.send(null);
   // Get file contents
-  if (xhr.readyState != 4) {
+  if (xhr.readyState !== 4) {
     return;
   }
   if (returnType === 'xml') {

--- a/chromium/util.js
+++ b/chromium/util.js
@@ -28,6 +28,30 @@ function log(level, str) {
   }
 }
 
+/**
+ * Load a file packaged with the extension
+ *
+ * @param url: a relative URL to local file
+ */
+function loadExtensionFile(url, returnType) {
+  var xhr = new XMLHttpRequest();
+  // Use blocking XHR to ensure everything is loaded by the time
+  // we return.
+  xhr.open("GET", chrome.extension.getURL(url), false);
+  xhr.send(null);
+  // Get file contents
+  if (xhr.readyState != 4) {
+    return;
+  }
+  if (returnType === 'xml') {
+    return xhr.responseXML;
+  }
+  if (returnType === 'json') {
+    return JSON.parse(xhr.responseText);
+  }
+  return xhr.responseText;
+}
+
 Object.assign(exports, {
   VERB,
   DBUG,
@@ -35,6 +59,7 @@ Object.assign(exports, {
   NOTE,
   WARN,
   log,
+  loadExtensionFile
 });
 
 })(typeof exports == 'undefined' ? window.util = {} : exports);


### PR DESCRIPTION
…e'll be using

This ensures that the rulesets are not initialized more than once from default.rulesets, and wraps all the initialization of rulesets into background.initialize.  Initialize is only called after we're sure what storage engine we'll be using.

This also ensures that the enableMixedRulesets is loaded from the correct storage engine before loading rulesets.