### PR TITLE
Add openbudget and news subdomains to City_of_Seattle.gov

### DIFF
--- a/src/chrome/content/rules/City_of_Seattle.xml
+++ b/src/chrome/content/rules/City_of_Seattle.xml
@@ -2,54 +2,22 @@
 Disabled by https-everywhere-checker because:
 Non-2xx HTTP code: http://seattle.gov/ (200) => https://www.seattle.gov/ (303)
 	For other U.S. government coverage, see US-government.xml.
-
-
-	Nonfunctional subdomains:
-
-		- host1		(times out)
-
-
-	Problematic subdomains:
-
-		- ^ *
-		- citylink *
-		- web5		(cert only matches web1)
-
-	* Cert only matches www
-
-
-	Fully covered subdomains:
-
-		- ^		(→ www)
-		- citylink	(→ www)
-		- data
-		- my
-		- wald1
-		- web1
-		- web5		(→ web6)
-		- web6
-		- www
-
 -->
 <ruleset name="City of Seattle (partial)" platform="mixedcontent">
 
 	<target host="seattle.gov" />
-	<target host="*.seattle.gov" />
+	<target host="council.seattle.gov" />
+	<target host="data.seattle.gov" />
+	<target host="my.seattle.gov" />
+	<target host="news.seattle.gov" />
+	<target host="openbudget.seattle.gov" />
+	<target host="performance.seattle.gov" />
+	<target host="web6.seattle.gov" />
+	<target host="web7.seattle.gov" />
+	<target host="www.seattle.gov" />
+	<!-- thescoop.seattle.gov -->
 
+	<rule from="^http:" to="https:" />
 
 	<securecookie host="^.+\.seattle\.gov$" name=".+" />
-
-
-	<rule from="^http://(?:www\.)?seattle\.gov/"
-		to="https://www.seattle.gov/" />
-
-	<rule from="^http://citylink\.seattle\.gov/"
-		to="https://www.seattle.gov/citylink/" />
-
-	<rule from="^http://(data|my|wald1|web1)\.seattle\.gov/"
-		to="https://$1.seattle.gov/" />
-
-	<rule from="^http://web[56]\.seattle\.gov/"
-		to="https://web6.seattle.gov/" />
-
 </ruleset>


### PR DESCRIPTION
Two more sub domains for `seattle.gov`.