### PR TITLE
Restore a missing line break

### DIFF
--- a/docs/en_US/development.md
+++ b/docs/en_US/development.md
@@ -93,7 +93,8 @@ workflow down.
 
 First, tell git your name:
 
-    git config --global user.name "Your Name"   git config --global user.email "you@example.com"
+    git config --global user.name "Your Name"
+    git config --global user.email "you@example.com"
 
 Then, get a copy of the 'origin' repository:
 


### PR DESCRIPTION
that seems to have been accidentally deleted at some point since
https://github.com/EFForg/https-docs/commit/236ea7c5f0404a2d0f4b7ac1cf614b555ae734d4
.