### PR TITLE
Fix the bot commenting on edits more than once

### DIFF
--- a/utils/issue-format-bot/test/issueedit-handler-test.js
+++ b/utils/issue-format-bot/test/issueedit-handler-test.js
@@ -5,6 +5,8 @@
 const vows = require('perjury'),
   handlerutil = require('./lib/handlerutil');
 
+// TODO make this test that the bot doesn't post >1 "you fixed it" comments
+
 vows.describe('issue edit handler').addBatch(
   handlerutil.setup('../../lib/issueedit', {
     'and we pass it the context of an issue edit with a null body': handlerutil.nullBody('don\'t see any text'),

--- a/utils/issue-format-bot/test/mocks/context.js
+++ b/utils/issue-format-bot/test/mocks/context.js
@@ -22,6 +22,12 @@ module.exports = {
       github: {
         issues: {
           createComment: sinon.spy(),
+          // TODO actually make this keep track of data
+          getComments: function() {
+            return {
+              data: []
+            };
+          },
           addLabels: sinon.spy(),
           removeLabel: sinon.spy(() => new Promise(noop))
         }


### PR DESCRIPTION
Note: this does the *bare minimum* to make tests pass. This change has no real test coverage, but this bug is causing real pain and I _did_ test it manually in production so it'll have to do for now. At some point I'll send a followup PR adding the missing coverage.

Fixes #12855