### PR TITLE
Fix path to .eslintignore in build exclusions

### DIFF
--- a/.build_exclusions
+++ b/.build_exclusions
@@ -15,4 +15,4 @@ chrome-resources/update-from-chrome-svn.sh
 webextension/chrome-resources/update-from-chrome-svn.sh
 .eslintrc.json
 webextension/.eslintrc.json
-chromium/.eslintignore
+.eslintignore


### PR DESCRIPTION
`.eslintignore` is added to the packaged extension (see [here](https://github.com/EFForg/https-everywhere/pull/13693/files#diff-ac9aed2a391263bbc3c8236f8e674155R3)). It was added to `build_exclusions` in #13560 but it looks like the path was wrong.

@Hainish @jeremyn 