### PR TITLE
Create Ace-book.net.xml

### DIFF
--- a/src/chrome/content/rules/Ace-book.net.xml
+++ b/src/chrome/content/rules/Ace-book.net.xml
@@ -1,0 +1,9 @@
+<ruleset name="Acebook">
+	<target host="ace-book.net" />
+	<target host="www.ace-book.net" />
+
+	<securecookie host=".+" name=".+" />
+
+	<rule from="^http:"
+			to="https:" />
+</ruleset>


### PR DESCRIPTION
The site has active mixed content blocking caused by http stylesheet requests (eg. on the homepage) however this doesn't interfere with usage of the site or cause any noticeable breakage.