### PR TITLE
Update tagesschau.de

### DIFF
--- a/src/chrome/content/rules/tagesschau.de.xml
+++ b/src/chrome/content/rules/tagesschau.de.xml
@@ -1,52 +1,33 @@
 <!--
 	Non-functional subdomains:
-		- atlas		(connection refused)
+		atlas (connection refused)
 
-	¹ Hostname mismatch
-
-	Insecure cookies are set for these domains:
-
-		- www.tagesschau.de
-
+	Redirect to Flypsite.com
+		duell.live.tagesschau.de
+		
+	Redirect to tagesschau.de
+		tagesschau24.de
+		www.tagesschau24.de
 
 	Mixed content:
-
-		- Images, on:
-
-			- wetter and www from wetter *
-			- wetter from www *
-
-		- Bugs, on:
-
-			- wetter and www from de.sitestat.com *
-			- wetter and www from gsea.ivwbox.de *
-			- wetter and www from tagessch.ivwbox.de *
-			- www from ts.flyp.tv *
-
-	* Secured by us
+		karten.tagesschau.de
+		wahl.tagesschau.de
+		
+	Invalid Certificate:
+		blog.tagesschau.de
 
 -->
 <ruleset name="tagesschau.de (partial)">
-	<target host=       "tagesschau.de"/>
-	<target host=    "www.tagesschau.de"/>
-	<target host= "karten.tagesschau.de"/>
-	<target host=  "media.tagesschau.de"/>
-	<target host=   "meta.tagesschau.de"/>
-	<target host=   "wahl.tagesschau.de"/>
-	<target host= "wetter.tagesschau.de"/>
-
-
-	<!--	Not secured by server:
-					-->
-	<!--securecookie host="^www\.tagesschau\.de$" name="X-Mapping-[a-z]+$" /-->
+	<target host="www.tagesschau.de"/>
+	<target host="faktenfinder.tagesschau.de"/>
+	<target host="media.tagesschau.de"/>
+	<target host="download.media.tagesschau.de"/>
+	<target host="meta.tagesschau.de"/>
+	<target host="service.tagesschau.de"/>
+	<target host="wetter.tagesschau.de"/>
+	<target host="programm.tagesschau24.de"/>
 
 	<securecookie host="^www\.tagesschau\.de$" name=".+" />
 
-	<rule from="^http://tagesschau\.de/"
-		to="https://www.tagesschau.de/"/>
-
-		<test url="http://www.tagesschau.de/" />
-
-	<rule from="^http:" 
-    		to="https:" />
+	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/tagesschau.de.xml
+++ b/src/chrome/content/rules/tagesschau.de.xml
@@ -1,4 +1,6 @@
 <!--
+	tageschau.de redirect to www version
+	
 	Non-functional subdomains:
 		atlas (connection refused)
 
@@ -38,6 +40,9 @@
 	<target host="programm.tagesschau24.de"/>
 
 	<securecookie host="^www\.tagesschau\.de$" name=".+" />
+	
+	<rule from="^http://tagesschau\.de/"
+		to="https://www.tagesschau.de/"/>
 
 	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/tagesschau.de.xml
+++ b/src/chrome/content/rules/tagesschau.de.xml
@@ -15,6 +15,12 @@
 		
 	Invalid Certificate:
 		blog.tagesschau.de
+		origin.blog.tagesschau.de
+		intern.tagesschau.de
+		korrespondenten.tagesschau.de
+		stat.tagesschau.de
+		rbb24.wahl.tagesschau.de
+		wahlarchiv.tagesschau.de
 
 -->
 <ruleset name="tagesschau.de (partial)">
@@ -23,7 +29,9 @@
 	<target host="media.tagesschau.de"/>
 	<target host="download.media.tagesschau.de"/>
 	<target host="meta.tagesschau.de"/>
+	<target host="prodforum.tagesschau.de"/>
 	<target host="service.tagesschau.de"/>
+	<target host="todo.tagesschau.de"/>
 	<target host="wetter.tagesschau.de"/>
 	<target host="programm.tagesschau24.de"/>
 

--- a/src/chrome/content/rules/tagesschau.de.xml
+++ b/src/chrome/content/rules/tagesschau.de.xml
@@ -13,6 +13,9 @@
 		karten.tagesschau.de
 		wahl.tagesschau.de
 		
