### PR TITLE
Add a require function

### DIFF
--- a/chromium/.eslintrc.json
+++ b/chromium/.eslintrc.json
@@ -21,5 +21,6 @@
     "background": true,
     "rules": true,
     "incognito": true
+    "require": true
   }
 }

--- a/chromium/.eslintrc.json
+++ b/chromium/.eslintrc.json
@@ -16,11 +16,6 @@
   },
   "globals": {
     "exports": true,
-    "util": true,
-    "store": true,
-    "background": true,
-    "rules": true,
-    "incognito": true
     "require": true
   }
 }

--- a/chromium/background.js
+++ b/chromium/background.js
@@ -7,7 +7,7 @@ let all_rules = new rules.RuleSets();
 async function initialize() {
   await store.initialize();
   await initializeStoredGlobals();
-  await all_rules.initialize();
+  await all_rules.initialize(store);
 
   // Send a message to the embedded webextension bootstrap.js to get settings to import
   chrome.runtime.sendMessage("import-legacy-data", import_settings);
@@ -597,7 +597,7 @@ async function import_settings(settings) {
     });
 
     Object.assign(all_rules, new rules.RuleSets());
-    await all_rules.initialize();
+    await all_rules.initialize(store);
 
   }
 }

--- a/chromium/background.js
+++ b/chromium/background.js
@@ -2,6 +2,11 @@
 
 (function(exports) {
 
+const rules = require('./rules'),
+  store = require('./store'),
+  util = require('./util');
+
+
 let all_rules = new rules.RuleSets();
 
 async function initialize() {
@@ -607,4 +612,4 @@ Object.assign(exports, {
   urlBlacklist
 });
 
-})(typeof exports == 'undefined' ? window.background = {} : exports);
+})(typeof exports == 'undefined' ? require.scopes.background = {} : exports);

--- a/chromium/bootstrap.js
+++ b/chromium/bootstrap.js
@@ -1,0 +1,9 @@
+"use strict";
+
+function require(module) {
+  if (module.startsWith('./') && !module.hasOwnProperty(module.slice(2))) {
+    return require.scopes[module.slice(2)];
+  }
+  throw new Error('module: ' + module + ' not found.');
+}
+require.scopes = {};

--- a/chromium/incognito.js
+++ b/chromium/incognito.js
@@ -2,6 +2,10 @@
 
 (function(exports) {
 
+const util = require('./util'),
+  background = require('./background'),
+  rules = require('./rules');
+
 // This file keeps track of incognito sessions, and clears any caches after
 // an entire incognito session is closed (i.e. all incognito windows are closed).
 
@@ -67,4 +71,4 @@ if (chrome.windows) {
 
 Object.assign(exports, {});
 
-})(typeof exports == 'undefined' ? window.incognito = {} : exports);
+})(typeof exports == 'undefined' ? require.scopes.incognito = {} : exports);

--- a/chromium/manifest.json
+++ b/chromium/manifest.json
@@ -8,6 +8,7 @@
     "author": "eff.software.projects@gmail.com",
     "background": {
         "scripts": [
+            "bootstrap.js",
             "util.js",
             "rules.js",
             "store.js",

--- a/chromium/rules.js
+++ b/chromium/rules.js
@@ -3,6 +3,8 @@
 
 (function(exports) {
 
+const util = require('./util');
+
 // Stubs so this runs under nodejs. They get overwritten later by util.js
 if (typeof util == 'undefined' || typeof global != 'undefined') {
   Object.assign(global, {
@@ -680,4 +682,4 @@ Object.assign(exports, {
   RuleSets
 });
 
-})(typeof exports == 'undefined' ? window.rules = {} : exports);
+})(typeof exports == 'undefined' ? require.scopes.rules = {} : exports);

--- a/chromium/rules.js
+++ b/chromium/rules.js
@@ -206,7 +206,8 @@ function RuleSets() {
 
 RuleSets.prototype = {
 
-  initialize: async function() {
+  initialize: async function(store) {
+    this.store = store;
     this.ruleActiveStates = store.localStorage;
     this.addFromJson(util.loadExtensionFile('rules/default.rulesets', 'json'));
     this.loadStoredUserRules();
@@ -356,7 +357,7 @@ RuleSets.prototype = {
   * Retrieve stored user rules from localStorage
   **/
   getStoredUserRules: function() {
-    const oldUserRuleString = store.localStorage.getItem(this.USER_RULE_KEY);
+    const oldUserRuleString = this.store.localStorage.getItem(this.USER_RULE_KEY);
     let oldUserRules = [];
     if (oldUserRuleString) {
       oldUserRules = JSON.parse(oldUserRuleString);
@@ -390,7 +391,7 @@ RuleSets.prototype = {
       // client windows in different event loops.
       oldUserRules.push(params);
       // TODO: can we exceed the max size for storage?
-      store.localStorage.setItem(this.USER_RULE_KEY, JSON.stringify(oldUserRules));
+      this.store.localStorage.setItem(this.USER_RULE_KEY, JSON.stringify(oldUserRules));
     }
   },
 
@@ -406,13 +407,13 @@ RuleSets.prototype = {
         !(r.host == ruleset.name &&
           r.redirectTo == ruleset.rules[0].to)
       );
-      store.localStorage.setItem(this.USER_RULE_KEY, JSON.stringify(userRules));
+      this.store.localStorage.setItem(this.USER_RULE_KEY, JSON.stringify(userRules));
     }
   },
 
   addStoredCustomRulesets: function(){
     return new Promise(resolve => {
-      store.get({
+      this.store.get({
         legacy_custom_rulesets: [],
         debugging_rulesets: ""
       }, item => {

--- a/chromium/rules.js
+++ b/chromium/rules.js
@@ -1,21 +1,8 @@
-/* globals global: false */
 "use strict";
 
 (function(exports) {
 
 const util = require('./util');
-
-// Stubs so this runs under nodejs. They get overwritten later by util.js
-if (typeof util == 'undefined' || typeof global != 'undefined') {
-  Object.assign(global, {
-    util: {
-      DBUG: 2,
-      INFO: 3,
-      WARN: 5,
-      log: ()=>{},
-    }
-  });
-}
 
 let settings = {
   enableMixedRulesets: false,

--- a/chromium/store.js
+++ b/chromium/store.js
@@ -41,4 +41,4 @@ Object.assign(exports, {
   initialize
 });
 
-})(typeof exports == 'undefined' ? window.store = {} : exports);
+})(typeof exports == 'undefined' ? require.scopes.store = {} : exports);

--- a/chromium/util.js
+++ b/chromium/util.js
@@ -62,4 +62,4 @@ Object.assign(exports, {
   loadExtensionFile
 });
 
-})(typeof exports == 'undefined' ? window.util = {} : exports);
+})(typeof exports == 'undefined' ? require.scopes.util = {} : exports);


### PR DESCRIPTION
NB: This is blocked until #12859 is merged, since that removes the `background` dependency in `store.js`.

This PR adds a "`require`" function. This is nice because:
* We have no more mystery globals floating around.
* We can import files like `rules.js` using node, this lets us unittest them our code without  a browser.