### PR TITLE
[BiblioCommons.com] New ruleset

### DIFF
--- a/src/chrome/content/rules/BiblioCommons.com.xml
+++ b/src/chrome/content/rules/BiblioCommons.com.xml
@@ -1,0 +1,26 @@
+<!--
+	Invalid certificate:
+		careers.bibliocommons.com
+
+-->
+<ruleset name="BiblioCommons">
+	<target host="bibliocommons.com" />
+	<target host="*.bibliocommons.com" />
+		<test url="http://austin.bibliocommons.com/" />
+		<test url="http://bpl.bibliocommons.com/" />
+		<test url="http://calgary.bibliocommons.com/" />
+		<test url="http://hpl.bibliocommons.com/" />
+		<test url="http://logan.bibliocommons.com/" />
+		<test url="http://marinet.bibliocommons.com/" />
+		<test url="http://partnerportal.bibliocommons.com/" />
+		<test url="http://portlandlibrary.bibliocommons.com/" />
+		<test url="http://seattle.bibliocommons.com/" />
+		<test url="http://sfpl.bibliocommons.com/" />
+		<test url="http://vpl.bibliocommons.com/" />
+		<exclusion pattern="^http://careers\.bibliocommons\.com" />
+			<test url="http://careers.bibliocommons.com/" />
+
+	<securecookie host=".+" name=".+" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>


### PR DESCRIPTION
BiblioCommons runs the online catalogs for over a hundred public [libraries](https://www.bibliocommons.com/about/libraries/united-states) throughout the US, Canada, Australia and New Zealand.

The catalog subdomains all serve the HSTS header with `max-age=0`.