### PR TITLE
Bulk re-enabling of default_off="missing certificate chain" rulesets.

### DIFF
--- a/src/chrome/content/rules/Advconversion.com.xml
+++ b/src/chrome/content/rules/Advconversion.com.xml
@@ -1,14 +1,7 @@
-<!--
-	NB: Server sends no certificate chain, see https://whatsmychaincert.com
+<ruleset name="Advconversion.com">
 
--->
-<ruleset name="advconversion.com" default_off="missing certificate chain">
-
-	<!--	Direct rewrites:
-				-->
 	<target host="advconversion.com" />
 	<target host="www.advconversion.com" />
-
 		<test url="http://www.advconversion.com/ads-conversiontrack/conversion/track.do?type=img&amp;advertiserId=" />
 
 

--- a/src/chrome/content/rules/Andrew_Brookins.com.xml
+++ b/src/chrome/content/rules/Andrew_Brookins.com.xml
@@ -1,11 +1,5 @@
-<!--
-	NB: Server sends no certificate chain, see https://whatsmychaincert.com
+<ruleset name="Andrew Brookins.com">
 
--->
-<ruleset name="Andrew Brookins.com" default_off="missing certificate chain">
-
-	<!--	Direct rewrites:
-				-->
 	<target host="andrewbrookins.com" />
 	<target host="www.andrewbrookins.com" />
 

--- a/src/chrome/content/rules/Ask_the_Builder.com.xml
+++ b/src/chrome/content/rules/Ask_the_Builder.com.xml
@@ -9,10 +9,8 @@
 
 	Problematic hosts in *askthebuilder.com:
 
-		- shop ᶜ
 		- sod1 ˢ
 
-	ᶜ Server sends no certificate chain, see https://whatsmychaincert.com
 	ˢ Self-signed
 
 
@@ -21,14 +19,10 @@
 		- .shop.askthebuilder.com
 
 -->
-<ruleset name="Ask the Builder.com (partial)" default_off="missing certificate chain">
+<ruleset name="Ask the Builder.com (partial)">
 
 	<target host="shop.askthebuilder.com" />
 
-
-	<!--	Not secured by server:
-					-->
-	<!--securecookie host="^\.shop\.askthebuilder\.com$" name="^(?:RECENTLY_VIEWED_PRODUCTS|SHOP_SESSION_TOKEN|fornax_anonymousId)$" /-->
 
 	<securecookie host="^\w" name=".+" />
 	<securecookie host="^\.shop\." name=".+" />

--- a/src/chrome/content/rules/BitVisor.org.xml
+++ b/src/chrome/content/rules/BitVisor.org.xml
@@ -1,19 +1,4 @@
-<!--
-	NB: server sends no certificate chain, see https://whatsmychaincert.com
-
-
-	Mixed content:
-
-		- Bugs, from:
-
-			- www.facebook.com ˢ
-			- b.hatena.ne.jp ˢ
-			- b.st-hatena.com ˢ
-
-	ˢ Secured by us, see https://www.paulirish.com/2010/the-protocol-relative-url/
-
--->
-<ruleset name="BitVisor.org" default_off="missing certificate chain">
+<ruleset name="BitVisor.org">
 
 	<target host="bitvisor.org" />
 	<target host="www.bitvisor.org" />

--- a/src/chrome/content/rules/Blank_Slate.io.xml
+++ b/src/chrome/content/rules/Blank_Slate.io.xml
@@ -1,32 +1,15 @@
 <!--
-	^:  Server sends no certificate chain, see https://whatsmychaincert.com
-	www: Mismatched
 
+	Mismatched hosts in *blankslate.io:
 
-	These altnames don't exist:
-
-		- api.blankslate.io
-
-
-	Insecure cookies are set for these hosts:
-
-		- blankslate.io
+		- www
 
 -->
-<ruleset name="Blank Slate.io" default_off="missing certificate chain">
+<ruleset name="Blank Slate.io">
 
