### PR TITLE
Debugging rulesets

### DIFF
--- a/chromium/background.js
+++ b/chromium/background.js
@@ -68,8 +68,9 @@ chrome.storage.onChanged.addListener(async function(changes, areaName) {
       updateState();
     }
     if ('debugging_rulesets' in changes) {
-      Object.assign(all_rules, new rules.RuleSets());
-      await all_rules.initialize();
+      const r = new rules.RuleSets();
+      await r.initialize();
+      Object.assign(all_rules, r);
     }
   }
 });

--- a/chromium/background.js
+++ b/chromium/background.js
@@ -69,7 +69,7 @@ chrome.storage.onChanged.addListener(async function(changes, areaName) {
     }
     if ('debugging_rulesets' in changes) {
       const r = new rules.RuleSets();
-      await r.initialize();
+      await r.loadFromBrowserStorage(store);
       Object.assign(all_rules, r);
     }
   }

--- a/chromium/background.js
+++ b/chromium/background.js
@@ -67,6 +67,10 @@ chrome.storage.onChanged.addListener(async function(changes, areaName) {
       isExtensionEnabled = changes.globalEnabled.newValue;
       updateState();
     }
+    if ('debugging_rulesets' in changes) {
+      Object.assign(all_rules, new rules.RuleSets());
+      await all_rules.initialize();
+    }
   }
 });
 

--- a/chromium/debugging-rulesets.css
+++ b/chromium/debugging-rulesets.css
@@ -1,0 +1,20 @@
+.section-header{
+  margin-bottom: 10px;
+}
+
+.section-header-span{
+  border-bottom: 1px solid #ccc;
+  font-size: 15px;
+}
+
+#debugging-rulesets{
+  width: 100%;
+  height: 500px;
+}
+
+#saved{
+  display: none;
+  color: green;
+  font-weight: bold;
+  margin: 30px;
+}

--- a/chromium/debugging-rulesets.css
+++ b/chromium/debugging-rulesets.css
@@ -10,6 +10,7 @@
 #debugging-rulesets{
   width: 100%;
   height: 500px;
+  display: none;
 }
 
 #saved{

--- a/chromium/debugging-rulesets.css
+++ b/chromium/debugging-rulesets.css
@@ -2,6 +2,10 @@
   margin-bottom: 10px;
 }
 
+.section-explainer{
+  margin-bottom: 5px;
+}
+
 .section-header-span{
   border-bottom: 1px solid #ccc;
   font-size: 15px;
@@ -11,6 +15,11 @@
   width: 100%;
   height: 500px;
   display: none;
+  border: 1px solid black;
+}
+
+#debugging-rulesets.unsaved{
+  border: 1px solid red;
 }
 
 #saved{

--- a/chromium/debugging-rulesets.css
+++ b/chromium/debugging-rulesets.css
@@ -22,6 +22,14 @@
   border: 1px solid red;
 }
 
+#changed{
+  font-weight: bold;
+  margin: 10px 0px;
+  color: #F00;
+  visibility: hidden;
+  text-align: center;
+}
+
 #saved{
   display: none;
   color: green;

--- a/chromium/debugging-rulesets.html
+++ b/chromium/debugging-rulesets.html
@@ -8,7 +8,11 @@
   <body>
     <form id="debugging-rulesets-form">
       <div class="section-header"><span class="section-header-span">Debugging Rulesets</span></div>
-      <textarea id="debugging-rulesets"></textarea>
+      <div class="section-explainer">
+        Enter ruleset XML below and click save when ready.  These rulesets will be immediately instated upon saving, and will persist across restarts.<br>
+        <i>Note</i>: Due to a bug in Chromium, it may be necessary to close the options ui before saving.
+      </div>
+      <textarea id="debugging-rulesets" spellcheck="false"></textarea>
       <button type="submit" id="save">Save</button>
     </form>
     <div id='saved'>Saved!</div>

--- a/chromium/debugging-rulesets.html
+++ b/chromium/debugging-rulesets.html
@@ -6,13 +6,13 @@
     <link href="debugging-rulesets.css" rel="stylesheet">
   </head>
   <body>
