### PR TITLE
[AerisWeather.com] New ruleset

### DIFF
--- a/src/chrome/content/rules/AerisWeather.com.xml
+++ b/src/chrome/content/rules/AerisWeather.com.xml
@@ -1,0 +1,39 @@
+<!--
+	Non-functional subdomains:
+
+		- hosted	(e)
+		- status	(m)
+		- wx-orig	(e)
+		- wx-origin	(e)
+
+	e: expired certificate
+	h: http redirect
+	i: invalid certificate chain
+	m: certificate mismatch
+	r: connection refused
+	s: self-signed certificate
+	t: timeout on https
+-->
+<ruleset name="AerisWeather">
+
+	<target host="aerisweather.com" />
+	<target host="www.aerisweather.com" />
+	<target host="beta.aerisweather.com" />
+	<target host="cdn.aerisweather.com" />
+	<target host="helpdesk.aerisweather.com" />
+	<target host="support.aerisweather.com" />
+	<target host="uat.aerisweather.com" />
+	<target host="www-origin.aerisweather.com" />
+	<target host="wx.aerisweather.com" />
+	<target host="wx-legacy.aerisweather.com" />
+	<target host="wx-origin.aerisweather.com" />
+
+	<securecookie host=".+" name=".+" />
+
+	<!-- expired certificate -->
+	<rule from="^http://wx-origin\.aerisweather\.com/"
+		to="https://wx.aerisweather.com/" />
+
+	<rule from="^http:"
+		to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/AerisWeather.com.xml
+++ b/src/chrome/content/rules/AerisWeather.com.xml
@@ -1,10 +1,14 @@
 <!--
 	Non-functional subdomains:
 
-		- hosted	(e)
-		- status	(m)
-		- wx-orig	(e)
-		- wx-origin	(e)
+		- aerisweather.com
+			- hosted	(e)
+			- status	(m)
+			- wx-orig	(e)
+			- wx-origin	(e)
+
+		- aerisapi.com	(t)
+		- www.aerisapi.com	(r)
 
 	e: expired certificate
 	h: http redirect
@@ -27,6 +31,31 @@
 	<target host="wx.aerisweather.com" />
 	<target host="wx-legacy.aerisweather.com" />
 	<target host="wx-origin.aerisweather.com" />
+
+	<target host="api.aerisapi.com" />
+	<target host="cdn.aerisapi.com" />
+	<target host="contours-legacy.aerisapi.com" />
+	<target host="img.aerisapi.com" />
+	<target host="iwx.aerisapi.com" />
+	<target host="js.aerisapi.com" />
+	<target host="js-origin.aerisapi.com" />
+	<target host="js-secure.aerisapi.com" />
+	<target host="legends.aerisapi.com" />
+	<target host="maps.aerisapi.com" />
+	<target host="maps1.aerisapi.com" />
+	<target host="maps2.aerisapi.com" />
+	<target host="maps3.aerisapi.com" />
+	<target host="maps4.aerisapi.com" />
+	<target host="rads-legacy.aerisapi.com" />
+	<target host="sats-legacy.aerisapi.com" />
+	<target host="tile.aerisapi.com" />
+	<target host="tile1.aerisapi.com" />
+	<target host="tile2.aerisapi.com" />
+	<target host="tile3.aerisapi.com" />
+	<target host="tile4.aerisapi.com" />
+	<target host="video.aerisapi.com" />
+	<target host="warnings-legacy.aerisapi.com" />
+	<target host="wxblox.aerisapi.com" />
 
 	<securecookie host=".+" name=".+" />
 


### PR DESCRIPTION
wildcard `securecookie` can be applied since non-functional subdomains either redirect to functional's (e.g. `hosted`→`wx`) or unnecessary to the function of the website (e.g. `status`).