### PR TITLE
Add canada.ca and Government of Canada web sites

### DIFF
--- a/src/chrome/content/rules/canada.ca.xml
+++ b/src/chrome/content/rules/canada.ca.xml
@@ -1,0 +1,7 @@
+<ruleset name="Government of Canada">
+	<target host="canada.ca" />
+        <target host="meteo.gc.ca" />
+	<target host="weather.gc.ca" />
+
+        <rule from="^http:" to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/canada.ca.xml
+++ b/src/chrome/content/rules/canada.ca.xml
@@ -1,7 +1,7 @@
 <ruleset name="Government of Canada">
 	<target host="canada.ca" />
-        <target host="meteo.gc.ca" />
+	<target host="meteo.gc.ca" />
 	<target host="weather.gc.ca" />
 
-        <rule from="^http:" to="https:" />
+	<rule from="^http:" to="https:" />
 </ruleset>


### PR DESCRIPTION
Government of Canada web sites
canada.ca, weather.gc.ca and meteo.gc.ca is manage by the same Government of Canada entity.