### PR TITLE
The New York Times has a new SecureDrop URL

### DIFF
--- a/src/chrome/content/rules/NYTimes.xml
+++ b/src/chrome/content/rules/NYTimes.xml
@@ -6,7 +6,7 @@
 		- NYT_cn.me.xml
 		- NYT_eXaminer.com.xml
 		- INYT.com.xml
-		- nytimes2tsqtnxek.onion.xml
+		- nyttips4bmquxfzw.onion
 
 	CDN buckets:
 		- pimage.timespeople.nytimes.com.amazonaws.com

--- a/src/chrome/content/rules/NYTimes.xml
+++ b/src/chrome/content/rules/NYTimes.xml
@@ -6,7 +6,7 @@
 		- NYT_cn.me.xml
 		- NYT_eXaminer.com.xml
 		- INYT.com.xml
-		- nyttips4bmquxfzw.onion
+		- nyttips4bmquxfzw.onion.xml
 
 	CDN buckets:
 		- pimage.timespeople.nytimes.com.amazonaws.com

--- a/src/chrome/content/rules/NYTimes.xml
+++ b/src/chrome/content/rules/NYTimes.xml
@@ -45,6 +45,7 @@
 
 	Too many redirects:
 		regilite.nytimes.com
+		homedelivery.nytimes.com
 
 	Problematic hosts in *nytimesathome.com:
 		- ^ ᵐ
@@ -71,15 +72,12 @@
 		<test url="http://graphics8.nytimes.com/css/common/global.css" />
 		<test url="http://graphics8.nytimes.com/images/blogs_v5/artsbeat/artsbeat_main.png" />
 		<test url="http://graphics8.nytimes.com/images/misc/nytlogo153x23.gif" />
-	<target host="homedelivery.nytimes.com" />
 	<target host="international.nytimes.com" />
 	<target host="meter-svc.nytimes.com" />
 	<target host="myaccount.nytimes.com" />
 	<target host="markets.on.nytimes.com" />
 		<test url="http://markets.on.nytimes.com/research/Net/SectionFrontAPI/MarketModuleData/jsonp" />
 	<target host="static.nytimes.com" />
-	<target host="store-media.nytimes.com" />
-	<target host="store-skin.nytimes.com" />
 	<target host="typeface.nytimes.com" />
 	<target host="up.nytimes.com" />
 	<target host="tagx.nytimes.com" />

--- a/src/chrome/content/rules/NYTimes.xml
+++ b/src/chrome/content/rules/NYTimes.xml
@@ -44,8 +44,8 @@
 	² Mixed content (iframe)
 
 	Too many redirects:
-		regilite.nytimes.com
 		homedelivery.nytimes.com
+		regilite.nytimes.com
 
 	Problematic hosts in *nytimesathome.com:
 		- ^ ᵐ

--- a/src/chrome/content/rules/nyttips4bmquxfzw.onion.xml
+++ b/src/chrome/content/rules/nyttips4bmquxfzw.onion.xml
@@ -5,9 +5,9 @@
 	associated with The New York Times.
 
 	Invalid certificate:
-            www.nyttips4bmquxfzw.onion
+		www.nyttips4bmquxfzw.onion
 -->
-<ruleset name="The New York Times SecureDrop (onion)">
+<ruleset name="nyttips4bmquxfzw.onion">
 
 	<target host="nyttips4bmquxfzw.onion" />
 

--- a/src/chrome/content/rules/nyttips4bmquxfzw.onion.xml
+++ b/src/chrome/content/rules/nyttips4bmquxfzw.onion.xml
@@ -1,5 +1,11 @@
 <!--
 	For other NY Times rulesets, see NYTimes.xml
+
+	See https://nytimes.com/tips to verify that this site is
+	associated with The New York Times.
+
+	Invalid certificate:
+            www.nyttips4bmquxfzw.onion
 -->
 <ruleset name="The New York Times SecureDrop (onion)">
 

--- a/src/chrome/content/rules/nyttips4bmquxfzw.onion.xml
+++ b/src/chrome/content/rules/nyttips4bmquxfzw.onion.xml
@@ -1,13 +1,9 @@
 <!--
 	For other NY Times rulesets, see NYTimes.xml
-
-	Invalid certificate:
-		www.nytimes2tsqtnxek.onion
-
 -->
 <ruleset name="The New York Times SecureDrop (onion)">
 
-	<target host="nytimes2tsqtnxek.onion" />
+	<target host="nyttips4bmquxfzw.onion" />
 
 	<rule from="^http:" to="https:" />
 


### PR DESCRIPTION
Updated the .xml files to indicate that The New York Times has a new SecureDrop URL. This can be verified on [https://nytimes.com/tips](https://nytimes.com/tips). The old URL is serving a static page over HTTP.