### PR TITLE
Fix rewriter.js and test the API it uses.

### DIFF
--- a/chromium/background.js
+++ b/chromium/background.js
@@ -13,7 +13,7 @@ let all_rules = new rules.RuleSets();
 async function initialize() {
   await store.initialize();
   await initializeStoredGlobals();
-  await all_rules.initialize(store);
+  await all_rules.loadFromBrowserStorage(store);
   await incognito.onIncognitoDestruction(destroy_caches);
 
   // Send a message to the embedded webextension bootstrap.js to get settings to import
@@ -604,7 +604,7 @@ async function import_settings(settings) {
     });
 
     Object.assign(all_rules, new rules.RuleSets());
-    await all_rules.initialize(store);
+    await all_rules.loadFromBrowserStorage(store);
 
   }
 }

--- a/chromium/rules.js
+++ b/chromium/rules.js
@@ -208,7 +208,11 @@ function RuleSets() {
 
 RuleSets.prototype = {
 
-  initialize: async function(store) {
+  /**
+   * Load packaged rulesets, and rulesets in browser storage
+   * @param store object from store.js
+   */
+  loadFromBrowserStorage: async function(store) {
     this.store = store;
     this.ruleActiveStates = store.localStorage;
     this.addFromJson(util.loadExtensionFile('rules/default.rulesets', 'json'));

--- a/chromium/test/rules_test.js
+++ b/chromium/test/rules_test.js
@@ -126,6 +126,10 @@ describe('rules.js', function() {
 
         assert.strictEqual(newuri, 'https://' + host + '/', 'protocol changed to https')
       })
+
+      it('does not rewrite unknown hosts', function() {
+        assert.isNull(this.rsets.rewriteURI('http://unknown.com/', 'unknown.com'));
+      })
     });
 
     describe('#potentiallyApplicableRulesets', function() {

--- a/chromium/test/rules_test.js
+++ b/chromium/test/rules_test.js
@@ -96,7 +96,14 @@ describe('rules.js', function() {
   })
 
   describe('RuleSets', function() {
-    let rules_json = JSON.parse('[{"name":"Freerangekitten.com","rule":[{"to":"https:","from":"^http:"}],"target":["freerangekitten.com","www.freerangekitten.com"]}]');
+    let rules_json = [{
+      name: "Freerangekitten.com",
+      rule: [{
+        to: "https:",
+        from: "^http:"
+      }],
+      target: ["freerangekitten.com", "www.freerangekitten.com"]
+    }];
 
     beforeEach(function() {
       this.rsets = new RuleSets();

--- a/chromium/test/rules_test.js
+++ b/chromium/test/rules_test.js
@@ -96,13 +96,34 @@ describe('rules.js', function() {
   })
 
   describe('RuleSets', function() {
+    let rules_json = JSON.parse('[{"name":"Freerangekitten.com","rule":[{"to":"https:","from":"^http:"}],"target":["freerangekitten.com","www.freerangekitten.com"]}]');
+
+    beforeEach(function() {
+      this.rsets = new RuleSets();
+    });
+
+    describe('#addFromJson', function() {
+      it('can add a rule', function() {
+        this.rsets.addFromJson(rules_json);
+
+        assert.isTrue(this.rsets.targets.has('freerangekitten.com'));
+      });
+    });
+
+    describe('#rewriteURI', function() {
+      it('rewrites host added from json', function() {
+        let host = 'freerangekitten.com';
+        this.rsets.addFromJson(rules_json);
+
+        let newuri = this.rsets.rewriteURI('http://' + host + '/', host);
+
+        assert.strictEqual(newuri, 'https://' + host + '/', 'protocol changed to https')
+      })
+    });
+
     describe('#potentiallyApplicableRulesets', function() {
       let host = 'example.com',
         value = [host];
-
-      beforeEach(function() {
-        this.rsets = new RuleSets();
-      });
 
       it('returns nothing when empty', function() {
         assert.isEmpty(this.rsets.potentiallyApplicableRulesets(host));

--- a/rewriter/rewriter.js
+++ b/rewriter/rewriter.js
@@ -95,9 +95,8 @@ function processFile(filename) {
 function loadRuleSets() {
   console.log("Loading rules...");
   var fileContents = fs.readFileSync(path.join(__dirname, '../pkg/crx/rules/default.rulesets'), 'utf8');
-  var xml = new DOMParser().parseFromString(fileContents, 'text/xml');
   ruleSets = new rules.RuleSets({});
-  ruleSets.addFromXml(xml);
+  ruleSets.addFromJson(JSON.parse(fileContents));
 }
 
 function usage() {


### PR DESCRIPTION
cc @RReverser 

I looked at `rewriter.js`. It was broken :( It happened when the packaged rulesets switched from xml to json in #12273.

I updated `rewriter.js` and did a quick test on a file that just contained `<a href="http://freerangekitten.com/">foo</a>` and it rewrote it as expected.

I also added tests for the API's that rewriter js uses: `addFromJson` (previously `addFromXml`) and `rewriteURI`.