+	Invalid Certificate-Chain:
+		todo.tagesschau.de
+		
 	Invalid Certificate:
 		blog.tagesschau.de
 		origin.blog.tagesschau.de
@@ -31,7 +34,6 @@
 	<target host="meta.tagesschau.de"/>
 	<target host="prodforum.tagesschau.de"/>
 	<target host="service.tagesschau.de"/>
-	<target host="todo.tagesschau.de"/>
 	<target host="wetter.tagesschau.de"/>
 	<target host="programm.tagesschau24.de"/>
 

--- a/src/chrome/content/rules/tagesschau.de.xml
+++ b/src/chrome/content/rules/tagesschau.de.xml
@@ -43,6 +43,7 @@
 	
 	<rule from="^http://tagesschau\.de/"
 		to="https://www.tagesschau.de/"/>
+		<test url="http://www.tagesschau.de/" />
 
 	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/tagesschau.de.xml
+++ b/src/chrome/content/rules/tagesschau.de.xml
@@ -17,7 +17,7 @@
 		
 	Invalid Certificate-Chain:
 		todo.tagesschau.de
-		
+
 	Invalid Certificate:
 		blog.tagesschau.de
 		origin.blog.tagesschau.de
@@ -34,7 +34,7 @@
 	<target host="faktenfinder.tagesschau.de"/>
 	<target host="media.tagesschau.de"/>
 	<target host="download.media.tagesschau.de"/>
-	<target host="karten.tageschau.de"/>
+	<target host="karten.tagesschau.de"/>
 	<target host="meta.tagesschau.de"/>
 	<target host="prodforum.tagesschau.de"/>
 	<target host="service.tagesschau.de"/>
@@ -44,7 +44,7 @@
 
 	<securecookie host="^www\.tagesschau\.de$" name=".+" />
 
-    <rule from="^http://tagesschau\.de/"
+	<rule from="^http://tagesschau\.de/"
 		to="https://www.tagesschau.de/"/>
 
 	<rule from="^http:" 

--- a/src/chrome/content/rules/tagesschau.de.xml
+++ b/src/chrome/content/rules/tagesschau.de.xml
@@ -29,13 +29,16 @@
 
 -->
 <ruleset name="tagesschau.de (partial)">
+	<target host="tagesschau.de"/>
 	<target host="www.tagesschau.de"/>
 	<target host="faktenfinder.tagesschau.de"/>
 	<target host="media.tagesschau.de"/>
 	<target host="download.media.tagesschau.de"/>
+	<target host="karten.tageschau.de"/>
 	<target host="meta.tagesschau.de"/>
 	<target host="prodforum.tagesschau.de"/>
 	<target host="service.tagesschau.de"/>
+	<target host="wahl.tagesschau.de"/>
 	<target host="wetter.tagesschau.de"/>
 	<target host="programm.tagesschau24.de"/>
 
@@ -43,8 +46,6 @@
 
     <rule from="^http://tagesschau\.de/"
 		to="https://www.tagesschau.de/"/>
-
-		<test url="http://www.tagesschau.de/" />
 
 	<rule from="^http:" 
 		to="https:" />

--- a/src/chrome/content/rules/tagesschau.de.xml
+++ b/src/chrome/content/rules/tagesschau.de.xml
@@ -1,5 +1,5 @@
 <!--
-	tageschau.de redirect to www version
+	tageschau.de refuse https
 	
 	Non-functional subdomains:
 		atlas (connection refused)
@@ -40,10 +40,13 @@
 	<target host="programm.tagesschau24.de"/>
 
 	<securecookie host="^www\.tagesschau\.de$" name=".+" />
-	
-	<rule from="^http://tagesschau\.de/"
+
+    <rule from="^http://tagesschau\.de/"
 		to="https://www.tagesschau.de/"/>
+
 		<test url="http://www.tagesschau.de/" />
 
-	<rule from="^http:" to="https:" />
+	<rule from="^http:" 
+		to="https:" />
+
 </ruleset>


### PR DESCRIPTION
PR #13790 not mantained anymore. 

Remove Test Url for tagesschau.de in PR #14660