### PR TITLE
Update University-of-Waterloo.xml yet again

### DIFF
--- a/src/chrome/content/rules/University-of-Waterloo.xml
+++ b/src/chrome/content/rules/University-of-Waterloo.xml
@@ -8,8 +8,6 @@
 		cacr.uwaterloo.ca
 		cecs.uwaterloo.ca
 		hr.uwaterloo.ca
-		bookings.lib.uwaterloo.ca (incomplete certificate chain)
-		digital.library.uwaterloo.ca (incomplete certificate chain)
 
 -->
 <ruleset name="University of Waterloo (partial)">
@@ -21,7 +19,10 @@
 	<target host="cs.uwaterloo.ca" />
 	<target host="www.cs.uwaterloo.ca" />
 	<target host="csclub.uwaterloo.ca" />
+	<target host="mirror.csclub.uwaterloo.ca" />
+	<target host="bookings.lib.uwaterloo.ca" />
 	<target host="www.lib.uwaterloo.ca" />
+	<target host="digital.library.uwaterloo.ca" />
 	<target host="mailservices.uwaterloo.ca" />	
 	<target host="math.uwaterloo.ca" />
 	<target host="cemc.math.uwaterloo.ca" />


### PR DESCRIPTION
This PR:
 - moves two subdomains from broken into rules (I believe they have now been fixed)
 - adds mirror.csclub.uwaterloo.ca (official Canadian mirror for a lot of FOSS projects)

related previous PRs: #14126, #14441 
