### PR TITLE
add rule for ORF.at

### DIFF
--- a/src/chrome/content/rules/ORF.at.xml
+++ b/src/chrome/content/rules/ORF.at.xml
@@ -1,0 +1,253 @@
+<!--
+
+	Non-2xx HTTP code:
+		- anmeldung.orf.at
+		- bachmannpreis.orf.at
+		- bewerbungen.orf.at
+		- burgenland.orf.at
+		- diegrossechance.orf.at
+		- game.orf.at
+		- games.orf.at
+		- hrvati.orf.at
+		- kaernten.orf.at
+		- mallorca.orf.at
+		- noe.orf.at
+		- oekastatic.orf.at
+		- oesterreich.orf.at
+		- ooe.orf.at
+		- salzburg.orf.at
+		- single.orf.at
+		- steiermark.orf.at
+		- tirol.orf.at
+		- volksgruppen.orf.at
+		- vorarlberg.orf.at
+		- voting.orf.at
+		- wien.orf.at
+		
+	Cert expired:
+		- oe3verkehr.orf.at
+
+	Cert mismatch:
+		- burgenlandkalender.orf.at
+		- cluboe3.orf.at
+		- hanoi.orf.at
+		- ipv4.debatte.orf.at
+		- itv.orf.at
+		- langenacht2.orf.at
+		- musikprotokoll.orf.at
+		- newsletter.insider.orf.at
+		- orfdrei.insider.orf.at
+		- pub2.mc.orf.at
+		- radiokulturhaus.orf.at
+		- vorarlberg-sport.orf.at
+		- wahl.orf.at
+		- www.tvthek.orf.at
+
+	Chain issues:
+		- oe1.orf.at
+		- orfeapp6.orf.at
+		- orfeapp66.orf.at
+		- laos.orf.at
+		- roi.orf.at
+		- u19.orf.at
+
+	Redirect to plain:
+		- ^
+		- www
+		- api-stage-tvthek
+		- api-tvthek
+		- averell
+		- backstage
+		- brava
+		- cook
+		- dalton
+		- der
+		- extra
+		- files
+		- files2
+		- fm4
+		- go
+		- insider
+		- iptv
+		- jack
+		- jobs
+		- klimaschutzpreis
+		- m
+		- magazin
+		- mediaresearch
+		- medienforschung
+		- mobil
+		- muttererde
+		- nanga
+		- news
+		- oe3
+		- oe3dabei
+		- onepager
+		- publikumsrat
+		- songcontest
+		- sport
+		- static
+		- static2
+		- suche
+		- tonga
+		- totoya
+		- tv-thek
+		- tvportal
+		- tvthek
+		- video
+		- webport7
+		- werbung
+		- ws3
+		- ws4
+
+	TLS Error:
+		- adfs.orf.at
+		- avedge.orf.at
+		- conedge.orf.at
+		- eas.orf.at
+		- jericho.orf.at
+		- mash.orf.at
+		- members.orf.at
+		- osm.orf.at
+		- yucca.orf.at
+
+-->
+<ruleset name="ORF.at (partial)">
+
+	<target host="access.orf.at" />
+	<target host="appfeeds.orf.at" />
+	<target host="audioapi.orf.at" />
+	<target host="autodiscover.orf.at" />
+	<target host="bernard.orf.at" />
+	<target host="bert.orf.at" />
+	<target host="bianca.orf.at" />
+	<target host="bikini.orf.at" />
+	<target host="bits.orf.at" />
+	<target host="boa.orf.at" />
+	<target host="bolek.orf.at" />
+	<target host="book.orf.at" />
+	<target host="booking.orf.at" />
+	<target host="bpo.orf.at" />
+	<target host="brain.orf.at" />
+	<target host="buergerforumdb.orf.at" />
+	<target host="cloud.orf.at" />
+	<target host="clyde.orf.at" />
+	<target host="content.orf.at" />
+	<target host="crm.orf.at" />
+	<target host="crmtest.orf.at" />
+	<target host="crmweb.orf.at" />
+	<target host="ctest.orf.at" />
+	<target host="dancingstars.orf.at" />
+	<target host="debatte.orf.at" />
+	<target host="dev.orf.at" />
+	<target host="developer.orf.at" />
+	<target host="dialin.orf.at" />
+	<target host="digital.orf.at" />
+	<target host="drei.orf.at" />
+	<target host="echtjetzt.orf.at" />
+	<target host="ecommerce.orf.at" />
+	<target host="emm.orf.at" />
+	<target host="enterprise.orf.at" />
+	<target host="enterpriseweb.orf.at" />
+	<target host="ernie.orf.at" />
+	<target host="extern-marco.orf.at" />
+	<target host="extranet.orf.at" />
+	<target host="extranet1.orf.at" />
+	<target host="extranet2.orf.at" />
+	<target host="ftp-test.orf.at" />
+	<target host="gmfi.orf.at" />
+	<target host="gomera.orf.at" />
+	<target host="gonzales.orf.at" />
+	<target host="gromit.orf.at" />
+	<target host="guns.orf.at" />
+	<target host="gutenmorgen.orf.at" />
+	<target host="harris.orf.at" />
+	<target host="help.orf.at" />
+	<target host="hermes.orf.at" />
+	<target host="ibiza.orf.at" />
+	<target host="insiderservice.orf.at" />
+	<target host="joe.orf.at" />
+	<target host="kundenportal.orf.at" />
+	<target host="langenacht.orf.at" />
+	<target host="lichtinsdunkel.orf.at" />
+	<target host="login.orf.at" />
+	<target host="lolek.orf.at" />
+	<target host="lyncdiscover.orf.at" />
+	<target host="mak.orf.at" />
+	<target host="mantis.orf.at" />
+	<target host="marco.orf.at" />
+	<target host="meet.orf.at" />
+	<target host="mercy.orf.at" />
+	<target host="moskau.orf.at" />
+	<target host="musiclibrary.orf.at" />
+	<target host="musikverlag.orf.at" />
+	<target host="mx.orf.at" />
+	<target host="my.orf.at" />
+	<target host="mykonos.orf.at" />
+	<target host="nachbarinnot.orf.at" />
+	<target host="oe1kalender.orf.at" />
+	<target host="oe3meta.orf.at" />
+	<target host="oe3pinnwand.orf.at" />
+	<target host="okidoki.orf.at" />
+	<target host="our.orf.at" />
+	<target host="pinky.orf.at" />
+	<target host="pipe.orf.at" />
+	<target host="plovdiv.orf.at" />
+	<target host="preview.orf.at" />
+	<target host="prm.orf.at" />
+	<target host="programm.orf.at" />
+	<target host="pumuckl.orf.at" />
+	<target host="pvc.orf.at" />
+	<target host="radiobilder.orf.at" />
+	<target host="religion.orf.at" />
+	<target host="roses.orf.at" />
+	<target host="rso.orf.at" />
+	<target host="rss.orf.at" />
+	<target host="s4bpage.orf.at" />
+	<target host="science.orf.at" />
+	<target host="shop.orf.at" />
+	<target host="sister.orf.at" />
+	<target host="skype.orf.at" />
+	<target host="smartweb.orf.at" />
+	<target host="sms.orf.at" />
+	<target host="speedy.orf.at" />
+	<target host="sts.orf.at" />
+	<target host="thredbo.orf.at" />
+	<target host="tickets.orf.at" />
+	<target host="tobago.orf.at" />
+	<target host="trichter.orf.at" />
+	<target host="trinidad.orf.at" />
+	<target host="tts.orf.at" />
+	<target host="tube.orf.at" />
+	<target host="tubestatic.orf.at" />
+	<target host="tv.orf.at" />
+	<target host="unterwegs.orf.at" />
+	<target host="vote.orf.at" />
+	<target host="vpngate.orf.at" />
+	<target host="vpngate1.orf.at" />
+	<target host="wac.orf.at" />
+	<target host="walk.orf.at" />
+	<target host="wallace.orf.at" />
+	<target host="webim.orf.at" />
+	<target host="webmail.orf.at" />
+	<target host="weboffice.orf.at" />
+	<target host="webport1.orf.at" />
+	<target host="webport6.orf.at" />
+	<target host="werbenmal9.orf.at" />
+	<target host="piwik.werbenmal9.orf.at" />
+	<target host="william.orf.at" />
+	<target host="wilma.orf.at" />
+	<target host="ws.orf.at" />
+	<target host="ws1.orf.at" />
+	<target host="ws10.orf.at" />
+	<target host="ws11.orf.at" />
+	<target host="ws12.orf.at" />
+	<target host="ws2.orf.at" />
+	<target host="ws7.orf.at" />
+	<target host="ws9.orf.at" />
+
+
+	<rule from="^http:"
+		to="https:" />
+
+</ruleset>


### PR DESCRIPTION
Work in Progress,
some "subfolders" of the websites that relink to plain can be secured.
Needs a few more exceptions therefore