### PR TITLE
Add mannheim24.de, heidelberg24.de, ludwigshafen24.de

### DIFF
--- a/src/chrome/content/rules/headline24.de.xml
+++ b/src/chrome/content/rules/headline24.de.xml
@@ -18,7 +18,7 @@
 	<target host="lust.ludwigshafen24.de"/>
 	<target host="play.ludwigshafen24.de"/>
 	
-	<securecookie host=".+" name=".+"/>
+	<securecookie host=".+" name=".+" />
 
 	<rule from="^http:" to="https:"/>
 </ruleset>

--- a/src/chrome/content/rules/headline24.de.xml
+++ b/src/chrome/content/rules/headline24.de.xml
@@ -1,0 +1,24 @@
+<ruleset name="Headline24 GmbH">
+
+	<!-- *Mannheim24.de -->
+	<target host="mannheim24.de"/>
+	<target host="www.mannheim24.de"/>
+	<target host="lust.mannheim24.de"/>
+	<target host="play.mannheim24.de"/>
+	
+	<!-- *Heidelberg24.de -->
+	<target host="heidelberg24.de"/>
+	<target host="www.heidelberg24.de"/>
+	<target host="lust.heidelberg24.de"/>
+	<target host="play.heidelberg24.de"/>
+	
+	<!-- *Ludwigshafen24.de -->
+	<target host="ludwigshafen24.de"/>
+	<target host="www.ludwigshafen24.de"/>
+	<target host="lust.ludwigshafen24.de"/>
+	<target host="play.ludwigshafen24.de"/>
+	
+	<securecookie host=".+" name=".+"/>
+
+	<rule from="^http:" to="https:"/>
+</ruleset>


### PR DESCRIPTION
@J0WI 
A new PR

I renamed the ruleset to there  company name "Headline24 GmbH", because headline24.de is only the domain for the company with no content / valid certificate. 

