### PR TITLE
 Add Travis test for obsolete ruleset references 

### DIFF
--- a/test/travis.sh
+++ b/test/travis.sh
@@ -39,6 +39,7 @@ set -e
 if [ "$TEST" == "rules" ]; then
   echo >&2 "Performing comprehensive coverage test."
   docker run --rm -ti -v $(pwd):/opt httpse python utils/ruleset_filenames_validate.py
+  docker run --rm -ti -v $(pwd):/opt httpse bash -c "utils/remove-obsolete-references.sh"
   docker run --rm -ti -v $(pwd):/opt httpse bash -c "utils/validate.sh"
   docker run --rm -ti -v $(pwd):/opt httpse bash -c "test/rules.sh"
   docker run --rm -ti -v $(pwd):/opt node bash -c "cd /opt && node utils/normalize-securecookie.js"

--- a/utils/remove-obsolete-references.sh
+++ b/utils/remove-obsolete-references.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Remove obsolete references to child rulesets which
+# has been renamed/ deleted
+
+
+# Change directory to git root; taken from ../test/test.sh
+if [ -n "$GIT_DIR" ]
+then
+    # $GIT_DIR is set, so we're running as a hook.
+    cd $GIT_DIR
+else
+    # Git command exists? Cool, let's CD to the right place.
+    git rev-parse && cd "$(git rev-parse --show-toplevel)"
+fi
+
+# Run from ruleset folder to simplify the output
+cd src/chrome/content/rules
+
+# Default exit status
+EXIT_CODE=0
+
+# List of file(s) which contain at least one reference
+FILES=`egrep -l '^\s*[-|+]\s*([^ ]*\.xml)\s*$' *.xml`
+
+while read FILE; do
+    # List of referenced rulesets
+    REFS=`sed -n 's/^\s*[-|+]\s*\([^ ]*\.xml\)\s*$/\1/gp' "$FILE"`
+    
+    while read REF; do
+        if [ ! -f "$REF" ]; then
+            echo >&2 "ERROR src/chrome/content/rules/$FILE: Dangling reference to $REF"
+            sed -i "/^\s*[-|+]\s*$REF$/d" "$FILE"
+            EXIT_CODE=1
+        fi
+    done <<< "$REFS"
+done <<< "$FILES"
+
+# Exit with errors, if any
+exit "$EXIT_CODE"


### PR DESCRIPTION
Failing Travis is expected, blocked by #13657. This will help to keep the ruleset references up-to-date when we have some bulk ruleset updates, e.g. when running `hsts-prune` etc. The effort required by contributors should be minimal in each PR as they are only responsible for ruleset they have changed.

ping @Hainish @cowlicks @J0WI @jeremyn for opinions and reviews. Thanks!!

EDIT: ~It seem that when the script is ran in debug mode, the output doesn't fit Travis console....~

Where to `chmod +x` ???