### PR TITLE
Update test/run_travis.sh, Fix Travis fetch-test

### DIFF
--- a/test/run_travis.sh
+++ b/test/run_travis.sh
@@ -38,7 +38,7 @@ elif [ "$TEST" == "unittests" ]; then
 elif [ "$TEST" == "validations" ] || [ "$TEST" == "fetch" ] || [ "$TEST" == "preloaded" ]; then
 
     # Folder paths, relative to parent
-    RULESETFOLDER="${toplevel}/src/chrome/content/rules"
+    RULESETFOLDER="src/chrome/content/rules"
 
     # Go to git repo root; taken from ../test.sh. Note that
     # $GIT_DIR is .git in this case.


### PR DESCRIPTION
#14586 should not pass the fetch-test. IMHO, we should assume all tests are running from `${toplevel}` and use relative path everywhere.

cc @Hainish @jeremyn @J0WI `preload` and `fetch-test` is not running. 