### PR TITLE
Create SIMILE-Widgets.org.xml

### DIFF
--- a/src/chrome/content/rules/SIMILE-Widgets.org.xml
+++ b/src/chrome/content/rules/SIMILE-Widgets.org.xml
@@ -1,0 +1,18 @@
+<!--
+	Different content HTTP/HTTPS:
+		static.simile-widgets.org
+
+	Secure connection failed:
+		trunk.simile-widgets.org
+
+-->
+<ruleset name="SIMILE-Widgets.org">
+
+	<target host="simile-widgets.org" />
+	<target host="www.simile-widgets.org" />
+	<target host="api.simile-widgets.org" />
+	<target host="service.simile-widgets.org" />
+
+	<rule from="^http:" to="https:" />
+
+</ruleset>


### PR DESCRIPTION
MCB on https://api.simile-widgets.org has almost no impact on page appearance so I think it's okay to include this subdomain.