-    <form>
+    <form id="debugging-rulesets-form">
       <div class="section-header"><span class="section-header-span">Debugging Rulesets</span></div>
       <textarea id="debugging-rulesets"></textarea>
       <button type="submit" id="save">Save</button>
     </form>
     <div id='saved'>Saved!</div>
-    <script src="debugging-rulesets.js"></script>
     <script src="send-message.js"></script>
+    <script src="debugging-rulesets.js"></script>
   </body>
 </html>

--- a/chromium/debugging-rulesets.html
+++ b/chromium/debugging-rulesets.html
@@ -9,9 +9,10 @@
     <form id="debugging-rulesets-form">
       <div class="section-header"><span class="section-header-span">Debugging Rulesets</span></div>
       <div class="section-explainer">
-        Enter ruleset XML below and click save when ready.  These rulesets will be immediately instated upon saving, and will persist across restarts.<br>
+        Enter ruleset XML below and click save when ready.  These rulesets will be immediately activated upon saving, and will persist across restarts.<br>
         <i>Note</i>: Due to a bug in Chromium, it may be necessary to close the options ui before saving.
       </div>
+      <div id="changed">There are unsaved changes!  Be sure to save them for them to take effect.</div>
       <textarea id="debugging-rulesets" spellcheck="false"></textarea>
       <button type="submit" id="save">Save</button>
     </form>

--- a/chromium/debugging-rulesets.html
+++ b/chromium/debugging-rulesets.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title></title>
+    <link href="debugging-rulesets.css" rel="stylesheet">
+  </head>
+  <body>
+    <form>
+      <div class="section-header"><span class="section-header-span">Debugging Rulesets</span></div>
+      <textarea id="debugging-rulesets"></textarea>
+      <button type="submit" id="save">Save</button>
+    </form>
+    <div id='saved'>Saved!</div>
+    <script src="debugging-rulesets.js"></script>
+    <script src="send-message.js"></script>
+  </body>
+</html>

--- a/chromium/debugging-rulesets.html
+++ b/chromium/debugging-rulesets.html
@@ -10,6 +10,7 @@
       <div class="section-header"><span class="section-header-span">Debugging Rulesets</span></div>
       <div class="section-explainer">
         Enter ruleset XML below and click save when ready.  These rulesets will be immediately activated upon saving, and will persist across restarts.<br>
+        <i>Warning</i>: This should only be used for debugging rulesets.  This feature is not guaranteed to work reliably for regular usage.<br>
         <i>Note</i>: Due to a bug in Chromium, it may be necessary to close the options ui before saving.
       </div>
       <div id="changed">There are unsaved changes!  Be sure to save them for them to take effect.</div>

--- a/chromium/debugging-rulesets.js
+++ b/chromium/debugging-rulesets.js
@@ -1,0 +1,20 @@
+/* global sendMessage */
+
+"use strict";
+
+window.onload = function() {
+  document.querySelector("form").addEventListener("submit", save_debugging_rulesets);
+
+  sendMessage("get_option", { debugging_rulesets: "" }, item => {
+    document.getElementById("debugging-rulesets").value = item.debugging_rulesets;
+  });
+}
+
+function save_debugging_rulesets(e){
+  e.preventDefault();
+  sendMessage("set_option", { debugging_rulesets: document.getElementById("debugging-rulesets").value }, () => {
+    const saved = document.getElementById("saved");
+    saved.style.display = "block";
+    setTimeout(() => { saved.style.display = "none" }, 1000);
+  });
+}

--- a/chromium/debugging-rulesets.js
+++ b/chromium/debugging-rulesets.js
@@ -3,6 +3,7 @@
 "use strict";
 
 const debugging_rulesets_textarea = document.getElementById("debugging-rulesets");
+const changed = document.getElementById("changed");
 const default_title = "Debugging Rulesets";
 const unsaved_title = "* Debugging Rulesets";
 
@@ -25,10 +26,12 @@ function save_debugging_rulesets(e){
 
     document.title = default_title;
     debugging_rulesets_textarea.className = "";
+    changed.style.visibility = "hidden";
   });
 }
 
 function debugging_rulesets_changed(){
   debugging_rulesets_textarea.className = "unsaved";
   document.title = unsaved_title;
+  changed.style.visibility = "visible";
 }

