### PR TITLE
Exclude test directory while generating package

### DIFF
--- a/.build_exclusions
+++ b/.build_exclusions
@@ -18,3 +18,4 @@ webextension/.eslintrc.json
 .eslintignore
 node_modules
 package-lock.json
+test


### PR DESCRIPTION
The 2017.10.30 release includes a test directory which is not used within the extension