### PR TITLE
Update Reichelt.de.xml

### DIFF
--- a/src/chrome/content/rules/Reichelt.de.xml
+++ b/src/chrome/content/rules/Reichelt.de.xml
@@ -4,8 +4,8 @@
 	<target host="en.reichelt.de" />
 	<target host="m.reichelt.de" />
 	<target host="secure.reichelt.de" />
-	<target host="statistic.reichelt.de
-	<target host="statistic2.reichelt.de
+	<target host="statistic.reichelt.de" />
+	<target host="statistic2.reichelt.de" />
 	<target host="such001.reichelt.de" />
 	<target host="versandkosten.reichelt.de" />
 	

--- a/src/chrome/content/rules/Reichelt.de.xml
+++ b/src/chrome/content/rules/Reichelt.de.xml
@@ -4,14 +4,30 @@
 	<target host="en.reichelt.de" />
 	<target host="m.reichelt.de" />
 	<target host="secure.reichelt.de" />
+	<target host="statistic.reichelt.de
+	<target host="statistic2.reichelt.de
 	<target host="such001.reichelt.de" />
 	<target host="versandkosten.reichelt.de" />
 	
 	<target host="reichelt.com" />
 	<target host="www.reichelt.com" />
+	<target host="m.reichelt.com />
+	<target host="secure.reichelt.com />
+	
+	<target host="reichelt.at" />
+	<target host="www.reichelt.at" />
+	<target host="m.reichelt.at />
+	<target host="secure.reichelt.at />
+	
+	<target host="reichelt.nl" />
+	<target host="www.reichelt.nl" />
+	<target host="m.reichelt.nl />
+	<target host="secure.reichelt.nl />
 	
 	<target host="cdn-reichelt.de" />
-	
+	<target host="css.cdn-reichelt.de" />
+	<target host="js.cdn-reichelt.de" />
+
 	<securecookie host=".+" name=".+" />
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/Reichelt.de.xml
+++ b/src/chrome/content/rules/Reichelt.de.xml
@@ -11,18 +11,18 @@
 	
 	<target host="reichelt.com" />
 	<target host="www.reichelt.com" />
-	<target host="m.reichelt.com />
-	<target host="secure.reichelt.com />
+	<target host="m.reichelt.com" />
+	<target host="secure.reichelt.com" />
 	
 	<target host="reichelt.at" />
 	<target host="www.reichelt.at" />
-	<target host="m.reichelt.at />
-	<target host="secure.reichelt.at />
+	<target host="m.reichelt.at" />
+	<target host="secure.reichelt.at" />
 	
 	<target host="reichelt.nl" />
 	<target host="www.reichelt.nl" />
-	<target host="m.reichelt.nl />
-	<target host="secure.reichelt.nl />
+	<target host="m.reichelt.nl" />
+	<target host="secure.reichelt.nl" />
 	
 	<target host="cdn-reichelt.de" />
 	<target host="css.cdn-reichelt.de" />

--- a/src/chrome/content/rules/Reichelt.de.xml
+++ b/src/chrome/content/rules/Reichelt.de.xml
@@ -1,11 +1,19 @@
 <ruleset name="Reichelt.de">
+	<target host="reichelt.de" />
+	<target host="www.reichelt.de" />
+	<target host="en.reichelt.de" />
+	<target host="m.reichelt.de" />
+	<target host="secure.reichelt.de" />
+	<target host="such001.reichelt.de" />
+	<target host="versandkosten.reichelt.de" />
+	
+	<target host="reichelt.com" />
+	<target host="www.reichelt.com" />
+	
+	<target host="cdn-reichelt.de" />
+	
+	<securecookie host=".+" name=".+" />
 
-  <!-- http://secure.reichelt.de does not redirect to https -->
-
-  <target host="www.reichelt.de" />
-  <target host="reichelt.de" />
-  <target host="secure.reichelt.de" />
-  <target host="such001.reichelt.de" />
-
-  <rule from="^http://(?:www\.|such001\.|secure\.)?reichelt\.de/" to="https://secure.reichelt.de/"/>
+	<rule from="^http:"
+		to="https:" />
 </ruleset>


### PR DESCRIPTION
All domains work via HTTPS now, redirect to secure.reichelt.de no longer needed. Also adding some domains that were missing before.