-	<!--	Direct rewrites:
-				-->
 	<target host="blankslate.io" />
-
-	<!--	Complications:
-				-->
 	<target host="www.blankslate.io" />
 
-
-	<!--	Not secured by server:
-					-->
-	<!--securecookie host="^blankslate\.io$" name="^(blankslatefirstime|laravel_session)$" /-->
 
 	<securecookie host="^blankslate\.io$" name=".+" />
 

--- a/src/chrome/content/rules/Clkads.com.xml
+++ b/src/chrome/content/rules/Clkads.com.xml
@@ -1,26 +1,6 @@
-<!--
-	NB: Server sends no certificate chain, see https://whatsmychaincert.com
+<ruleset name="Clkads.com">
 
-
-	Cert only matches ^clkads.com
-
-
-	Mixed content:
-
-		- css from fonts.googleapis.com *
-		- Bug from piwik.cable6.net *
-
-	* Secured by us
-
--->
-<ruleset name="clkads.com" default_off="missing certificate chain">
-
-	<!--	Direct rewrites:
-				-->
 	<target host="clkads.com" />
-
-	<!--	Complications:
-				-->
 	<target host="www.clkads.com" />
 	<target host="clkmon.com" />
 	<target host="www.clkmon.com" />
@@ -28,7 +8,7 @@
 	<target host="www.clkrev.com" />
 
 
-	<rule from="^http://(?:www\.)?clk(?:ads|mon|rev)\.com/"
-		to="https://clkads.com/" />
+	<rule from="^http:"
+		to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Dixcart.xml
+++ b/src/chrome/content/rules/Dixcart.xml
@@ -6,34 +6,13 @@
 
 	ʳ Refused
 
-
-	NB: Server sends no certificate chain, see https://whatsmychaincert.com
-
-
-	Mixed content:
-
-		- Images, on:
-
-			- ^ from $self ˢ
-			- ^ from development.dixcart.com ʳ
-
-		- Bug on ^ from stats.dixcart.com ʳ
-
-	ʳ Unsecurable <= refused
-	ˢ Secured by us
-
 -->
-<ruleset name="Dixcart.com (partial)" default_off="missing certificate chain">
+<ruleset name="Dixcart.com (partial)">
 
 	<target host="dixcart.com" />
 	<target host="www.dixcart.com" />
 
-
-	<!--	Not secured by server:
-					-->
-	<!--securecookie host="^(?:www\.)?dixcart\.com$" name="^ASPSESSIONID[A-Z]{8}$" /-->
-
-	<securecookie host="^\w" name=".+" />
+	<securecookie host=".+" name=".+" />
 
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/Engaging_Networks.net.xml
+++ b/src/chrome/content/rules/Engaging_Networks.net.xml
@@ -1,13 +1,11 @@
 <!--
-	NB: Server sends no certificate chain, see https://whatsmychaincert.com
-
 
 	Other Engaging Networks rulesets:
 
 		- E-activist.com.xml
 
 -->
-<ruleset name="Engaging Networks.net" default_off="missing certificate chain">
+<ruleset name="Engaging Networks.net">
 
 	<target host="engagingnetworks.net" />
 	<target host="www.engagingnetworks.net" />

--- a/src/chrome/content/rules/Flownative.com.xml
+++ b/src/chrome/content/rules/Flownative.com.xml
@@ -1,11 +1,5 @@
-<!--
-	NB: Server sends no certificate chain, see https://whatsmychaincert.com
+<ruleset name="Flownative.com">
 
--->
-<ruleset name="Flownative.com" default_off="missing certificate chain">
-
-	<!--	Direct rewrites:
-				-->
 	<target host="flownative.com" />
 	<target host="www.flownative.com" />
 

--- a/src/chrome/content/rules/Global_Network_Initiative.org.xml
+++ b/src/chrome/content/rules/Global_Network_Initiative.org.xml
@@ -1,13 +1,5 @@
-<!--
-	Server sends no certificate chain *
+<ruleset name="Global Network Initiative.org">
 
