### PR TITLE
Added ruleset for pops.co

### DIFF
--- a/src/chrome/content/rules/Pops.co.xml
+++ b/src/chrome/content/rules/Pops.co.xml
@@ -1,0 +1,11 @@
+<!--
+	Invalid certificate:
+		www.pops.co
+
+-->
+<ruleset name="Pops.co">
+	<target host="pops.co" />
+	<target host="app.pops.co" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>


### PR DESCRIPTION
If I understood well, the site has no HSTS so it makes sense to make a ruleset for it despite the HTTP to HTTPS redirect