### PR TITLE
[DuckDuckGo] Update targets

### DIFF
--- a/src/chrome/content/rules/DuckDuckGo.xml
+++ b/src/chrome/content/rules/DuckDuckGo.xml
@@ -40,14 +40,12 @@
 	<target host="dub.duckduckgo.com" />
 	<target host="favicons.duckduckgo.com" />
 		<test url="http://favicons.duckduckgo.com/ip2/twitter.com.ico" />
-		<exclusion pattern="^http://favicons\.duckduckgo\.com/$" />
 	<target host="ff.duckduckgo.com" />
 	<target host="help.duckduckgo.com" />
 	<target host="i.duckduckgo.com" />
 	<target host="images.duckduckgo.com" />
 	<target host="icons.duckduckgo.com" />
 		<test url="http://icons.duckduckgo.com/ip2/twitter.com.ico" />
-		<exclusion pattern="^http://icons\.duckduckgo\.com/$" />
 	<target host="karma.duckduckgo.com" />
 	<target host="meme.duckduckgo.com" />
 	<target host="moollaza.duckduckgo.com" />

--- a/src/chrome/content/rules/DuckDuckGo.xml
+++ b/src/chrome/content/rules/DuckDuckGo.xml
@@ -20,17 +20,10 @@
 			 - va-ddgc-staging-web1.duckduckgo.com
 
 		Peer certificate cannot be authenticated with given CA certificates:
-			 - blog.duckduckgo.com
-			 - help.duckduckgo.com
-			 - meme.duckduckgo.com
-			 - settings.duckduckgo.com
-			 - shop.duckduckgo.com
-			 - wiki.duckduckgo.com
 			 - www.ddg.gg
 
-		5xx server error:
-			 - favicons.duckduckgo.com
-			 - icons.duckduckgo.com
+		Couldn't resolve host:
+			 - va-l1.duckduckgo.com
 -->
 <ruleset name="DuckDuckGo">
 	<target host="duck.co" />
@@ -41,13 +34,22 @@
 	<target host="ac.duckduckgo.com" />
 	<target host="api.duckduckgo.com" />
 	<target host="beta.duckduckgo.com" />
+	<target host="blog.duckduckgo.com" />
 	<target host="bttf.duckduckgo.com" />
 	<target host="chrome.duckduckgo.com" />
 	<target host="dub.duckduckgo.com" />
+	<target host="favicons.duckduckgo.com" />
+		<test url="http://favicons.duckduckgo.com/ip2/twitter.com.ico" />
+		<exclusion pattern="^http://favicons\.duckduckgo\.com/$" />
 	<target host="ff.duckduckgo.com" />
+	<target host="help.duckduckgo.com" />
 	<target host="i.duckduckgo.com" />
 	<target host="images.duckduckgo.com" />
+	<target host="icons.duckduckgo.com" />
+		<test url="http://icons.duckduckgo.com/ip2/twitter.com.ico" />
+		<exclusion pattern="^http://icons\.duckduckgo\.com/$" />
 	<target host="karma.duckduckgo.com" />
+	<target host="meme.duckduckgo.com" />
 	<target host="moollaza.duckduckgo.com" />
 	<target host="news.duckduckgo.com" />
 	<target host="next.duckduckgo.com" />
@@ -55,10 +57,12 @@
 	<target host="refresh.duckduckgo.com" />
 	<target host="reports.duckduckgo.com" />
 	<target host="safe.duckduckgo.com" />
+	<target host="settings.duckduckgo.com" />
+	<target host="shop.duckduckgo.com" />
 	<target host="staging.duckduckgo.com" />
 	<target host="start.duckduckgo.com" />
-	<target host="va-l1.duckduckgo.com" />
 	<target host="watrcoolr.duckduckgo.com" />
+	<target host="wiki.duckduckgo.com" />
 
 	<target host="dukgo.com" />
 


### PR DESCRIPTION
Many certificates have been fixed. Also Include `favicons.` and `icons.` with the correct exclusion rule and tests.
`va-l1.duckduckgo.com` doesn't seem to exist anymore.