### PR TITLE
Remove unused python libraries

### DIFF
--- a/test/rules/setup.py
+++ b/test/rules/setup.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python
 
-import os
-import sys
-
-
 from setuptools import setup, find_packages
 
 readme = open('README.rst').read()

--- a/test/rules/src/https_everywhere_checker/check_rules.py
+++ b/test/rules/src/https_everywhere_checker/check_rules.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import binascii
-import collections
 import argparse
 import json
 import glob

--- a/test/rules/src/https_everywhere_checker/http_client.py
+++ b/test/rules/src/https_everywhere_checker/http_client.py
@@ -1,10 +1,8 @@
-import os
 import sys
 import logging
 import pycurl
 import urlparse
 import cStringIO
-import regex
 import cPickle
 import tempfile
 import traceback

--- a/test/selenium/test_options.py
+++ b/test/selenium/test_options.py
@@ -1,5 +1,4 @@
 from util import ExtensionTestCase
-from time import sleep
 
 class OptionsTest(ExtensionTestCase):
     def load_options(self):

--- a/utils/check_certs.py
+++ b/utils/check_certs.py
@@ -3,7 +3,6 @@
 import sys
 import re
 from subprocess import Popen, PIPE
-from glob import glob
 
 host_targets = re.compile(r'<target *host="([a-z0-9\-\*\.]+)"')
 wget_cmd = lambda h : ["wget", "-O", "/dev/null", "https://" + h]

--- a/utils/create_xpi.py
+++ b/utils/create_xpi.py
@@ -10,7 +10,6 @@ Usage: python create_xpi.py -x <exclusions> -n <name of zipped file> <directory>
 import argparse
 import glob
 import os
-import sys
 import zipfile_deterministic as zipfile
 
 parser = argparse.ArgumentParser(

--- a/utils/merge-rulesets.py
+++ b/utils/merge-rulesets.py
@@ -11,8 +11,6 @@ import argparse
 import glob
 import json
 import os
-import subprocess
-import sys
 import unicodedata
 import xml.etree.ElementTree
 

--- a/utils/single_rule_response.py
+++ b/utils/single_rule_response.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python2.7
 
-import sys, os, re
+import sys
+import re
 from functools import partial
 
 try:

--- a/utils/test-generator.py
+++ b/utils/test-generator.py
@@ -27,7 +27,6 @@ python2.7 https-everywhere-checker/src/https_everywhere_checker/check_rules.py \
 """
 
 import exrex
-import lxml
 from lxml import etree
 import sys
 

--- a/utils/trivial-response.py
+++ b/utils/trivial-response.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python2.7
 
-import sys, os, re, subprocess
+import sys
+import os
+import subprocess
 from time import sleep
 
 try:


### PR DESCRIPTION
Found by using pyflakes (https://launchpad.net/pyflakes)
Run `pyflakes .` in project root

@Hainish 

The new [Github security alerts](https://github.com/blog/2470-introducing-security-alerts-on-github) may be really useful to ensure optimal security while using external dependencies but we need to make sure that the list is up-to-date.

(Note that Github can't track python libraries yet but they make it sound like it's in the works.)