### PR TITLE
Add 100% unit test coverage for incognito.js

### DIFF
--- a/chromium/background.js
+++ b/chromium/background.js
@@ -4,6 +4,7 @@
 
 const rules = require('./rules'),
   store = require('./store'),
+  incognito = require('./incognito'),
   util = require('./util');
 
 
@@ -13,6 +14,7 @@ async function initialize() {
   await store.initialize();
   await initializeStoredGlobals();
   await all_rules.initialize(store);
+  await incognito.onIncognitoDestruction(destroy_caches);
 
   // Send a message to the embedded webextension bootstrap.js to get settings to import
   chrome.runtime.sendMessage("import-legacy-data", import_settings);
@@ -605,6 +607,17 @@ async function import_settings(settings) {
     await all_rules.initialize(store);
 
   }
+}
+
+/**
+ * Clear any cache/ blacklist we have.
+ */
+function destroy_caches() {
+  util.log(util.DBUG, "Destroying caches.");
+  all_rules.cookieHostCache.clear();
+  all_rules.ruleCache.clear();
+  rules.settings.domainBlacklist.clear();
+  urlBlacklist.clear();
 }
 
 Object.assign(exports, {

--- a/chromium/incognito.js
+++ b/chromium/incognito.js
@@ -2,73 +2,72 @@
 
 (function(exports) {
 
-const util = require('./util'),
-  background = require('./background'),
-  rules = require('./rules');
-
 // This file keeps track of incognito sessions, and clears any caches after
 // an entire incognito session is closed (i.e. all incognito windows are closed).
 
-let incognito_session_exists = false;
+let state = {
+  incognito_session_exists: false,
+};
 
-/**
- * Detect if an incognito session is created, so we can clear caches when it's destroyed.
- *
- * @param window: A standard Window object.
- */
-function detect_incognito_creation(window) {
-  if (window.incognito === true) {
-    incognito_session_exists = true;
+function Incognito(onIncognitoDestruction) {
+  Object.assign(this, {onIncognitoDestruction});
+  // Listen to window creation, so we can detect if an incognito window is created
+  if (chrome.windows) {
+    chrome.windows.onCreated.addListener(this.detect_incognito_creation);
+  }
+
+  // Listen to window destruction, so we can clear caches if all incognito windows are destroyed
+  if (chrome.windows) {
+    chrome.windows.onRemoved.addListener(this.detect_incognito_destruction);
   }
 }
 
-/**
- * Clear any cache/ blacklist we have.
- * Called if an incognito session is destroyed.
- */
-function destroy_caches() {
-  util.log(util.DBUG, "Destroying caches.");
-  background.all_rules.cookieHostCache.clear();
-  background.all_rules.ruleCache.clear();
-  rules.settings.domainBlacklist.clear();
-  background.urlBlacklist.clear();
-}
-
-/**
- * Check if any incognito window still exists. If not, destroy caches.
- * @param arrayOfWindows: A array of all open Window objects.
- */
-function check_for_incognito_session(arrayOfWindows) {
-  for (let window of arrayOfWindows) {
-    if (window.incognito === true) {
-      // An incognito window still exists, so don't destroy caches yet.
-      return;
+Incognito.prototype = {
+  /**
+   * Detect if an incognito session is created, so we can clear caches when it's destroyed.
+   *
+   * @param window: A standard Window object.
+   */
+  detect_incognito_creation: function(window_) {
+    if (window_.incognito === true) {
+      state.incognito_session_exists = true;
     }
-  }
-  // All incognito windows have been closed.
-  incognito_session_exists = false;
-  destroy_caches();
+  },
+
+  // If a window is destroyed, and an incognito session existed, see if it still does.
+  detect_incognito_destruction: async function() {
+    if (state.incognito_session_exists) {
+      if (!(await any_incognito_windows())) {
+        state.incognito_session_exists = false;
+        this.onIncognitoDestruction();
+      }
+    }
+  },
 }
 
-// If a window is destroyed, and an incognito session existed, see if it still does.
-function detect_incognito_destruction() {
-  if (incognito_session_exists) {
-    // Are any current windows incognito?
-    chrome.windows.getAll(check_for_incognito_session);
-  }
+/**
+ * Check if any incognito window still exists
+ */
+function any_incognito_windows() {
+  return new Promise(resolve => {
+    chrome.windows.getAll(arrayOfWindows => {
+      for (let window_ of arrayOfWindows) {
+        if (window_.incognito === true) {
+          return resolve(true);
+        }
+      }
+      resolve(false);
+    });
+  });
 }
 
+function onIncognitoDestruction(callback) {
+  return new Incognito(callback);
+};
 
-// Listen to window creation, so we can detect if an incognito window is created
-if (chrome.windows) {
-  chrome.windows.onCreated.addListener(detect_incognito_creation);
-}
-
-// Listen to window destruction, so we can clear caches if all incognito windows are destroyed
-if (chrome.windows) {
-  chrome.windows.onRemoved.addListener(detect_incognito_destruction);
-}
-
-Object.assign(exports, {});
+Object.assign(exports, {
+  onIncognitoDestruction,
+  state,
+});
 
 })(typeof exports == 'undefined' ? require.scopes.incognito = {} : exports);

--- a/chromium/manifest.json
+++ b/chromium/manifest.json
@@ -12,8 +12,8 @@
             "util.js",
             "rules.js",
             "store.js",
-            "background.js",
-            "incognito.js"
+            "incognito.js",
+            "background.js"
         ]
     },
     "browser_action": {

--- a/chromium/test/incognito_test.js
+++ b/chromium/test/incognito_test.js
@@ -1,0 +1,59 @@
+'use strict'
+
+const expect = require('chai').expect,
+  tu = require('./testing_utils'),
+  incognito = require('../incognito');
+
+describe('incognito.js', function() {
+  beforeEach(function() {
+    tu.stubber([
+      ['chrome.windows.onCreated.addListener', tu.Mock()],
+      ['chrome.windows.onRemoved.addListener', tu.Mock()],
+      ['chrome.windows.getAll', tu.Mock()],
+    ]);
+  });
+
+  describe('onIncognitoDestruction', function() {
+    beforeEach(function() {
+      incognito.state.incognito_session_exists = false;
+      this.callbackCalled = false;
+      this.callback = () => this.callbackCalled = true;
+      this.instance = incognito.onIncognitoDestruction(this.callback);
+    })
+
+    it('no incognito session by default', function() {
+      expect(incognito.state.incognito_session_exists).to.be.false;
+    })
+
+    it('with no incognito, callback not called', async function() {
+      incognito.state.incognito_session_exists = false;
+
+      await this.instance.detect_incognito_destruction();
+
+      expect(this.callbackCalled).to.be.false;
+    });
+
+    it('with incognitos still open, callback not called', async function() {
+      incognito.state.incognito_session_exists = true;
+      chrome.windows.getAll = func => func([{incognito: true}]);
+
+      await this.instance.detect_incognito_destruction();
+
+      expect(this.callbackCalled, 'not called').to.be.false;
+    });
+
+    it('callback called when last incognito closed', async function() {
+      incognito.state.incognito_session_exists = true;
+      chrome.windows.getAll = func => func([]);
+
+      await this.instance.detect_incognito_destruction();
+      expect(incognito.state.incognito_session_exists, 'constant changed').to.be.false;
+      expect(this.callbackCalled).to.be.true;
+    });
+
+    it('detcts when an incognito window is created', function() {
+      this.instance.detect_incognito_creation({incognito: true});
+      expect(incognito.state.incognito_session_exists, 'constant changed').to.be.true;
+    })
+  });
+});

--- a/chromium/test/incognito_test.js
+++ b/chromium/test/incognito_test.js
@@ -51,7 +51,7 @@ describe('incognito.js', function() {
       expect(this.callbackCalled).to.be.true;
     });
 
-    it('detcts when an incognito window is created', function() {
+    it('detects when an incognito window is created', function() {
       this.instance.detect_incognito_creation({incognito: true});
       expect(incognito.state.incognito_session_exists, 'constant changed').to.be.true;
     })


### PR DESCRIPTION
This  makes background.js depend on incognito.js, instead of incognito.js depending on background.js. This lets us test incognito.js, and it makes more sense for background.js to orchestrate imports.

This also adds unit tests that cover incognito.js 100%.