### PR TITLE
Remove individual-villas.co.uk from Wyndham.xml

### DIFF
--- a/src/chrome/content/rules/Wyndham.xml
+++ b/src/chrome/content/rules/Wyndham.xml
@@ -28,8 +28,6 @@
 Disabled by https-everywhere-checker because:
 Fetch error: http://competitionsbywyndham.com.au/ => https://competitionsbywyndham.com.au/: (60, 'SSL certificate problem: unable to get local issuer certificate')
 Fetch error: http://www.competitionsbywyndham.com.au/ => https://www.competitionsbywyndham.com.au/: (60, 'SSL certificate problem: unable to get local issuer certificate')
-Fetch error: http://individual-villas.co.uk/ => https://www.individual-villas.co.uk/: (7, 'Failed to connect to www.individual-villas.co.uk port 443: Connection refused')
-Fetch error: http://www.individual-villas.co.uk/ => https://www.individual-villas.co.uk/: (7, 'Failed to connect to www.individual-villas.co.uk port 443: Connection refused')
 Fetch error: http://secureholidays.com/ => https://www.secureholidays.com/: (28, 'Connection timed out after 20000 milliseconds')
 Fetch error: http://www.secureholidays.com/ => https://www.secureholidays.com/: (28, 'Connection timed out after 20000 milliseconds')
 Fetch error: http://wyndham.com/ => https://www.wyndham.com/: (28, 'Operation timed out after 30001 milliseconds with 0 bytes received')
@@ -69,8 +67,6 @@ Fetch error: http://www.wyndhamrentals.com/ => https://www.wyndhamrentals.com/: 
 	<target host="www.competitionsbywyndham.com.au"/>
 	<target host="cottagesdirect.co.uk"/>
 	<target host="www.cottagesdirect.co.uk"/>
-	<target host="individual-villas.co.uk"/>
-	<target host="www.individual-villas.co.uk"/>
 	<target host="landalcampings.be"/>
 	<target host="www.landalcampings.be"/>
 	<target host="landalcampings.nl"/>
@@ -90,12 +86,12 @@ Fetch error: http://www.wyndhamrentals.com/ => https://www.wyndhamrentals.com/: 
 	<target host="www.wyndhamrentals.com"/>
 
 	<!--	incomplete	-->
-	<securecookie host="^(?:.*\.)?(?:cottagesdirect|individual-villas)\.co\.uk$" name=".+" />
+	<securecookie host="^(?:.*\.)?cottagesdirect\.co\.uk$" name=".+" />
 	<securecookie host="^(?:www\.)?competitionsbywyndham\.com\.au$" name=".+" />
 	<securecookie host="^www\.ourvacationstore\.com$" name=".+" />
 
 
-	<rule from="^http://(?:www\.)?(cottagesdirect|individual-villas|villas4you)\.co\.uk/"
+	<rule from="^http://(?:www\.)?(cottagesdirect|villas4you)\.co\.uk/"
 		to="https://www.$1.co.uk/"/>
 
 	<rule from="^http://(www\.)?competitionsbywyndham\.com\.au/"


### PR DESCRIPTION
`^` and `www` refused over HTTPS and `301` redirect to https://www.jamesvillas.co.uk/?individual-villas. I assume that this domain is no longer in use.