--- a/chromium/debugging-rulesets.js
+++ b/chromium/debugging-rulesets.js
@@ -2,13 +2,13 @@
 
 "use strict";
 
-window.onload = function() {
-  document.querySelector("form").addEventListener("submit", save_debugging_rulesets);
+document.getElementById("debugging-rulesets-form").addEventListener("submit", save_debugging_rulesets);
 
-  sendMessage("get_option", { debugging_rulesets: "" }, item => {
-    document.getElementById("debugging-rulesets").value = item.debugging_rulesets;
-  });
-}
+sendMessage("get_option", { debugging_rulesets: "" }, item => {
+  let debugging_rulesets_textarea = document.getElementById("debugging-rulesets");
+  debugging_rulesets_textarea.value = item.debugging_rulesets;
+  debugging_rulesets_textarea.style.display = "block";
+});
 
 function save_debugging_rulesets(e){
   e.preventDefault();

--- a/chromium/debugging-rulesets.js
+++ b/chromium/debugging-rulesets.js
@@ -2,19 +2,33 @@
 
 "use strict";
 
+const debugging_rulesets_textarea = document.getElementById("debugging-rulesets");
+const default_title = "Debugging Rulesets";
+const unsaved_title = "* Debugging Rulesets";
+
+debugging_rulesets_textarea.addEventListener("input", debugging_rulesets_changed);
 document.getElementById("debugging-rulesets-form").addEventListener("submit", save_debugging_rulesets);
 
+document.title = default_title;
+
 sendMessage("get_option", { debugging_rulesets: "" }, item => {
-  let debugging_rulesets_textarea = document.getElementById("debugging-rulesets");
   debugging_rulesets_textarea.value = item.debugging_rulesets;
   debugging_rulesets_textarea.style.display = "block";
 });
 
 function save_debugging_rulesets(e){
   e.preventDefault();
-  sendMessage("set_option", { debugging_rulesets: document.getElementById("debugging-rulesets").value }, () => {
+  sendMessage("set_option", { debugging_rulesets: debugging_rulesets_textarea.value }, () => {
     const saved = document.getElementById("saved");
     saved.style.display = "block";
     setTimeout(() => { saved.style.display = "none" }, 1000);
+
+    document.title = default_title;
+    debugging_rulesets_textarea.className = "";
   });
+}
+
+function debugging_rulesets_changed(){
+  debugging_rulesets_textarea.className = "unsaved";
+  document.title = unsaved_title;
 }

--- a/chromium/options.js
+++ b/chromium/options.js
@@ -38,4 +38,11 @@ document.addEventListener("DOMContentLoaded", () => {
       sendMessage("set_option", { showCounter: showCounter.checked });
     });
   });
+
+  document.onkeydown = function(evt) {
+    evt = evt || window.event;
+    if (evt.ctrlKey && evt.keyCode == 90) {
+      window.open("debugging-rulesets.html");
+    }
+  };
 });

--- a/chromium/rules.js
+++ b/chromium/rules.js
@@ -424,7 +424,7 @@ RuleSets.prototype = {
         debugging_rulesets: ""
       }, item => {
         this.loadCustomRulesets(item.legacy_custom_rulesets);
-        this.loadCustomRuleset(item.debugging_rulesets);
+        this.loadCustomRuleset("<root>" + item.debugging_rulesets + "</root>");
         resolve();
       });
     });


### PR DESCRIPTION
Depends on https://github.com/EFForg/https-everywhere/pull/12859

Adds a special page where ruleset testers can enter debugging rulesets into a textarea.

When multiple rulesets are added, these have to all be wrapped `<root>` and `</root>` opening and closing tag in order to be valid XML.

To access this page, navigate to the extension options UI, then click "General Settings" and type `Ctrl-Z`.  This should open a new tab to enter debugging rules into.

When you click `Save`, these rulesets should immediately take effect.

The UX is pretty rough, but since this is only to be used by testers I figure that's alright.  The reason this page is so hidden away is that I'd rather have users enter custom rulesets in the standard way, through the popup.