### PR TITLE
Update and rename osnews.com.xml to OSNews.com.xml

### DIFF
--- a/src/chrome/content/rules/OSNews.com.xml
+++ b/src/chrome/content/rules/OSNews.com.xml
@@ -1,0 +1,11 @@
+<!--
+	Different HTTP/HTTPS content:
+		mobile.osnews.com
+
+-->
+<ruleset name="OSNews.com" platform="mixedcontent">
+	<target host="osnews.com" />
+	<target host="www.osnews.com" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/osnews.com.xml
+++ b/src/chrome/content/rules/osnews.com.xml
@@ -1,6 +1,0 @@
-<ruleset name="osnews.com">
-	<target host="osnews.com" />
-	<target host="www.osnews.com" />
-
-	<rule from="^http:" to="https:" />
-</ruleset>


### PR DESCRIPTION
This pull request replaces https://github.com/EFForg/https-everywhere/pull/12162 .

About `platform="mixedcontent"`: as @da2x reported in https://github.com/EFForg/https-everywhere/pull/12162#issue-253379415 :

> Preview button doesn’t work, so can’t progress to submission. Form works when loaded over HTTP.

It looks like some pages try and fail to load http://www.osnews.com/js/corejs.20091020.js , which seems responsible for both previewing submissions and other site behavior too. So it is safest to just mark the entire ruleset with `mixedcontent`.