### PR TITLE
Add Neis-One.org.xml

### DIFF
--- a/src/chrome/content/rules/Neis-One.org.xml
+++ b/src/chrome/content/rules/Neis-One.org.xml
@@ -1,0 +1,23 @@
+<!--
+	Pascal Neis' Web Blog and OpenStreetMap Tools (neis-one.org)
+	
+-->
+<ruleset name="Neis-One.org">
+	<target host="neis-one.org" />
+	<target host="www.neis-one.org" />
+	<target host="hdyc.neis-one.org" />
+	<target host="www.hdyc.neis-one.org" />
+	<target host="maps.neis-one.org" />
+	<target host="www.maps.neis-one.org" />
+	<target host="osmfight.neis-one.org" />
+	<target host="www.osmfight.neis-one.org" />
+	<target host="osmstats.neis-one.org" />
+	<target host="www.osmstats.neis-one.org" />
+	<target host="resultmaps.neis-one.org" />
+	<target host="www.resultmaps.neis-one.org" />
+	<target host="yosmhm.neis-one.org" />
+	<target host="www.yosmhm.neis-one.org" />
+	
+	<rule from="^http:"
+		to="https:" />
+</ruleset>


### PR DESCRIPTION
This pull request enforces HTTPS on Pascal Neis's website ([neis-one.org](https://neis-one.org/)), which is a blog related to [OpenStreetMap project](https://www.openstreetmap.org/). This also includes its _known list_ of related subdomains- which hosts OpenStreetMap tools like [contributions heatmap](https://yosmhm.neis-one.org/), [GitHub-like contribution statistics](https://hdyc.neis-one.org/), and [few others](https://resultmaps.neis-one.org/).

All domains are apparently served using [ISRG Let's Encrypt](https://letsencrypt.org/) certificate.

### Notes: ###

The browser might issue a block on some scripted "mixed content", e.g. on [OpenStreetMap GPS Points page](https://resultmaps.neis-one.org/osmgps.html). Though when user actually chose to lift the block, the page would work properly _without any unencrypted HTTP request leaked_. From a look at page's source and its cross-domain script usage, this seems to be caused by the browser blocking cross-domain HTTP `<script>` URL according to page's source code (that is- before rewritten by the add-on). When the scripts are actually to be loaded, their URLs will get rewritten into HTTPS by the add-on as usual.

This blocking behavior is pretty much the same when accessing that page in HTTPS without ruleset or add-on enabled (though doing so left the unencrypted HTTP request for those scripts clearly visible). I'm not sure if this behavior is the same on other browsers and/or vanilla version of EFF HTTPS Everywhere.

HTTPS Everywhere: [Encrypted Web 5.1.5](https://addons.palemoon.org/addon/encrypted-web/)
Browser: Pale Moon 25.8.1 (binary)
Wireshark: 1.8.2 (debian)
System: Debian GNU/Linux 7.0 "Wheezy" i386
