### PR TITLE
Remove duplicated test urls from JS.org.xml

### DIFF
--- a/src/chrome/content/rules/JS.org.xml
+++ b/src/chrome/content/rules/JS.org.xml
@@ -872,7 +872,6 @@
 	<exclusion pattern="^http://zodiac\.js\.org/" />
 	<exclusion pattern="^http://zombie\.js\.org/" />
 
-	<test url="http://js.org/" />
 	<test url="http://www.js.org/" />
 	<test url="http://100dayz.js.org/" />
 	<test url="http://101.js.org/" />

--- a/src/chrome/content/rules/JS.org.xml
+++ b/src/chrome/content/rules/JS.org.xml
@@ -1566,7 +1566,6 @@
 	<test url="http://repackage.js.org/" />
 	<test url="http://request.js.org/" />
 	<test url="http://reshift.js.org/" />
-	<test url="http://resourceful-redux.js.org/" />
 	<test url="http://restjs.js.org/" />
 	<test url="http://revaluate.js.org/" />
 	<test url="http://riklewis.js.org/" />

--- a/src/chrome/content/rules/JS.org.xml
+++ b/src/chrome/content/rules/JS.org.xml
@@ -1776,7 +1776,6 @@
 	<test url="http://weaver.js.org/" />
 	<test url="http://webpack.js.org/" />
 	<test url="http://weekly.js.org/" />
-	<test url="http://weh.js.org/" />
 	<test url="http://wiki.js.org/" />
 	<test url="http://within.js.org/" />
 	<test url="http://wooyun.js.org/" />
@@ -1795,10 +1794,8 @@
 	<test url="http://youtim.js.org/" />
 	<test url="http://youtube-box.js.org/" />
 	<test url="http://zanyuyu.js.org/" />
-	<test url="http://zaporizhzhya.js.org/" />
 	<test url="http://zazu.js.org/" />
 	<test url="http://zeit.js.org/" />
 	<test url="http://zodiac.js.org/" />
 	<test url="http://zombie.js.org/" />
-	<test url="http://zuck.js.org/" />
 </ruleset>


### PR DESCRIPTION
Honestly, I don't really like this ruleset given the overwhelming amount of `exclusion` which cannot be tested automatically... 