### PR TITLE
NetCologne:

### DIFF
--- a/src/chrome/content/rules/NetCologne.xml
+++ b/src/chrome/content/rules/NetCologne.xml
@@ -1,60 +1,103 @@
-
-<!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://webtv.netcologne.de/ => https://webtv.netcologne.de/: (6, 'Could not resolve host: webtv.netcologne.de')
-
-	NetCologne Gesellschaft für Telekommunikation mbH
+<!--NetCologne Gesellschaft für Telekommunikation mbH
 
 	Other NetCologne rulesets:
 
 		- DotCologne.de.xml
 
-	Insecure cookies are set for these hosts:
+	Cert expired:
+		- gk-shop
+		- hosting
 
-		- tracking.netcologne.de
+	Cert mismatch:
+		- ifr
+		- mg
+		- microsoft-hosting
+		- mirror2
+		- navigator
+		- partner
+		- prtg
+		- reg
+		- report
+		- vcp
+		- webcam
+		- webcluster01
+
+	Chain issues:
+		- cpbxlogin
+		- in-service
+		- ntmail
+		- owa
+		- sso-test
+		- vsm
+
+	Self-signed cert:
+		- cftp
+		- kftp
+		
+	Timeout:
+		- netty
+		- speedtest
+		- plg
+		- merkur
+		- websitemakertest
+		- news
+		- sitestest[1-3]
+
+	TLS error:
+		- deny
 
 -->
-<ruleset name="NetCologne.de (partial)" default_off='failed ruleset test'>
+<ruleset name="NetCologne.de (partial)">
 
 	<!--	Direct rewrites:
 				-->
-	<target host="aktion.netcologne.de"/>
-	<target host="comcenter.netcologne.de"/>
-	<target host="debian.netcologne.de"/>
-	<target host="mirror.netcologne.de"/>
-	<target host="mobilshop.netcologne.de"/>
-	<target host="musicbox.netcologne.de"/>
-	<target host="netcologne.de"/>
-	<target host="netkompakt-fuer-mitarbeiter.netcologne.de"/>
-	<target host="onlineservice.netcologne.de"/>
-	<target host="planauskunft.netcologne.de"/>
-	<target host="shop.netcologne.de"/>
-	<target host="statistik.netcologne.de"/>
-	<target host="tracking.netcologne.de"/>
-	<target host="webtv.netcologne.de"/>
-	<target host="www.netcologne.de"/>
+	<target host="netcologne.de" />
+	<target host="www.netcologne.de" />
 
-	<!--
-	timed out:
-	netty.netcologne.de
-	speedtest.netcologne.de
-	plg.netcologne.de
-	merkur.netcologne.de
-	websitemakertest.netcologne.de
-	news.netcologne.de
-	sitestest[1-3].netcologne.de
+	<target host="aktion.netcologne.de" />
+	<target host="comcenter.netcologne.de" />
+	<target host="comcenter-test.netcologne.de" />
+	<target host="cpbxhilfe.netcologne.de" />
+	<target host="cpbxkalkulator.netcologne.de" />
+	<target host="cpbxshop.netcologne.de" />
+	<target host="fileservice.cnsrv.netcologne.de" />
+	<target host="debian.netcologne.de" />
+	<target host="einstellungen.netcologne.de" />
+	<target host="fb.netcologne.de" />
+	<target host="fcadmin.netcologne.de" />
+	<target host="fcdb.netcologne.de" />
+	<target host="fcdevadmin.netcologne.de" />
+	<target host="hilfe.netcologne.de" />
+	<target host="livechat.netcologne.de" />
+	<target host="mirror.netcologne.de" />
+	<target host="mobilshop.netcologne.de" />
+	<target host="musicbox.netcologne.de" />
+	<target host="netkompakt-fuer-mitarbeiter.netcologne.de" />
+	<target host="netkompakt.netcologne.de" />
+	<target host="nettv.netcologne.de" />
+	<target host="onlineservice.netcologne.de" />
+	<target host="planauskunft.netcologne.de" />
+	<target host="webmail.schulen.netcologne.de" />
+	<target host="secure.netcologne.de" />
+	<target host="shop.netcologne.de" />
+	<target host="sourceforge.netcologne.de" />
+	<target host="sso.netcologne.de" />
+	<target host="statistik.netcologne.de" />
+	<target host="view.netcologne.de" />
+	<target host="vpnj-fttb.netcologne.de" />
+	<target host="vpnj-nmc.netcologne.de" />
+	<target host="vpnj-saprov.netcologne.de" />
+	<target host="vpnjb-pg-iv.netcologne.de" />
+	<target host="vpnjb-pg-office.netcologne.de" />
+	<target host="wartung.netcologne.de" />
+	<target host="webmanager-cp.netcologne.de" />
+	<target host="webshop.netcologne.de" />
+	<target host="websitemaker.netcologne.de" />
+	<target host="wgc.netcologne.de" />
+	<target host="wwwftp.netcologne.de" />
+	<target host="wwwstaging.netcologne.de" />
 
-	Mismatch:
-	mg.netcologne.de
-	netkompakt.netcologne.de
-	  -->
-
-	<!--	Not secured by server:
-					-->
-	<!--securecookie host="^tracking\.netcologne\.de$" name="^wt[es]id_\d+$" /-->
-
-	<securecookie host="^tracking\.netcologne\.de$" name=".+" />
-
+	<securecookie host=".+" name=".+" />
 
 	<rule from="^http:"
 		to="https:" />


### PR DESCRIPTION
- check subdomains and re-enable the ruleset

Webtv is called nettv now so we can enable the ruleset again