### PR TITLE
Order rulesets by names in popup, Fix #11986

### DIFF
--- a/chromium/popup.js
+++ b/chromium/popup.js
@@ -128,15 +128,17 @@ function toggleEnabledDisabled() {
  * @param tabArray
  */
 function gotTab(activeTab) {
-  sendMessage("get_active_rulesets", activeTab.id, function(rulesets){
-    for (var r in rulesets) {
-      var listDiv = stableRules;
-      if (!rulesets[r].default_state) {
+  sendMessage("get_active_rulesets", activeTab.id, function(rulesets) {
+    for (const ruleset of rulesets) {
+      let listDiv = stableRules;
+
+      if (!ruleset.default_state) {
         listDiv = unstableRules;
       }
-      appendRuleLineToListDiv(rulesets[r], listDiv, activeTab.id);
+      appendRuleLineToListDiv(ruleset, listDiv, activeTab.id);
       listDiv.style.display = 'block';
     }
+
     // Only show the "Add a rule" link if we're on an HTTPS page
     if (/^https:/.test(activeTab.url)) {
       show(e("add-rule-link"));


### PR DESCRIPTION
this PR makes rulesets shown in the popup sorted by names. Close #11986

Test performed (possibly more needed...)
- when extension is disabled, counter not shown
- toggles checkbox to enable/ disable ruleset should works
- counters should display the correct numbers
- rulesets are sorted by name, in both `stableRules` and `unstableRules`

Not sure if this should be introduced in the next release as well (given #14600). 

cc @Hainish @J0WI @jeremyn @Bisaloo 