### PR TITLE
[Ubuntu.com] Exclude keyserver.ubuntu.com:11371 (fix #14185)

### DIFF
--- a/src/chrome/content/rules/Ubuntu.xml
+++ b/src/chrome/content/rules/Ubuntu.xml
@@ -86,7 +86,6 @@
 	<target host="shop.ubuntu.com" />
 	<target host="tutorials.ubuntu.com" />
 	<target host="uec-images.ubuntu.com" />
-	<target host="unity.ubuntu.com" />
 	<target host="wiki.ubuntu.com" />
 
 	<securecookie host=".+" name=".+" />

--- a/src/chrome/content/rules/Ubuntu.xml
+++ b/src/chrome/content/rules/Ubuntu.xml
@@ -72,6 +72,9 @@
 	<target host="irclogs.ubuntu.com" />
 	<target host="juju.ubuntu.com" />
 	<target host="keyserver.ubuntu.com" />
+		<!-- HTTPS doesn't work on port 11371 -->
+		<exclusion pattern="^http://keyserver\.ubuntu\.com:11371/" />
+			<test url="http://keyserver.ubuntu.com:11371/pks/lookup?op=vindex&amp;search=extension-devs%40eff.org&amp;fingerprint=on" />
 	<target host="maas.ubuntu.com" />
 	<target host="merges.ubuntu.com" />
 	<target host="packages.ubuntu.com" />


### PR DESCRIPTION
fix #14185