### PR TITLE
Update potentiallyApplicableRulesets and add unittest

### DIFF
--- a/chromium/rules.js
+++ b/chromium/rules.js
@@ -531,8 +531,8 @@ RuleSets.prototype = {
       new Set());
 
     // Ensure host is well-formed (RFC 1035)
-    if (host.length > 255 || host.indexOf("..") != -1) {
-      util.log(util.WARN,"Malformed host passed to potentiallyApplicableRulesets: " + host);
+    if (host.length <= 0 || host.length > 255 || host.indexOf("..") != -1) {
+      util.log(util.WARN, "Malformed host passed to potentiallyApplicableRulesets: " + host);
       return nullIterable;
     }
 

--- a/chromium/test/rules_test.js
+++ b/chromium/test/rules_test.js
@@ -144,6 +144,10 @@ describe('rules.js', function() {
         assert.isEmpty(this.rsets.potentiallyApplicableRulesets('....'));
       });
 
+      it('returns nothing for empty hosts', function() {
+        assert.isEmpty(this.rsets.potentiallyApplicableRulesets(''));
+      });
+
       it('returns cached rulesets', function() {
         this.rsets.ruleCache.set(host, value);
         assert.deepEqual(this.rsets.potentiallyApplicableRulesets(host), value);


### PR DESCRIPTION
@cowlicks @Hainish currently, `potentiallyApplicableRulesets("")` returns `nullIterable`. I guess we can safely introduce this requirement.