### PR TITLE
Add deprecated image to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ os: linux
 dist: trusty
 language: python
 python: 2.7
+group: deprecated-2017Q4
 services:
   - docker
 matrix:


### PR DESCRIPTION
When https://github.com/EFForg/https-everywhere/pull/14364/files is rebased on top of this, it should fix the ipv6 issues.  This is a temporary measure - after extensive testing with solutions listed and linked from [here](https://github.com/travis-ci/travis-ci/issues/8891), I wasn't able to resolve the ipv6 issue with the latest trusty build.