### PR TITLE
Update Ovh.xml

### DIFF
--- a/src/chrome/content/rules/Ovh.xml
+++ b/src/chrome/content/rules/Ovh.xml
@@ -52,6 +52,7 @@
 	<target host="ssl17.ovh.net" />
 	<target host="webanalytics2.ovh.net" />
 	<target host="webmail.ovh.net" />
+	<target host="mail.ovh.net" />
 
 	<target host="ovh.co.uk" />
 	<target host="www.ovh.co.uk" />
@@ -104,7 +105,7 @@
 
 	<securecookie host=".+" name=".+" />
 
-	<rule from="^http://(imp|webmail)\.ovh\.net/" to="https://ssl0.ovh.net/" />
+	<rule from="^http://(imp|webmail)\.ovh\.net/" to="https://mail.ovh.net/" />
 
 	<rule from="^http:" to="https:" />
 


### PR DESCRIPTION
Ovh webmail is now hosted at https://mail.ovh.net now no longer at https://ssl0.ovh.net.

Added mail.ovh.net  and updated the redirect for webmail to the new address of https://mail.ovh.net.