### PR TITLE
Add upgrade-insecure-requests to responseHeaders in HTTP Nowhere Mode

### DIFF
--- a/chromium/background.js
+++ b/chromium/background.js
@@ -503,6 +503,20 @@ function onErrorOccurred(details) {
  */
 function onHeadersReceived(details) {
   if (isExtensionEnabled && httpNowhereOn) {
+    for (const idx in details.responseHeaders) {
+      if (details.responseHeaders[idx].name.match(/Content-Security-Policy/i)) {
+        // Existing CSP headers found
+        const value = details.responseHeaders[idx].value;
+
+        // Prepend if no upgrade-insecure-requests directive exists
+        if (!value.match(/upgrade-insecure-requests/i)) {
+          details.responseHeaders[idx].value = "upgrade-insecure-requests; " + value;
+        }
+        return {responseHeaders: details.responseHeaders};
+      }
+    }
+
+    // CSP headers not found
     const upgradeInsecureRequests = {
       name: 'Content-Security-Policy',
       value: 'upgrade-insecure-requests'

--- a/chromium/background.js
+++ b/chromium/background.js
@@ -507,7 +507,7 @@ function onHeadersReceived(details) {
     // See https://github.com/EFForg/https-everywhere/pull/14600#discussion_r168072480
     const uri = new URL(details.url);
     if (uri.hostname.slice(-6) == '.onion') {
-      return {responseHeaders: details.responseHeaders};
+      return {};
     }
 
     for (const idx in details.responseHeaders) {
@@ -518,8 +518,9 @@ function onHeadersReceived(details) {
         // Prepend if no upgrade-insecure-requests directive exists
         if (!value.match(/upgrade-insecure-requests/i)) {
           details.responseHeaders[idx].value = "upgrade-insecure-requests; " + value;
+          return {responseHeaders: details.responseHeaders};
         }
-        return {responseHeaders: details.responseHeaders};
+        return {};
       }
     }
 
@@ -529,8 +530,9 @@ function onHeadersReceived(details) {
       value: 'upgrade-insecure-requests'
     }
     details.responseHeaders.push(upgradeInsecureRequests);
+    return {responseHeaders: details.responseHeaders};
   }
-  return {responseHeaders: details.responseHeaders};
+  return {};
 }
 
 // Registers the handler for requests

--- a/chromium/background.js
+++ b/chromium/background.js
@@ -502,7 +502,7 @@ function onErrorOccurred(details) {
  * @param details details for the chrome.webRequest (see chrome doc)
  */
 function onHeadersReceived(details) {
-  if (httpNowhereOn) {
+  if (isExtensionEnabled && httpNowhereOn) {
     const upgradeInsecureRequests = {
       name: 'Content-Security-Policy',
       value: 'upgrade-insecure-requests'

--- a/chromium/background.js
+++ b/chromium/background.js
@@ -503,6 +503,13 @@ function onErrorOccurred(details) {
  */
 function onHeadersReceived(details) {
   if (isExtensionEnabled && httpNowhereOn) {
+    // Do not upgrade the .onion requests in HTTP Nowhere Mode,
+    // See https://github.com/EFForg/https-everywhere/pull/14600#discussion_r168072480
+    const uri = new URL(details.url);
+    if (uri.hostname.slice(-6) == '.onion') {
+      return {responseHeaders: details.responseHeaders};
+    }
+
     for (const idx in details.responseHeaders) {
       if (details.responseHeaders[idx].name.match(/Content-Security-Policy/i)) {
         // Existing CSP headers found


### PR DESCRIPTION
cc @Hainish @gloomy-ghost It would be really great to see this in the next release.

TEST CASES
1. CSP Exists, Contains `upgrade-insecure-requests` directive
  - https://www.w3.org/TR/upgrade-insecure-requests/

2. CSP Exists, Not Contains `upgrade-insecure-requests` directive
  - https://www.theguardian.com/international

3. CSP Not Exists, With mixed content
  - https://www.gsu.edu/about/

4. CSP Not Exists, Without mixed content
  - https://www.mozilla.org/

Follow up: Should we modify the CORS headers as well??

Close #8506 Close cschanaj/https-everywhere/pull/13