### PR TITLE
Update University-of-Waterloo.xml

### DIFF
--- a/src/chrome/content/rules/University-of-Waterloo.xml
+++ b/src/chrome/content/rules/University-of-Waterloo.xml
@@ -7,6 +7,7 @@
 		cacr.uwaterloo.ca
 		cecs.uwaterloo.ca
 		hr.uwaterloo.ca
+		bookings.lib.uwaterloo.ca (incomplete certificate chain)
 
 -->
 <ruleset name="University of Waterloo (partial)">
@@ -19,7 +20,6 @@
 	<target host="www.cs.uwaterloo.ca" />
 	<target host="csclub.uwaterloo.ca" />
 	<target host="library.uwaterloo.ca" />
-	<target host="bookings.lib.uwaterloo.ca" />
 	<target host="www.lib.uwaterloo.ca" />
 	<target host="math.uwaterloo.ca" />
 	<target host="cemc.math.uwaterloo.ca" />

--- a/src/chrome/content/rules/University-of-Waterloo.xml
+++ b/src/chrome/content/rules/University-of-Waterloo.xml
@@ -2,6 +2,7 @@
 	Different HTTP/HTTPS content:
 		development.uwaterloo.ca
 		info.uwaterloo.ca
+		library.uwaterloo.ca
 
 	Invalid certificate:
 		cacr.uwaterloo.ca
@@ -19,7 +20,6 @@
 	<target host="cs.uwaterloo.ca" />
 	<target host="www.cs.uwaterloo.ca" />
 	<target host="csclub.uwaterloo.ca" />
-	<target host="library.uwaterloo.ca" />
 	<target host="www.lib.uwaterloo.ca" />
 	<target host="math.uwaterloo.ca" />
 	<target host="cemc.math.uwaterloo.ca" />

--- a/src/chrome/content/rules/University-of-Waterloo.xml
+++ b/src/chrome/content/rules/University-of-Waterloo.xml
@@ -13,16 +13,24 @@
 	<target host="uwaterloo.ca" />
 	<target host="www.uwaterloo.ca" />
 	<target host="cecspilot.cecssys.uwaterloo.ca" />
+	<target host="www.civil.uwaterloo.ca" />
 	<target host="crysp.uwaterloo.ca" />
 	<target host="cs.uwaterloo.ca" />
 	<target host="www.cs.uwaterloo.ca" />
 	<target host="csclub.uwaterloo.ca" />
+	<target host="library.uwaterloo.ca" />
+	<target host="bookings.lib.uwaterloo.ca" />
+	<target host="www.lib.uwaterloo.ca" />
 	<target host="math.uwaterloo.ca" />
+	<target host="cemc.math.uwaterloo.ca" />
 	<target host="www.math.uwaterloo.ca" />
 		<!-- 404 with HTTPS -->
 		<exclusion pattern="^http://www.math.uwaterloo.ca/tsp/" />
 		<test url="http://www.math.uwaterloo.ca/tsp/" />
+	<target host="www.reserves.uwaterloo.ca" />
 	<target host="ripple.uwaterloo.ca" />
+	<target host="uwspace.uwaterloo.ca" />
+	<target host="wise.uwaterloo.ca" />
 
 	<rule from="^http:"
 		to="https:" />


### PR DESCRIPTION
Added some new rules for the University of Waterloo, mostly relating to the library.

I also found a bunch of subdomains that could go in the leading comment, but I don't know what's considered sufficient cause to add them there, so I didn't. Some examples (all linked from library pages) include:

subjectguides.uwaterloo.ca
digital.library.uwaterloo.ca
ereference.uwaterloo.ca
journal-indexes.uwaterloo.ca
testtube.uwaterloo.ca