### PR TITLE
remove the wildcard entry for openrightsgroup.org

### DIFF
--- a/src/chrome/content/rules/Open_Rights_Group.xml
+++ b/src/chrome/content/rules/Open_Rights_Group.xml
@@ -4,32 +4,23 @@
 		- 451_Unavailable.org.xml
 		- Blocked.org.uk.xml
 
-
-	Insecure cookies are set for these domains:
-
-		- .openrightsgroup.org
+	Widcard matching cannot be used since some subdomains point at third-party services
+	(without matching https certificates) such as news.openrightsgroup.org
 
 -->
 <ruleset name="Open Rights Group.org">
 
 	<target host="openrightsgroup.org" />
-	<target host="*.openrightsgroup.org" />
-
-		<test url="http://bug.openrightsgroup.org/" />
-		<test url="http://cardiff.openrightsgroup.org/" />
-		<test url="http://lists.openrightsgroup.org/" />
-		<test url="http://northeast.openrightsgroup.org/" />
-		<test url="http://scotland.openrightsgroup.org/" />
-		<test url="http://sheffield.openrightsgroup.org/" />
-		<test url="http://widgets.openrightsgroup.org/" />
-		<test url="http://wiki.openrightsgroup.org/" />
-		<test url="http://www.openrightsgroup.org/" />
-		<test url="http://zine.openrightsgroup.org/" />
-
-
-	<!--	Not secured by server:
-					-->
-	<!--securecookie host="^\.openrightsgroup\.org$" name="^PHPSESSID$" /-->
+	<target host="bug.openrightsgroup.org" />
+	<target host="cardiff.openrightsgroup.org" />
+	<target host="lists.openrightsgroup.org" />
+	<target host="northeast.openrightsgroup.org" />
+	<target host="scotland.openrightsgroup.org" />
+	<target host="sheffield.openrightsgroup.org" />
+	<target host="widgets.openrightsgroup.org" />
+	<target host="wiki.openrightsgroup.org" />
+	<target host="www.openrightsgroup.org" />
+	<target host="zine.openrightsgroup.org" />
 
 	<securecookie host=".+" name=".+" />
 

--- a/src/chrome/content/rules/Open_Rights_Group.xml
+++ b/src/chrome/content/rules/Open_Rights_Group.xml
@@ -5,7 +5,7 @@
 		- Blocked.org.uk.xml
 
 	Widcard matching cannot be used since some subdomains point at third-party services
-	(without matching https certificates) such as news.openrightsgroup.org
+	(without matching https certificates) such as news.openrightsgroup.org or gowers.openrightsgroup.org
 
 -->
 <ruleset name="Open Rights Group.org">
@@ -24,8 +24,5 @@
 
 	<securecookie host=".+" name=".+" />
 
-
-	<rule from="^http:"
-		to="https:" />
-
+	<rule from="^http:" to="https:" />
 </ruleset>


### PR DESCRIPTION
The wildcard entry for openrightsgroup.org is effectively breaking the unsubscribe links in some of the mails sent via a third-party service.

(If it were safe, "preload" would have to the openrightsgroup.org Strict-Transport-Security header.)