### PR TITLE
Delete Owl.English.Purdue.edu.xml

### DIFF
--- a/src/chrome/content/rules/Owl.English.Purdue.edu.xml
+++ b/src/chrome/content/rules/Owl.English.Purdue.edu.xml
@@ -1,4 +1,0 @@
-<ruleset name="Purdue OWL">
-  <target host="owl.english.purdue.edu"/>
-  <rule from="^http://(?:www\.)?owl\.english\.purdue\.edu/" to="https://owl.english.purdue.edu/"/>
-</ruleset>


### PR DESCRIPTION
- owl.english is covered in Purdue_University.xml
- www.owl.english does not exist