### PR TITLE
Extend duplicates check to rulesets with different platforms

### DIFF
--- a/test/validations/special/duplicate-whitelist-cleanup.sh
+++ b/test/validations/special/duplicate-whitelist-cleanup.sh
@@ -4,7 +4,7 @@ TMPFILE=`mktemp /tmp/buffer.XXXXXXXX`
 trap 'rm "$TMPFILE"' EXIT
 
 for host in `cat test/validations/special/duplicate-whitelist.txt`; do
-    REPEATS=`grep -F "target host=\"$host\"" src/chrome/content/rules/*.xml | wc -l`
+    REPEATS=`egrep -l "<target\s+host=\s*\"$host\"\s*/>" src/chrome/content/rules/*.xml | wc -l`
     if [ $REPEATS -gt 1 ]; then
         echo $host
     fi

--- a/test/validations/special/duplicate-whitelist.txt
+++ b/test/validations/special/duplicate-whitelist.txt
@@ -9,7 +9,6 @@ www1.arun.gov.uk
 mailing.channel4.com
 training.citrix.com
 consumerreports.org
-c-spanvideo.org
 dell.com
 www.dell.com
 investors.demandware.com
@@ -74,7 +73,6 @@ www2.scribblelive.com
 sparxtrading.com
 suppliesfordreams.org
 www.techrepublic.com
-tesco.com
 thefederalistpapers.org
 thompsonhotels.com
 ti.com

--- a/test/validations/special/run.py
+++ b/test/validations/special/run.py
@@ -180,24 +180,18 @@ for filename in filenames:
             failure = 1
             fail("%s failed test: %s" % (filename, test.__doc__))
 
-    platform_list = xpath_ruleset_platform(tree)
-    if len(platform_list) == 0:
-        platform = ''
-    else:
-        platform = platform_list[0]
-
     targets = xpath_host(tree)
     for target in targets:
-        host_counter.update([(target, platform)])
+        host_counter.update([target])
 
 
-for (host, platform), count in host_counter.most_common():
+for host, count in host_counter.most_common():
     if count > 1:
         if host in duplicate_allowed_list:
-            warn("Whitelisted hostname %s with platform '%s' shows up in %d different rulesets." % (host, platform, count))
+            warn("Whitelisted hostname %s shows up in %d different rulesets." % (host, count))
         else:
             failure = 1
-            fail("Hostname %s with platform '%s' shows up in %d different rulesets." % (host, platform, count))
+            fail("Hostname %s shows up in %d different rulesets." % (host, count))
     if not is_valid_target_host(host):
         failure = 1
         fail("%s failed: %s" % (host, is_valid_target_host.__doc__))


### PR DESCRIPTION
See https://github.com/EFForg/https-everywhere/issues/11440 for context (fix #11440).

I would like to get this merged when possible because @cschanaj [statistics](https://github.com/EFForg/https-everywhere/wiki/Ruleset-Statistics) show that duplicate targets count increases (even though I regularly remove entries) and I don't think this is really intended. It is probably more of an oversight from contributors.

I am not super happy with the current clean up script but after giving it some thought, I don't think it is worth fixing it because I would like to see this whitelist totally removed at some point.