### PR TITLE
Update https_everywhere_checker/http_client.py, Fix #14365

### DIFF
--- a/test/rules/src/https_everywhere_checker/http_client.py
+++ b/test/rules/src/https_everywhere_checker/http_client.py
@@ -217,15 +217,22 @@ class HTTPFetcher(object):
 				segments.remove('.')
 			while '..' in segments:
 				segments.remove('..')
-			joinedUrlParts = joinedUrlParts._replace(path='/'.join(segments))
+			path = '/'.join(segments)
 
 		# Non-trivial rewrites do not work without a trailing '/'
 		# See https://github.com/EFForg/https-everywhere/issues/14365
-		if path == "":
-			joinedUrlParts = joinedUrlParts._replace(path='/')
+		if path == '':
+			path = '/'
 
-		newUrl = urlparse.urlunparse(joinedUrlParts)
-		return newUrl
+		joinedUrlParts = urlparse.ParseResult(
+			joinedUrlParts.scheme,
+			joinedUrlParts.netloc,
+			path,
+			joinedUrlParts.params,
+			joinedUrlParts.query,
+			joinedUrlParts.fragment,
+		)
+		return joinedUrlParts.geturl()
 		
 	@staticmethod
 	def _doFetch(url, options, platformPath):


### PR DESCRIPTION
Travis failed to follow a non-trivial rewrite because the redirect location lack a trailing `/`. A testing PR is available at #14599. Close #14365. Close #14599 

P.S. This bug should not affect the extension itself.

cc @Hainish @jeremyn 

