### PR TITLE
Add unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ tokenkeys.py*
 Vagrantfile
 .cache/
 geckodriver.log
+node_modules/
+coverage/

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,13 @@ matrix:
   fast_finish: true
   include:
     - env: INFO="lint"
+      language: node_js
+      node_js:
+        - "node"
+    - env: INFO="unittests"
+      language: node_js
       node_js: node
+        - "node"
     - env: INFO="rules"
     - env: INFO="fetch"
     - env: INFO="preloaded"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [HTTPS Everywhere](https://www.eff.org/https-everywhere) [![Build Status](https://travis-ci.org/EFForg/https-everywhere.svg?branch=master)](https://travis-ci.org/EFForg/https-everywhere)
+[![Coverage Status](https://coveralls.io/repos/github/EFForg/https-everywhere/badge.svg?branch=master)](https://coveralls.io/github/EFForg/https-everywhere?branch=master)
 ================
 
 Getting Started

--- a/chromium/package.json
+++ b/chromium/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "https-everywhere",
+  "version": "1.0.0",
+  "description": "",
+  "main": "utils.js",
+  "dependencies": {},
+  "devDependencies": {
+    "chai": "^4.1.2",
+    "coveralls": "^3.0.0",
+    "mocha": "^4.0.0",
+    "nyc": "^11.2.1"
+  },
+  "scripts": {
+    "test": "mocha",
+    "cover": "nyc --reporter=html --reporter=text mocha",
+    "report": "nyc report --reporter=text-lcov | coveralls"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "GPL-2.0+"
+}

--- a/chromium/rules.js
+++ b/chromium/rules.js
@@ -666,6 +666,11 @@ RuleSets.prototype = {
 
 Object.assign(exports, {
   settings,
+  trivial_rule_to,
+  trivial_rule_from_c,
+  Exclusion,
+  Rule,
+  RuleSet,
   RuleSets
 });
 

--- a/chromium/test/.eslintrc
+++ b/chromium/test/.eslintrc
@@ -1,0 +1,6 @@
+{
+  "env": {
+    "node": true,
+    "mocha": true
+  }
+}

--- a/chromium/test/rules_test.js
+++ b/chromium/test/rules_test.js
@@ -1,0 +1,113 @@
+'use strict'
+
+const assert = require('chai').assert,
+  rules = require('../rules');
+
+const Exclusion = rules.Exclusion,
+  Rule = rules.Rule,
+  RuleSet = rules.RuleSet,
+  RuleSets = rules.RuleSets;
+
+
+describe('rules.js', function() {
+  let test_str = 'test';
+
+  describe('Exclusion', function() {
+    it('constructs', function() {
+      let exclusion = new Exclusion(test_str);
+      assert(exclusion.pattern_c.test(test_str), true);
+    });
+  });
+
+  describe('Rule', function() {
+    it('constructs trivial rule', function() {
+      let rule = new Rule('^http:', 'https:');
+      assert(rule.to, rules.trivial_rule_to);
+      assert(rule.from_c, rules.trivial_rule_from);
+    });
+  });
+
+  describe('RuleSet', function() {
+    beforeEach(function() {
+      this.ruleset = new RuleSet('set_name', true, 'note');
+    });
+
+    describe('#apply', function() {
+      it('excludes excluded uris', function() {
+        this.ruleset.exclusions = [new Exclusion(test_str)];
+        assert.isNull(this.ruleset.apply(test_str));
+      });
+
+      it('rewrites uris', function() {
+        let rule = new Rule('^http:', 'https:');
+        this.ruleset.rules.push(rule);
+        assert(this.ruleset.apply('http://example.com/'), 'https://example.com/');
+      });
+
+      it('does nothing when empty', function() {
+        assert.isNull(this.ruleset.apply('http://example.com/'));
+      });
+    });
+
+    describe('#isEquivalentTo', function() {
+      let inputs = ['a', 'b', 'c'];
+
+      it('not equivalent with different input', function() {
+        let rs = new RuleSet(...inputs);
+        assert.isFalse(
+          rs.isEquivalentTo(new RuleSet('e', 'f', 'g'))
+        );
+      });
+      it('not equivalent with different exclusions', function() {
+        let rs_a = new RuleSet(...inputs),
+          rs_b = new RuleSet(...inputs);
+        rs_a.exclusions = [new Exclusion('foo')];
+        rs_b.exclusions = [new Exclusion('bar')];
+
+        assert.isFalse(rs_a.isEquivalentTo(rs_b));
+      });
+
+      it('not equivalent with different rules', function() {
+        let rs_a = new RuleSet(...inputs),
+          rs_b = new RuleSet(...inputs);
+        rs_a.rules.push(new Rule('a', 'a'));
+        rs_b.rules.push(new Rule('b', 'b'));
+
+        assert.isFalse(rs_a.isEquivalentTo(rs_b));
+      });
+
+      it('equivalent to self', function() {
+        let rs = new RuleSet(...inputs);
+        assert.isTrue(rs.isEquivalentTo(rs));
+      });
+    });
+  })
+
+  describe('RuleSets', function() {
+    describe('#potentiallyApplicableRulesets', function() {
+      let example_host = 'example.com';
+
+      beforeEach(function() {
+        this.rsets = new RuleSets();
+      });
+
+      it('returns nothing when empty', function() {
+        assert.isEmpty(this.rsets.potentiallyApplicableRulesets(example_host));
+      });
+
+      it('returns cached rulesets', function() {
+        this.rsets.ruleCache.set(example_host, 'value');
+        assert(this.rsets.potentiallyApplicableRulesets(example_host), 'value');
+      });
+
+      it('returns applicable rule sets', function() {
+        let target = ['value'];
+        this.rsets.targets.set(example_host, target);
+
+        let result = this.rsets.potentiallyApplicableRulesets(example_host),
+          expected = new Set(target);
+        assert.deepEqual(result, expected);
+      });
+    });
+  });
+})

--- a/chromium/test/testing_utils.js
+++ b/chromium/test/testing_utils.js
@@ -1,0 +1,29 @@
+'use strict'
+
+function Mock() {
+  let out = function() {
+    out.calledWith = Array.from(arguments);
+  }
+  return out;
+}
+
+function stub(name, value) {
+  let parts = name.split('.'),
+    last = parts.pop(),
+    part = global;
+  parts.forEach(partName => {
+    if (!part.hasOwnProperty(partName)) {
+      part[partName] = {};
+    }
+    part = part[partName];
+  });
+  part[last] = value;
+}
+
+function stubber(namesValues) {
+  namesValues.forEach(nameValue => {
+    stub(...nameValue);
+  });
+}
+
+Object.assign(exports, {Mock, stub, stubber});

--- a/run_travis.sh
+++ b/run_travis.sh
@@ -3,15 +3,26 @@ set -x
 toplevel=$(git rev-parse --show-toplevel)
 testdir=${toplevel}/test/selenium
 linter=${toplevel}/utils/eslint/node_modules/.bin/eslint
-linttarget=${toplevel}/chromium
+srcdir=${toplevel}/chromium
 
 
 function run_lint {
-  $linter $linttarget
+  $linter $srcdir
   if [ $? != 0 ]; then
     echo "Linting errors"
     exit 1
   fi
+}
+
+function run_unittests {
+  pushd ${srcdir}
+    npm run cover # run with coverage
+    if [ $? != 0 ]; then
+        echo "unittest errors"
+        exit 1
+    fi
+    npm run report
+  popd
 }
 
 function run_selenium {
@@ -21,6 +32,9 @@ function run_selenium {
 if [ "$INFO" == "lint" ]; then
     echo "running lint tests"
     run_lint
+elif [ "$INFO" == "unittests" ]; then
+    echo "Running unittests"
+    run_unittests
 elif [ "$INFO" == "rules" ] || [ "$INFO" == "fetch" ] || [ "$INFO" == "preloaded" ]; then
     export TEST=${INFO}
     ${toplevel}/test/travis.sh # run old travis tests

--- a/setup_travis.sh
+++ b/setup_travis.sh
@@ -36,6 +36,12 @@ function setup_lint {
   popd
 }
 
+function setup_unittests {
+  pushd ${toplevel}/chromium
+    npm install
+  popd
+}
+
 function setup_docker {
   docker build -t httpse .
 }
@@ -51,6 +57,9 @@ case $INFO in
     ;;
   *lint*)
     setup_lint
+    ;;
+  *unittests*)
+    setup_unittests
     ;;
   *rules*|*fetch*|*preloaded*)
     setup_docker


### PR DESCRIPTION
NB: this depends on #12938 

This lays out the basics for adding unittests for code in `chromium/`.

To run them, cd into the `chromium/`. Run `npm install`. Then run `npm test`.

Todo: put tests in a better place. Hook in to travis.