### PR TITLE
[CarterCenter.org-mismatches] Delete ruleset.

### DIFF
--- a/src/chrome/content/rules/CarterCenter.org-mismatches.xml
+++ b/src/chrome/content/rules/CarterCenter.org-mismatches.xml
@@ -1,9 +1,0 @@
-<!--	See CarterCenter.org.xml also
--->
-<ruleset name="CarterCenter.org (mismatches)" default_off="Certificate mismatch">
-
-	<target host="blog.cartercenter.org" />
-
-	<rule from="^http:" to="https:" />
-
-</ruleset>


### PR DESCRIPTION
`blog` is no longer mismatched, but instead redirects to HTTP. This is noted in [CarterCenter.org.xml](https://github.com/EFForg/https-everywhere/blob/7e4193f45aeb4633e79cdfa56abe1178bf746b39/src/chrome/content/rules/CarterCenter.org.xml#L4) already.