-	* See https://whatsmychaincert.com
-
--->
-<ruleset name="Global Network Initiative.org" default_off="missing certificate chain">
-
-	<!--	Direct rewrites:
-				-->
 	<target host="globalnetworkinitiative.org" />
 	<target host="www.globalnetworkinitiative.org" />
 

--- a/src/chrome/content/rules/HKGov-AFCD.xml
+++ b/src/chrome/content/rules/HKGov-AFCD.xml
@@ -1,12 +1,15 @@
 <!--
 	For other HK government coverage, see GovHK.xml.
 -->
-<ruleset name="Agriculture, Fisheries and Conservation Department" default_off="missing certificate chain">
+<ruleset name="Agriculture, Fisheries and Conservation Department">
 
 	<target host="www.afcd.gov.hk" />
 	<target host="afcd.gov.hk" />
 
-	<rule from="^http://(?:www\.)?afcd\.gov\.hk/"
-	to="https://www.afcd.gov.hk/" />
+	<rule from="^http://afcd\.gov\.hk/"
+		to="https://www.afcd.gov.hk/" />
+
+	<rule from="^http:"
+		to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Immunityinc.com.xml
+++ b/src/chrome/content/rules/Immunityinc.com.xml
@@ -1,6 +1,4 @@
 <!--
-	NB: Server sends no certificate chain, see https://whatsmychaincert.com
-
 
 	Mixed content:
 
@@ -11,7 +9,7 @@
 	² Unsecurable <= 404
 
 -->
-<ruleset name="Immunityinc.com" default_off="missing certificate chain">
+<ruleset name="Immunityinc.com">
 
 	<target host="immunityinc.com" />
 	<target host="lists.immunityinc.com" />

--- a/src/chrome/content/rules/Islenzka.net.xml
+++ b/src/chrome/content/rules/Islenzka.net.xml
@@ -1,13 +1,5 @@
-<!--
-	Server sends no certificate chain *
+<ruleset name="Islenzka.net">
 
-	* See https://whatsmychaincert.com
-
--->
-<ruleset name="Islenzka.net" default_off="missing certificate chain">
-
-	<!--	Direct rewrites:
-				-->
 	<target host="islenzka.net" />
 	<target host="www.islenzka.net" />
 

--- a/src/chrome/content/rules/London_Sock_Company.com.xml
+++ b/src/chrome/content/rules/London_Sock_Company.com.xml
@@ -1,26 +1,7 @@
-<!--
-	Problematic hosts in *londonsockcompany.com:
+<ruleset name="London Sock Company.com">
 
-		- ^ ¹
-		- www ²
-
-	¹ Refused
-	² Server sends no certificate chain, see https://whatsmychaincert.com
-
--->
-<ruleset name="London Sock Company.com" default_off="missing certificate chain">
-
-	<!--	Direct rewrites:
-				-->
-	<target host="www.londonsockcompany.com" />
-
-	<!--	Complications:
-				-->
 	<target host="londonsockcompany.com" />
-
-
-	<rule from="^http://londonsockcompany\.com/"
-		to="https://www.londonsockcompany.com/" />
+	<target host="www.londonsockcompany.com" />
 
 	<rule from="^http:"
 		to="https:" />

--- a/src/chrome/content/rules/Oberheide.org.xml
+++ b/src/chrome/content/rules/Oberheide.org.xml
@@ -1,11 +1,13 @@
 <!--
-	Server sends no certificate chain *
 
-	* See https://whatsmychaincert.com
+	Refused hosts in *oberheide.org:
+
+		- ^
 
 -->
-<ruleset name="Oberheide.org" default_off="missing certificate chain">
+<ruleset name="Oberheide.org">
 
+	<target host="www.oberheide.org" />
 	<target host="jon.oberheide.org" />
 
 

