### PR TITLE
Remove bcvs.ch subdomains from kantonalbanken.xml

### DIFF
--- a/src/chrome/content/rules/kantonalbanken.xml
+++ b/src/chrome/content/rules/kantonalbanken.xml
@@ -33,8 +33,6 @@ Fetch error: http://tradedirect.ch/ => https://tradedirect.ch/: (51, "SSL: no al
 	<target host="*.bcn.ch"/>
 	<target host="bcv.ch"/>
 	<target host="*.bcv.ch"/>
-	<target host="bcvs.ch"/>
-	<target host="*.bcvs.ch"/>
 	<target host="bekb.ch"/>
 	<target host="*.bekb.ch"/>
 	<target host="bkb.ch"/>
@@ -92,10 +90,6 @@ Fetch error: http://tradedirect.ch/ => https://tradedirect.ch/: (51, "SSL: no al
 	<test url="http://bcv.ch/" />
 	<test url="http://www.bcv.ch/" />
 	<test url="http://structures.bvc.ch/" />
-	<test url="http://bcvs.ch/" />
-	<test url="http://www.bcvs.ch/" />
-	<test url="http://art.bcvs.ch/" />
-	<test url="http://mobile.bcvs.ch/" />
 	<test url="http://bekb.ch/" />
 	<test url="http://www.bekb.ch/" />
 	<test url="http://banking.bekb.ch/" />
@@ -181,7 +175,6 @@ Fetch error: http://tradedirect.ch/ => https://tradedirect.ch/: (51, "SSL: no al
 	<exclusion pattern="http://chart\.bancastato\.ch"/>
 	<exclusion pattern="http://test\.bcf\.ch"/>
 	<exclusion pattern="http://structures\.bvc\.ch"/>
-	<exclusion pattern="http://art\.bcvs\.ch"/>
 	<exclusion pattern="http://grow\.gkb\.ch/"/>
 	<exclusion pattern="http://www\.mobile\.gkb\.ch"/>
 	<exclusion pattern="http://mobile\.(gkb|glkb|nkb|owkb|sgkb|tkb)\.ch"/>
@@ -191,9 +184,9 @@ Fetch error: http://tradedirect.ch/ => https://tradedirect.ch/: (51, "SSL: no al
 	<exclusion pattern="http://kredit\.tkb\.ch/"/>
 	<exclusion pattern="http://mail\.yourmoney\.ch"/>
 
-	<securecookie host="^(?:.*\.)?(bancastato|bcf|bcge|bcj|bcn|bcv|bcvs|bekb|bkb|blkb|gkb|glkb|lukb|nkb|owkb|sgkb|shkb|szkb|tkb|urkb|yourmoney|zkb|zugerkb).ch$" name=".+" />
+	<securecookie host="^(?:.*\.)?(bancastato|bcf|bcge|bcj|bcn|bcv|bekb|bkb|blkb|gkb|glkb|lukb|nkb|owkb|sgkb|shkb|szkb|tkb|urkb|yourmoney|zkb|zugerkb).ch$" name=".+" />
 
-	<rule from="^http://(bancastato|bcf|bcge|bcj|bcn|bcv|bcvs|bekb|bkb|blkb|gkb|glkb|lukb|nkb|owkb|sgkb|shkb|szkb|tkb|urkb|yourmoney|zkb|zugerkb)\.ch/"
+	<rule from="^http://(bancastato|bcf|bcge|bcj|bcn|bcv|bekb|bkb|blkb|gkb|glkb|lukb|nkb|owkb|sgkb|shkb|szkb|tkb|urkb|yourmoney|zkb|zugerkb)\.ch/"
 		to="https://www.$1.ch/"/>
 
 	<rule from="^http:"


### PR DESCRIPTION
Domain is already secured in [`Banque_Cantonale_du_Valais.xml`](https://github.com/EFForg/https-everywhere/blob/master/src/chrome/content/rules/Banque_Cantonale_du_Valais.xml)