### PR TITLE
Revert "[Lemde.fr] Remove default_off (#13318)"

### DIFF
--- a/src/chrome/content/rules/Lemde.fr.xml
+++ b/src/chrome/content/rules/Lemde.fr.xml
@@ -2,14 +2,18 @@
 	For more Le Monde related rules, see LeMonde.fr.xml
 
 	Invalid certificate:
+
+		asset.lemde.fr (www.lemonde.fr and s1.lemde.fr link to //asset.lmde.fr)
+			<test url="http://asset.lemde.fr/data/0.14.2/css/cadre-page.css" />
+
+			see https://github.com/EFForg/https-everywhere/issues/10962
+
 		live.lemde.fr
 			<test url="http://live.lemde.fr/mux.json" />
 
 -->
-<ruleset name="Lemde.fr">
+<ruleset name="Lemde.fr" default_off="other">
 
-	<target host="asset.lemde.fr" />
-		<test url="http://asset.lemde.fr/data/0.14.2/css/cadre-page.css" />
 	<target host="img.lemde.fr" />
 		<test url="http://img.lemde.fr/2017/07/05/0/0/2220/1311/534/0/60/0/8d05901_9403-7gtdra.3xsto9lik9.jpg" />
 	<target host="s1.lemde.fr" />


### PR DESCRIPTION
It was working in https://github.com/EFForg/https-everywhere/pull/13318 so maybe this is just temporary. Maybe we should wait before the release to merge this.