### PR TITLE
Split Potager.org.xml into more manageable rulesets

### DIFF
--- a/src/chrome/content/rules/Pimienta.org.xml
+++ b/src/chrome/content/rules/Pimienta.org.xml
@@ -1,0 +1,20 @@
+<ruleset name="Pimienta.org">
+
+	<target host="pimienta.org" />
+	<target host="www.pimienta.org" />
+	<target host="alcachofa.pimienta.org" />
+	<target host="assembleasocialpoblenou.pimienta.org" />
+	<target host="bibliotecadelaevasion.pimienta.org" />
+	<target host="coati.pimienta.org" />
+	<target host="degenree.pimienta.org" />
+	<target host="fia.pimienta.org" />
+	<target host="frustros.pimienta.org"/>
+	<target host="gofistfoundation.pimienta.org" /><!-- NSFW -->
+	<target host="mambo.pimienta.org" />
+	<target host="oreja.pimienta.org" />
+	<target host="quematumovil.pimienta.org" />
+	<target host="terracremada.pimienta.org" />
+
+	<rule from="^http:" to="https:" />
+
+<ruleset>

--- a/src/chrome/content/rules/Pimienta.org.xml
+++ b/src/chrome/content/rules/Pimienta.org.xml
@@ -17,4 +17,4 @@
 
 	<rule from="^http:" to="https:" />
 
-<ruleset>
+</ruleset>

--- a/src/chrome/content/rules/Poivron.org.xml
+++ b/src/chrome/content/rules/Poivron.org.xml
@@ -1,0 +1,29 @@
+<!--
+	Invalid certificate:
+		radiodragon.poivron.org
+		stop-masculinisme.poivron.org
+
+-->
+<ruleset name="Poivron.org">
+
+	<target host="poivron.org" />
+	<target host="www.poivron.org" />
+	<target host="baygonvert.poivron.org" />
+	<target host="bouh.poivron.org" />
+	<target host="cas-libres.poivron.org" />
+	<target host="dl.poivron.org" />
+	<target host="eizada.poivron.org" />
+	<target host="enfance-buissonniere.poivron.org" />
+	<target host="icarus.poivron.org" />
+	<target host="listes.poivron.org" />
+	<target host="pinkusaido.poivron.org" />
+	<target host="robotnicka.poivron.org" />
+	<target host="timult.poivron.org" />
+	<target host="ttf.poivron.org" />
+	<target host="typonpatate.poivron.org" />
+	<target host="remuernotremerde.poivron.org" />
+	<target host="sundancekids.poivron.org" />
+
+	<rule from="^http:" to="https:" />
+
+</ruleset>

--- a/src/chrome/content/rules/Potager.org.xml
+++ b/src/chrome/content/rules/Potager.org.xml
@@ -1,44 +1,34 @@
 <!--
-	Fully covered domains:
+	Invalid certificate:
+		kigbg.potager.org
+		policespiesoutoflives.potager.org
 
-		- (www.)pimienta.org
-		- (www.)poivron.org
-		- potager.org
-
-		- *.potager.org:
-
-			- community
-			- mail
-			- www
-
-		(www.)sweetpepper.org
+	Login required:
+		community.potager.org
+		mail.potager.org
 
 -->
-<ruleset name="potager.org">
+<ruleset name="Potager.org">
 
-	<target host="pimienta.org" />
-	<target host="*.pimienta.org" />
-	<target host="poivron.org" />
-	<target host="*.poivron.org" />
 	<target host="potager.org" />
-	<target host="*.potager.org" />
-	<target host="sweetpepper.org" />
-	<target host="*.sweetpepper.org" />
+		<test url="http://potager.org/contact/jardiniers.asc" />
+	<target host="www.potager.org" />
+	<target host="awasmifee.potager.org" />
+	<target host="bla.potager.org" />
+	<target host="coquelicot.potager.org" />
+	<target host="help.potager.org" />
+	<target host="jardindesmaraichers.potager.org" />
+	<target host="lagrandeourse.potager.org" />
+	<target host="lentilleres.potager.org" />
+	<target host="leschouxlents.potager.org" />
+	<target host="mire.potager.org" />
+	<target host="pad.potager.org" />
+	<target host="prevelot.potager.org" />
 
+	<rule from="^http://www\.potager\.org/"
+		to="https://potager.org/" />
 
-	<securecookie host="^mail\.potager\.org$" name=".+" />
-
-
-	<rule from="^http://([^/:@\.]+\.)?pimienta\.org/"
-		to="https://$1pimienta.org/" />
-
-	<rule from="^http://([^/:@\.]+\.)?poivron\.org/"
-		to="https://$1poivron.org/" />
-
-	<rule from="^http://([^/:@\.]+\.)?potager\.org/"
-		to="https://$1potager.org/" />
-
-	<rule from="^http://([^/:@\.]+\.)?sweetpepper\.org/"
-		to="https://$1sweetpepper.org/" />
+	<rule from="^http:"
+		to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Potager.org.xml
+++ b/src/chrome/content/rules/Potager.org.xml
@@ -15,7 +15,6 @@
 	<target host="coquelicot.potager.org" />
 	<target host="help.potager.org" />
 	<target host="jardindesmaraichers.potager.org" />
-	<target host="lagrandeourse.potager.org" />
 	<target host="lentilleres.potager.org" />
 	<target host="leschouxlents.potager.org" />
 	<target host="mail.potager.org" />

--- a/src/chrome/content/rules/Potager.org.xml
+++ b/src/chrome/content/rules/Potager.org.xml
@@ -1,34 +1,29 @@
 <!--
 	Invalid certificate:
-		kigbg.potager.org
-		policespiesoutoflives.potager.org
+		- kigbg
+		- policespiesoutoflives
 
-	Login required:
-		community.potager.org
-		mail.potager.org
-
+	Expired:
+		- lagrandeourse
 -->
 <ruleset name="Potager.org">
-
 	<target host="potager.org" />
-		<test url="http://potager.org/contact/jardiniers.asc" />
 	<target host="www.potager.org" />
 	<target host="awasmifee.potager.org" />
 	<target host="bla.potager.org" />
+	<target host="community.potager.org" />
 	<target host="coquelicot.potager.org" />
 	<target host="help.potager.org" />
 	<target host="jardindesmaraichers.potager.org" />
 	<target host="lagrandeourse.potager.org" />
 	<target host="lentilleres.potager.org" />
 	<target host="leschouxlents.potager.org" />
+	<target host="mail.potager.org" />
 	<target host="mire.potager.org" />
 	<target host="pad.potager.org" />
-	<target host="prevelot.potager.org" />
 
 	<rule from="^http://www\.potager\.org/"
 		to="https://potager.org/" />
 
-	<rule from="^http:"
-		to="https:" />
-
+	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/SweetPepper.org.xml
+++ b/src/chrome/content/rules/SweetPepper.org.xml
@@ -1,0 +1,10 @@
+<ruleset name="SweetPepper.org">
+
+	<target host="sweetpepper.org" />
+	<target host="www.sweetpepper.org" />
+	<target host="thechemistandtheacevities.sweetpepper.org" />
+	<target host="velvetsluts.sweetpepper.org" />
+
+	<rule from="^http:" to="https:" />
+
+</ruleset>


### PR DESCRIPTION
@potager, could you fix the mismatch issues that occur when you are just redirecting to another domain?

In that case, we could bring back the wildcards. You may also want to consider [HSTS preloading](https://scotthelme.co.uk/hsts-preloading/).