### PR TITLE
Update AliExpress.com.xml

### DIFF
--- a/src/chrome/content/rules/AliExpress.com.xml
+++ b/src/chrome/content/rules/AliExpress.com.xml
@@ -7,6 +7,7 @@
 	Nonfunctional hosts in *aliexpress.com:
 
 		- bbs.seller ¹
+		- escrow
 
 	¹ Dropped
 
@@ -20,7 +21,6 @@
 		- collections ˣ
 		- daxue ˣ
 		- es ᵐ ˣ
-		- escrow ˣ
 		- fulfillment ˣ
 		- fuwu ˣ
 		- gaga ˣ
@@ -66,7 +66,7 @@
 		- css, on:
 
 			- activities, collections, daxue, es, fuwu, gaga, group, hz, id, it, mai, open, page, pl, superdeals, th from style.aliunicorn.com ˢ
-			- escrow, fulfillment from style.alibaba.com ˢ
+			- fulfillment from style.alibaba.com ˢ
 			- gw.api from style.c.aliimg.com ˢ
 			- mai img.alibaba.com ˢ
 			- sale from i0\d.i.aliimg.com ˢ
@@ -74,13 +74,13 @@
 		- Images, on:
 
 			- activities, gw.api, ar, de, es, group, he, id, ja, ko, mai, nl, pl, pt, ru, tr, vi from img.alibaba.com ˢ
-			- activities, escrow, fulfillment, gaga, seller from i0\d.i.aliimg.com ˢ
+			- activities, fulfillment, gaga, seller from i0\d.i.aliimg.com ˢ
 			- activities from style.aliunicorn.com ˢ
 			- ar, best, brands, de, coupon, group, hz, it, ja, ko, nl, page, pl, ru, sale, th, tr, vi from g0\d.a.alicdn.com ˢ
-			- escrow, fulfillment, hz from img.alibaba.com ˢ
+			- fulfillment, hz from img.alibaba.com ˢ
 			- university from gtms04.alicdn.com ˢ
 
-		- Bug on activities, collections, coupon, daxue, de, es, escrow, fr, fulfillment, fuwu, gaga, group, he, id, it, ja, ko, mai, nl, open, page, pl, pt, ru, seller, superdeals, th, tr, trade, university, vi from dmtracking2.alibaba.com ˢ
+		- Bug on activities, collections, coupon, daxue, de, es, fr, fulfillment, fuwu, gaga, group, he, id, it, ja, ko, mai, nl, open, page, pl, pt, ru, seller, superdeals, th, tr, trade, university, vi from dmtracking2.alibaba.com ˢ
 
 	ˢ Secured by us, see https://www.paulirish.com/2010/the-protocol-relative-url/
 
@@ -99,7 +99,6 @@
 	<target host="coupon.aliexpress.com" />
 	<!--target host="daxue.aliexpress.com" /-->
 	<target host="de.aliexpress.com" />
-	<target host="escrow.aliexpress.com" />
 	<target host="fr.aliexpress.com" />
 	<!--target host="fulfillment.aliexpress.com" /-->
 	<!--target host="fuwu.aliexpress.com" /-->

--- a/src/chrome/content/rules/AliExpress.com.xml
+++ b/src/chrome/content/rules/AliExpress.com.xml
@@ -38,7 +38,6 @@
 		- sale ᵐ ˣ
 		- seller ˣ
 		- superdeals ˣ
-		- www ᵐ ˣ
 
 	ᵐ Mismatched
 	ˣ Mixed css, see https://www.paulirish.com/2010/the-protocol-relative-url/
@@ -66,7 +65,7 @@
 
 		- css, on:
 
-			- activities, collections, daxue, es, fuwu, gaga, group, hz, id, it, mai, open, page, pl, superdeals, th, www from style.aliunicorn.com ˢ
+			- activities, collections, daxue, es, fuwu, gaga, group, hz, id, it, mai, open, page, pl, superdeals, th from style.aliunicorn.com ˢ
 			- escrow, fulfillment from style.alibaba.com ˢ
 			- gw.api from style.c.aliimg.com ˢ
 			- mai img.alibaba.com ˢ
@@ -74,21 +73,22 @@
 
 		- Images, on:
 
-			- activities, gw.api, ar, de, es, group, he, id, ja, ko, mai, nl, pl, pt, ru, tr, vi, www from img.alibaba.com ˢ
+			- activities, gw.api, ar, de, es, group, he, id, ja, ko, mai, nl, pl, pt, ru, tr, vi from img.alibaba.com ˢ
 			- activities, escrow, fulfillment, gaga, seller from i0\d.i.aliimg.com ˢ
-			- activities, www from style.aliunicorn.com ˢ
+			- activities from style.aliunicorn.com ˢ
 			- ar, best, brands, de, coupon, group, hz, it, ja, ko, nl, page, pl, ru, sale, th, tr, vi from g0\d.a.alicdn.com ˢ
 			- escrow, fulfillment, hz from img.alibaba.com ˢ
 			- university from gtms04.alicdn.com ˢ
 
-		- Bug on activities, collections, coupon, daxue, de, es, escrow, fr, fulfillment, fuwu, gaga, group, he, id, it, ja, ko, mai, nl, open, page, pl, pt, ru, seller, superdeals, th, tr, trade, university, vi, www from dmtracking2.alibaba.com ˢ
+		- Bug on activities, collections, coupon, daxue, de, es, escrow, fr, fulfillment, fuwu, gaga, group, he, id, it, ja, ko, mai, nl, open, page, pl, pt, ru, seller, superdeals, th, tr, trade, university, vi from dmtracking2.alibaba.com ˢ
 
 	ˢ Secured by us, see https://www.paulirish.com/2010/the-protocol-relative-url/
 
 -->
 <ruleset name="AliExpress.com (partial)">
 
-	<!--target host="aliexpress.com" /-->
+	<target host="aliexpress.com" />
+	<target host="www.aliexpress.com" />
 	<!--target host="activities.aliexpress.com" /-->
 	<target host="us.ae.aliexpress.com" />
 	<!--target host="gw.api.aliexpress.com" /-->
@@ -105,6 +105,7 @@
 	<!--target host="fuwu.aliexpress.com" /-->
 	<!--target host="group.aliexpress.com" /-->
 	<target host="help.aliexpress.com" />
+	<target host="home.aliexpress.com" />
 	<!--target host="id.aliexpress.com" /-->
 	<target host="it.aliexpress.com" />
 	<target host="ko.aliexpress.com" />


### PR DESCRIPTION
Adding www.aliexpress.com and home.aliexpress.com should be safe, since they use a Strict-Transport-Security header on these subdomains

Adding aliexpress.com should be safe too, since it redirects to www.aliexpress.com.