### PR TITLE
Create cubeupload.org.xml

### DIFF
--- a/src/chrome/content/rules/cubeupload.com.xml
+++ b/src/chrome/content/rules/cubeupload.com.xml
@@ -1,0 +1,13 @@
+<!--
+	cubeupload Image Hosting (cubeupload.com)
+	
+-->
+<ruleset name="cubeupload">
+	<target host="cubeupload.com" />
+	<target host="www.cubeupload.com" />
+	<target host="u.cubeupload.com" />
+	<target host="blog.cubeupload.com" />
+	
+	<rule from="^http:"
+		to="https:" />
+</ruleset>


### PR DESCRIPTION
This pull request enforces HTTPS on cubeupload image hosting site ([cubeupload.com](https://cubeupload.com)) and its known subdomains- they are currently using [ISRG Let's Encrypt](https://letsencrypt.org/) as certificate provider.
