### PR TITLE
rules: Hartwork-Project: Remove forward for binera.de

### DIFF
--- a/src/chrome/content/rules/Hartwork-Project.xml
+++ b/src/chrome/content/rules/Hartwork-Project.xml
@@ -8,8 +8,6 @@
 
 	<securecookie host="^blog\.hartwork\.org$" name=".+" />
 
-	<rule from="^http://(www\.)?binera\.de/"
-		to="https://www.hartwork.org/" />
 	<rule from="^http:"
 		to="https:" />
 


### PR DESCRIPTION
Somewhat related to #8265. binera.de has a dedicated certificate of its own by now and could change to serving its own content at some point.