### PR TITLE
Re-activating Ask.fm.xml

### DIFF
--- a/src/chrome/content/rules/Ask.fm.xml
+++ b/src/chrome/content/rules/Ask.fm.xml
@@ -1,7 +1,21 @@
+<!--
+	Remark: *.ask.fm have a wildcard DNS Record.
+-->
 <ruleset name="Ask.fm">
 	<target host="ask.fm" />
 	<target host="www.ask.fm" />
+	<target host="about.ask.fm" />
+	<target host="akimg0.ask.fm" />
+	<target host="akimg1.ask.fm" />
+	<target host="akimg2.ask.fm" />
+	<target host="akimg3.ask.fm" />
+	<target host="akimg4.ask.fm" />
+	<target host="l.ask.fm" />
+	<target host="link.ask.fm" />
 	<target host="m.ask.fm" />
+	<target host="safety.ask.fm" />
+	<target host="static.ask.fm" />
+	<target host="support.ask.fm" />
 
 	<securecookie host=".+" name=".+" />
 

--- a/src/chrome/content/rules/Ask.fm.xml
+++ b/src/chrome/content/rules/Ask.fm.xml
@@ -1,10 +1,9 @@
-<!--
-	https://github.com/EFForg/https-everywhere/issues/4660
--->
-<ruleset name="Ask.fm" default_off="webmaster request, http redirect">
+<ruleset name="Ask.fm">
 	<target host="ask.fm" />
 	<target host="www.ask.fm" />
 	<target host="m.ask.fm" />
+
+	<securecookie host=".+" name=".+" />
 
 	<rule from="^http:" to="https:" />
 </ruleset>


### PR DESCRIPTION
Note: Now it does have an HSTS header set to 15768000 but it isn't preloaded thus it's safe to re-activate the ruleset.