--- a/src/chrome/content/rules/Pilgrimage_Software.com.xml
+++ b/src/chrome/content/rules/Pilgrimage_Software.com.xml
@@ -1,13 +1,5 @@
-<!--
-	Server sends no certificate chain *
+<ruleset name="Pilgrimage Software.com">
 
-	* See https://whatsmychaincert.com
-
--->
-<ruleset name="Pilgrimage Software.com" default_off="missing certificate chain">
-
-	<!--	Direct rewrites:
-				-->
 	<target host="pilgrimagesoftware.com" />
 	<target host="www.pilgrimagesoftware.com" />
 

--- a/src/chrome/content/rules/Renovation_Experts.xml
+++ b/src/chrome/content/rules/Renovation_Experts.xml
@@ -25,18 +25,11 @@
 			- (www.)? from fetchback.com
 
 -->
-<ruleset name="RenovationExperts.com" default_off="missing certificate chain">
+<ruleset name="RenovationExperts.com">
 
-	<!--	Direct rewrites:
-				-->
 	<target host="renovationexperts.com" />
 	<target host="www.renovationexperts.com" />
 
-
-	<!--	Not secured by server:
-					-->
-	<!--securecookie host="^(?:www\.)?renovationexperts\.com$" name="^ASPSESSIONID[A-Z]{8}$" /-->
-	<!--securecookie host="^\.renovationexperts\.com$" name="^__qca$" /-->
 
 	<securecookie host=".+" name=".+" />
 

--- a/src/chrome/content/rules/Scalability.org.xml
+++ b/src/chrome/content/rules/Scalability.org.xml
@@ -1,26 +1,11 @@
-<!--
-	www.scalability.org: Mismatched
+<ruleset name="Scalability.org">
 
-
-	NB: Server sends no certificate chain, see https://whatsmychaincert.com
-
--->
-<ruleset name="Scalability.org" default_off="missing certificate chain">
-
-	<!--	Direct rewrites:
-				-->
 	<target host="scalability.org" />
-
-	<!--	Complications:
-				-->
 	<target host="www.scalability.org" />
 
 
-	<securecookie host="^\w" name=".+" />
+	<securecookie host=".+" name=".+" />
 
-
-	<rule from="^http://www\.scalability\.org/"
-		to="https://scalability.org/" />
 
 	<rule from="^http:"
 		to="https:" />

--- a/src/chrome/content/rules/ScanMyServer.com.xml
+++ b/src/chrome/content/rules/ScanMyServer.com.xml
@@ -1,27 +1,11 @@
 <!--
 	For other Beyond Security coverage, see Beyond-Security.xml.
-
-
-	NB: Server sends no certificate chain, see https://whatsmychaincert.com
-
-
-	Insecure cookies are set for these hosts:
-
-		- scanmyserver.com
-		- www.scanmyserver.com
-
 -->
-<ruleset name="ScanMyServer.com" default_off="missing certificate chain">
+<ruleset name="ScanMyServer.com">
 
-	<!--	Direct rewrites:
-				-->
 	<target host="scanmyserver.com" />
 	<target host="www.scanmyserver.com" />
 
-
-	<!--	Not secured by server:
-					-->
-	<!--securecookie host="^(?:www\.)?scanmyserver\.com$" name="^CGISESSID$" /-->
 
 	<securecookie host=".+" name=".+" />
 

--- a/src/chrome/content/rules/Srdrvp.com.xml
+++ b/src/chrome/content/rules/Srdrvp.com.xml
@@ -1,11 +1,5 @@
-<!--
-	NB: Server sends no certificate chain, see https://whatsmychaincert.com
+<ruleset name="srdrvp.com">
 
--->
-<ruleset name="srdrvp.com" default_off="missing certificate chain">
-
-	<!--	Direct rewrites:
-				-->
 	<target host="srdrvp.com" />
 	<target host="www.srdrvp.com" />
 

