### PR TITLE
[CDON] Remove cdon.se subdomains

### DIFF
--- a/src/chrome/content/rules/CDON.COM.xml
+++ b/src/chrome/content/rules/CDON.COM.xml
@@ -8,15 +8,13 @@
 	<target host="www.cdon.fi"/>
 	<target host="cdon.no"/>
 	<target host="www.cdon.no"/>
-	<target host="cdon.se"/>
-	<target host="www.cdon.se"/>
 	<target host="s.cdon.com"/>
 
 
-	<securecookie host="^cdon\.(?:dk|eu|fi|no|se)$" name=".+" />
+	<securecookie host="^cdon\.(?:dk|eu|fi|no)$" name=".+" />
 
 
-	<rule from="^http://(?:www)?cdon\.(dk|eu|fi|no|se)/"
+	<rule from="^http://(?:www)?cdon\.(dk|eu|fi|no)/"
 		to="https://cdon.$1/"/>
 
 	<rule from="^http://s\.cdon\.com/"

--- a/src/chrome/content/rules/CDON.COM.xml
+++ b/src/chrome/content/rules/CDON.COM.xml
@@ -1,3 +1,7 @@
+<!--
+	cdon.se subdomains are handled in cdon.se.xml 
+
+-->
 <ruleset name="CDON.COM" platform="mixedcontent">
 
 	<target host="cdon.dk"/>

--- a/src/chrome/content/rules/CDON.COM.xml
+++ b/src/chrome/content/rules/CDON.COM.xml
@@ -15,7 +15,7 @@
 
 
 	<rule from="^http://(www\.)?cdon\.(dk|eu|fi|no)/"
-		to="https://cdon.$1/"/>
+		to="https://cdon.$2/"/>
 
 	<rule from="^http://s\.cdon\.com/"
 		to="https://s.cdon.com/"/>

--- a/src/chrome/content/rules/CDON.COM.xml
+++ b/src/chrome/content/rules/CDON.COM.xml
@@ -14,7 +14,7 @@
 	<securecookie host="^cdon\.(?:dk|eu|fi|no)$" name=".+" />
 
 
-	<rule from="^http://(?:www)?cdon\.(dk|eu|fi|no)/"
+	<rule from="^http://(www\.)?cdon\.(dk|eu|fi|no)/"
 		to="https://cdon.$1/"/>
 
 	<rule from="^http://s\.cdon\.com/"

--- a/src/chrome/content/rules/cdon.se.xml
+++ b/src/chrome/content/rules/cdon.se.xml
@@ -12,7 +12,6 @@
 <ruleset name="cdon.se">
 	<target host="cdon.se" />
 	<target host="www.cdon.se" />
-	<target host="preprod.cdon.se" />
 
 	<securecookie host=".+" name=".+" />
 

--- a/src/chrome/content/rules/cdon.se.xml
+++ b/src/chrome/content/rules/cdon.se.xml
@@ -1,4 +1,6 @@
 <!--
+	For other cdon TLDs, see CDON.COM.xml
+
 	HTTP 400:
 		- www
 


### PR DESCRIPTION
cdon.se subdomains are handled in [`cdon.se.xml`](https://github.com/EFForg/https-everywhere/blob/master/src/chrome/content/rules/cdon.se.xml).