### PR TITLE
Update University-of-Waterloo.xml

### DIFF
--- a/src/chrome/content/rules/University-of-Waterloo.xml
+++ b/src/chrome/content/rules/University-of-Waterloo.xml
@@ -1,64 +1,23 @@
 <!--
-	Nonfunctional subdomains:
-
-		- cacr		("Gone")
-
-
-	Problematic subdomains:
-
-		- campaign	(refused)
-		- development	(refused)
-		- cecs		(shows info; mismatched, CN: uwaterloo.ca)
-		- hr		(redirects to ^.../$)
-		- info		(redirects to ^.../$, valid cert)
-
-
-	Partially covered subdomains:
-
-		- campaign	(→ ^)
-		- info		(→ ^)
-
-
-	Fully covered subdomains:
-
-		- (www.)
-		- cecs			(→ ^)
-		- cecspilot.cecssys
-		- crysp
-		- (www.)cs
-		- csclub
-		- development		( → ^)
-		- hr			(→ ^)
-		- (www.)math
-		- ripple
+	Invalid certificate and different HTTP/HTTPS content:
+		cacr.uwaterloo.ca
 
 -->
 <ruleset name="University of Waterloo (partial)">
-
 	<target host="uwaterloo.ca" />
-	<target host="*.uwaterloo.ca" />
+	<target host="www.uwaterloo.ca" />
+	<target host="cecspilot.cecssys.uwaterloo.ca" />
+	<target host="crysp.uwaterloo.ca" />
+	<target host="cs.uwaterloo.ca" />
+	<target host="www.cs.uwaterloo.ca" />
+	<target host="csclub.uwaterloo.ca" />
+	<target host="math.uwaterloo.ca" />
+	<target host="www.math.uwaterloo.ca" />
+		<!-- 404 with HTTPS -->
+		<exclusion pattern="^http://www.math.uwaterloo.ca/tsp/" />
+		<test url="http://www.math.uwaterloo.ca/tsp/" />
+	<target host="ripple.uwaterloo.ca" />
 
-
-	<rule from="^http://((?:cecspilot\.cecssys|crysp|csclub|(?:www\.)?cs|(?:www\.)?math|ripple|www)\.)?uwaterloo\.ca/"
-		to="https://$1uwaterloo.ca/" />
-
-	<rule from="^http://campaign\.uwaterloo\.ca/(?=$|\?)"
-		to="https://uwaterloo.ca/support/" />
-
-	<!--	Server drops path:
-					-->
-	<rule from="^http://cecs\.uwaterloo\.ca/.*"
-		to="https://uwaterloo.ca/co-operative-education" />
-
-	<rule from="^http://development\.uwaterloo\.ca/[^?]*(?=$|\?)"
-		to="https://uwaterloo.ca/support/" />
-
-	<!--	Redirects path but not args:
-						-->
-	<rule from="^http://hr\.uwaterloo\.ca/[^?]*(?=$|\?)"
-		to="https://uwaterloo.ca/human-resources/" />
-
-	<rule from="^http://info\.uwaterloo\.ca/+(?=$|\?)"
-		to="https://uwaterloo.ca/central-stores/" />
-
+	<rule from="^http:"
+		to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/University-of-Waterloo.xml
+++ b/src/chrome/content/rules/University-of-Waterloo.xml
@@ -1,6 +1,12 @@
 <!--
-	Invalid certificate and different HTTP/HTTPS content:
+	Different HTTP/HTTPS content:
+		development.uwaterloo.ca
+		info.uwaterloo.ca
+
+	Invalid certificate:
 		cacr.uwaterloo.ca
+		cecs.uwaterloo.ca
+		hr.uwaterloo.ca
 
 -->
 <ruleset name="University of Waterloo (partial)">


### PR DESCRIPTION
This pull request updates `University-of-Waterloo.xml` mainly to fix the problem with http://www.math.uwaterloo.ca/tsp/pubs/ reported in PR https://github.com/EFForg/https-everywhere/pull/7376 and to get the tests to pass, which was blocking the earlier PR.

Regarding the complex rewrite rules I deleted for `campaign.uwaterloo.ca` etc: it's not obvious what some of the regexes do, some of the rewrites are incorrect (for example check the search results for `site:hr.uwaterloo.ca -site:www.hr.uwaterloo.ca`), and they are generally bad practice.