--- a/src/chrome/content/rules/SuperAntiSpyware.xml
+++ b/src/chrome/content/rules/SuperAntiSpyware.xml
@@ -1,12 +1,6 @@
-<!--
-	Server sends no certificate chain *
+<ruleset name="SuperAntiSpyware.com">
+	<target host="superantispyware.com" />
+	<target host="www.superantispyware.com" />
 
-	* See https://whatsmychaincert.com
-
--->
-<ruleset name="SuperAntiSpyware.com" platform="mixedcontent" default_off="missing certificate chain">
-  <target host="www.superantispyware.com" />
-  <target host="superantispyware.com" />
-
-  <rule from="^http://(?:www\.)?superantispyware\.com/" to="https://www.superantispyware.com/"/>
+	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Tb.cn.xml
+++ b/src/chrome/content/rules/Tb.cn.xml
@@ -1,16 +1,8 @@
 <!--
 	For other Alibaba Group coverage, see Alibaba.xml.
-
-
-	^tb.cn: Server sends no certificate chain *
-
-	* See https://whatsmychaincert.com
-
 -->
-<ruleset name="Tb.cn" default_off="missing certificate chain">
+<ruleset name="Tb.cn">
 
-	<!--	Direct rewrites:
-				-->
 	<target host="tb.cn" />
 
 

--- a/src/chrome/content/rules/US_Pirates.org.xml
+++ b/src/chrome/content/rules/US_Pirates.org.xml
@@ -1,19 +1,13 @@
 <!--
 	For other Pirate Party coverage, see PirateParty.xml.
-
-
-	Server sends no certificate chain *
-
-	* See https://whatsmychaincert.com
-
 -->
-<ruleset name="US Pirates.org" default_off="missing certificate chain">
+<ruleset name="US Pirates.org">
 
 	<target host="uspirates.org" />
 	<target host="www.uspirates.org" />
 
 
-	<securecookie host=".+\.uspirates\.org$" name=".+" />
+	<securecookie host=".+" name=".+" />
 
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/Waag.org.xml
+++ b/src/chrome/content/rules/Waag.org.xml
@@ -1,18 +1,5 @@
-<!--
-	Server sends no certificate chain *
+<ruleset name="Waag.org">
 
-	* See https://whatsmychaincert.com
-
-
-	Mixed content:
-
-		- Images from ^waag.org
-
--->
-<ruleset name="Waag.org" default_off="missing certificate chain">
-
-	<!--	Direct rewrites:
-				-->
 	<target host="waag.org" />
 	<target host="www.waag.org" />
 

--- a/src/chrome/content/rules/Webthumbnail.org.xml
+++ b/src/chrome/content/rules/Webthumbnail.org.xml
@@ -1,13 +1,5 @@
-<!--
-	Server sends no certificate chain *
+<ruleset name="Webthumbnail.org">
 
-	* See https://whatsmychaincert.com
-
--->
-<ruleset name="Webthumbnail.org" default_off="missing certificate chain">
-
-	<!--	Direct rewrites:
-				-->
 	<target host="webthumbnail.org" />
 	<target host="www.webthumbnail.org" />
 

--- a/src/chrome/content/rules/YorkNY.xml
+++ b/src/chrome/content/rules/YorkNY.xml
@@ -1,16 +1,8 @@
-<!--
-	City University of New York
+<ruleset name="York College of New York">
 
+	<target host="york.cuny.edu" />
+	<target host="www.york.cuny.edu" />
 
-	(www.)?: Server sends no certificate chain *
+	<rule from="^http:" to="https:" />
 
-	* See https://whatsmychaincert.com
-
--->
-<ruleset name="York College of New York" default_off="missing certificate chain">
-
-  <target host="www.york.cuny.edu" />
-  <target host="york.cuny.edu" />
-
-  <rule from="^http:" to="https:"/>
 </ruleset>

