### PR TITLE
Added an additional rule for img bato.to subdomains.

### DIFF
--- a/src/chrome/content/rules/bato.to.xml
+++ b/src/chrome/content/rules/bato.to.xml
@@ -6,8 +6,8 @@
 	<target host="img2.bato.to"/>
 	<target host="img.bato.to"/>
 
-	<rule from="^http://img\d?\.bato\.to"
-		to="https://bato\.to"/>	
+	<rule from="^http://img\d?\.bato\.to/"
+		to="https://bato\.to/"/>	
 
 	<rule from="^http:"
 		to="https:"/>

--- a/src/chrome/content/rules/bato.to.xml
+++ b/src/chrome/content/rules/bato.to.xml
@@ -6,8 +6,8 @@
 	<target host="img2.bato.to"/>
 	<target host="img.bato.to"/>
 
-	<rule from="^http://img\d?\.bato\.to/"
-		to="https://bato\.to/"/>	
+	<rule from="^http:\/\/img\d?\.bato\.to\/"
+		to="https://bato.to/"/>	
 
 	<rule from="^http:"
 		to="https:"/>

--- a/src/chrome/content/rules/bato.to.xml
+++ b/src/chrome/content/rules/bato.to.xml
@@ -1,7 +1,11 @@
 <ruleset name="bato.to">
 	<target host="www.bato.to"/>
 	<target host="bato.to"/>
-	
+	<target host="img\d?.bato.to"/>
+
+	<rule from="^http://img\d?\.bato\.to"
+		to="https://bato\.to"/>	
+
 	<rule from="^http:"
 		to="https:"/>
 </ruleset>

--- a/src/chrome/content/rules/bato.to.xml
+++ b/src/chrome/content/rules/bato.to.xml
@@ -1,7 +1,10 @@
 <ruleset name="bato.to">
 	<target host="www.bato.to"/>
 	<target host="bato.to"/>
-	<target host="img\d?.bato.to"/>
+	<target host="img4.bato.to"/>
+	<target host="img3.bato.to"/>
+	<target host="img2.bato.to"/>
+	<target host="img.bato.to"/>
 
 	<rule from="^http://img\d?\.bato\.to"
 		to="https://bato\.to"/>	


### PR DESCRIPTION
Was seeing requests to img4.bato.to over port 80 but wouldn't accept https. Changed it to img.bato.to which did accept and also tried the base bato.to domain which happily serves images as well.