### PR TITLE
Automatically remove trailing whitespaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,6 +6,7 @@ root = true
 end_of_line = lf
 insert_final_newline = true
 charset = utf-8
+trim_trailing_whitespace = true
 
 [src/chrome/content/rules/*.xml]
 indent_style = tab


### PR DESCRIPTION
Many contributors will have this set as their default text editor config but it isn't the case on GitHub. Because GitHub natively works with editorconfig, trailing whitespaces will be trimmed even with the online editor.