--- a/src/chrome/content/rules/andrewmohawk.com.xml
+++ b/src/chrome/content/rules/andrewmohawk.com.xml
@@ -1,26 +1,10 @@
-<!--
-	NB: Server sends no certificate chain, see https://whatsmychaincert.com
-
-
-	Mixed content:
-
-		- iframes, from:
-
-			- player.vimeo.com ˢ
-			- www.youtube.com ˢ
-
-		- Images from $self ˢ
-
-	ˢ Secured by us, see https://www.paulirish.com/2010/the-protocol-relative-url/
-
--->
-<ruleset name="AndrewMohawk.com" default_off="missing certificate chain">
+<ruleset name="andrewmohawk.com">
 
 	<target host="andrewmohawk.com" />
 	<target host="www.andrewmohawk.com" />
 
 
-	<securecookie host="^\w" name=".+" />
+	<securecookie host=".+" name=".+" />
 
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/jewishvirtuallibrary.org.xml
+++ b/src/chrome/content/rules/jewishvirtuallibrary.org.xml
@@ -1,8 +1,4 @@
-<!--
-	NB: Server sends no certificate chain, see https://whatsmychaincert.com
-
--->
-<ruleset name="Jewish Virtual Library.org" default_off="missing certificate chain">
+<ruleset name="Jewish Virtual Library.org">
 
 	<target host="jewishvirtuallibrary.org" />
 	<target host="www.jewishvirtuallibrary.org" />

--- a/src/chrome/content/rules/link-page.info.xml
+++ b/src/chrome/content/rules/link-page.info.xml
@@ -1,8 +1,4 @@
-<!--
-	NB: Server sends no certificate chain, see https://whatsmychaincert.com
-
--->
-<ruleset name="link-page.info" default_off="missing certificate chain">
+<ruleset name="link-page.info">
 
 	<target host="link-page.info" />
 	<target host="www.link-page.info" />
@@ -12,7 +8,7 @@
 		<test url="http://link-page.info/event_tracking_1.png" />
 
 
-	<securecookie host="^\w" name=".+" />
+	<securecookie host=".+" name=".+" />
 
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/ox4.li.xml
+++ b/src/chrome/content/rules/ox4.li.xml
@@ -1,18 +1,9 @@
-<!--
-	NB: Server sends no certificate chain, see https://whatsmychaincert.com
-
-
-	These altnames do not exist:
-
-		- www.ox4.li
-
--->
-<ruleset name="OX4.li" default_off="missing certificate chain">
+<ruleset name="OX4.li">
 
 	<target host="ox4.li" />
 
 
-	<securecookie host="^\w" name=".+" />
+	<securecookie host=".+" name=".+" />
 
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/rbwmcarshare.co.uk.xml
+++ b/src/chrome/content/rules/rbwmcarshare.co.uk.xml
@@ -1,8 +1,4 @@
-<!--
-	NB: Server sends no certificate chain, see https://whatsmychaincert.com
-
--->
-<ruleset name="RBWM Car Share.co.uk" default_off="missing certificate chain">
+<ruleset name="RBWM Car Share.co.uk">
 
 	<target host="rbwmcarshare.co.uk" />
 	<target host="www.rbwmcarshare.co.uk" />

--- a/src/chrome/content/rules/xrllc.com.xml
+++ b/src/chrome/content/rules/xrllc.com.xml
@@ -1,17 +1,9 @@
-<!--
-	Problematic hosts in *xrllc.com:
-
-		- marketing ᶜ
-
-	ᶜ Server sends no certificate chain, see https://whatsmychaincert.com
-
--->
-<ruleset name="XR LLC.com" default_off="missing certificate chain">
+<ruleset name="XR LLC.com">
 
 	<target host="marketing.xrllc.com" />
 
 
-	<securecookie host="^\w" name=".+" />
+	<securecookie host=".+" name=".+" />
 
 
 	<rule from="^http:"


### PR DESCRIPTION
This PR re-enables all the rulesets from #13290 which require either only minimal simplification or straight re-enabling.