### PR TITLE
Add .mailmap file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,3 +1,5 @@
+Aaron Swartz <me@aaronsw.com>                               Aaron Swartz <me@aaronsw.com>
+Aaron Swartz <me@aaronsw.com>                               aaronsw <me@aaronsw.com>
 Dan Auerbach <dan@eff.org>                                  Dan Auerbach <dan@eff.org>
 Dan Auerbach <dan@eff.org>                                  Dan Auerbach <dan@EFFs-MacBook-Pro.local>
 Dan Auerbach <dan@eff.org>                                  Dan Auerbach <dan@EFFs-MacBook-Pro-2.local>

--- a/.mailmap
+++ b/.mailmap
@@ -9,6 +9,9 @@ Jeremy Nation <jeremy@jeremynation.me>                      Jeremy Nation <jerem
 J0WI <J0WI@users.noreply.github.com>                        J0WI <J0WI@users.noreply.github.com>
 J0WI <J0WI@users.noreply.github.com>                        J0WI <sjw@gmx.ch>
 J0WI <J0WI@users.noreply.github.com>                        jowi <sjw@gmx.ch>
+MB <kunjurcca@gmail.com>                                    MB <kunjurcca@gmail.com>
+MB <kunjurcca@gmail.com>                                    MB <loveithateit@users.noreply.github.com>
+MB <kunjurcca@gmail.com>                                    MB <newchain@users.noreply.github.com>
 Micah Lee <micah@eff.org>                                   Micah Lee <micah@eff.org>
 Micah Lee <micah@eff.org>                                   Micah Lee <micah@micahflee.com>
 Micah Lee <micah@eff.org>                                   Micah Lee <micahflee@riseup.net>

--- a/.mailmap
+++ b/.mailmap
@@ -4,6 +4,9 @@ Dan Auerbach <dan@eff.org>                                  Dan Auerbach <dan@EF
 Dan Auerbach <dan@eff.org>                                  Dan Auerbach <dtauerbach@gmail.com>
 Dominyk Tiller <DomT4@users.noreply.github.com>             Dominyk Tiller <DomT4@users.noreply.github.com>
 Dominyk Tiller <DomT4@users.noreply.github.com>             Dominyk Tiller <dominyktiller@gmail.com>
+Jacob Hoffman-Andrews <github@hoffman-andrews.com>          Jacob Hoffman-Andrews <github@hoffman-andrews.com>
+Jacob Hoffman-Andrews <github@hoffman-andrews.com>          jsha <github@hoffman-andrews.com>
+Jacob Hoffman-Andrews <github@hoffman-andrews.com>          Jacob Hoffman-Andrews <jsha@twitter.com>
 Jeremy Nation <jeremy@jeremynation.me>                      Jeremy Nation <jeremy@jeremynation.me>
 Jeremy Nation <jeremy@jeremynation.me>                      Jeremy Nation <jeremyn@users.noreply.github.com>
 J0WI <J0WI@users.noreply.github.com>                        J0WI <J0WI@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1,3 +1,6 @@
+J0WI <J0WI@users.noreply.github.com>                        J0WI <J0WI@users.noreply.github.com>
+J0WI <J0WI@users.noreply.github.com>                        J0WI <sjw@gmx.ch>
+J0WI <J0WI@users.noreply.github.com>                        jowi <sjw@gmx.ch>
 Peter Eckersley <pde@eff.org>                               Peter Eckersley <pde@eff.org> 
 Peter Eckersley <pde@eff.org>                               Peter Eckersley <pde eff org>
 Peter Eckersley <pde@eff.org>                               Peter Eckersley <pde@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -7,3 +7,5 @@ Peter Eckersley <pde@eff.org>                               Peter Eckersley <pde
 Peter Eckersley <pde@eff.org>                               pde <pde@eff-pde>
 sampablokuper (aka modem_down) <sampablokuper@uclmail.net>  <sampablokuper@uclmail.net>
 sampablokuper (aka modem_down) <sampablokuper@uclmail.net>  modem_down <sampablokuper@users.noreply.github.com>
+Seth Schoen <schoen@eff.org>                                Seth Schoen <schoen@eff.org>
+Seth Schoen <schoen@eff.org>                                Seth David Schoen <schoen eff org>

--- a/.mailmap
+++ b/.mailmap
@@ -25,3 +25,6 @@ sampablokuper (aka modem_down) <sampablokuper@uclmail.net>  <sampablokuper@uclma
 sampablokuper (aka modem_down) <sampablokuper@uclmail.net>  modem_down <sampablokuper@users.noreply.github.com>
 Seth Schoen <schoen@eff.org>                                Seth Schoen <schoen@eff.org>
 Seth Schoen <schoen@eff.org>                                Seth David Schoen <schoen eff org>
+Yan <yan@mit.edu>                                           Yan <yan@mit.edu>
+Yan <yan@mit.edu>                                           Yan Zhu <yan@mit.edu>
+Yan <yan@mit.edu>                                           yan <yzhu@yahoo-inc.com>

--- a/.mailmap
+++ b/.mailmap
@@ -2,6 +2,8 @@ Dan Auerbach <dan@eff.org>                                  Dan Auerbach <dan@ef
 Dan Auerbach <dan@eff.org>                                  Dan Auerbach <dan@EFFs-MacBook-Pro.local>
 Dan Auerbach <dan@eff.org>                                  Dan Auerbach <dan@EFFs-MacBook-Pro-2.local>
 Dan Auerbach <dan@eff.org>                                  Dan Auerbach <dtauerbach@gmail.com>
+Dominyk Tiller <DomT4@users.noreply.github.com>             Dominyk Tiller <DomT4@users.noreply.github.com>
+Dominyk Tiller <DomT4@users.noreply.github.com>             Dominyk Tiller <dominyktiller@gmail.com>
 J0WI <J0WI@users.noreply.github.com>                        J0WI <J0WI@users.noreply.github.com>
 J0WI <J0WI@users.noreply.github.com>                        J0WI <sjw@gmx.ch>
 J0WI <J0WI@users.noreply.github.com>                        jowi <sjw@gmx.ch>

--- a/.mailmap
+++ b/.mailmap
@@ -4,6 +4,8 @@ Dan Auerbach <dan@eff.org>                                  Dan Auerbach <dan@EF
 Dan Auerbach <dan@eff.org>                                  Dan Auerbach <dtauerbach@gmail.com>
 Dominyk Tiller <DomT4@users.noreply.github.com>             Dominyk Tiller <DomT4@users.noreply.github.com>
 Dominyk Tiller <DomT4@users.noreply.github.com>             Dominyk Tiller <dominyktiller@gmail.com>
+Jeremy Nation <jeremy@jeremynation.me>                      Jeremy Nation <jeremy@jeremynation.me>
+Jeremy Nation <jeremy@jeremynation.me>                      Jeremy Nation <jeremyn@users.noreply.github.com>
 J0WI <J0WI@users.noreply.github.com>                        J0WI <J0WI@users.noreply.github.com>
 J0WI <J0WI@users.noreply.github.com>                        J0WI <sjw@gmx.ch>
 J0WI <J0WI@users.noreply.github.com>                        jowi <sjw@gmx.ch>

--- a/.mailmap
+++ b/.mailmap
@@ -12,6 +12,11 @@ J0WI <J0WI@users.noreply.github.com>                        jowi <sjw@gmx.ch>
 Micah Lee <micah@eff.org>                                   Micah Lee <micah@eff.org>
 Micah Lee <micah@eff.org>                                   Micah Lee <micah@micahflee.com>
 Micah Lee <micah@eff.org>                                   Micah Lee <micahflee@riseup.net>
+numismatika <numismatika@users.noreply.github.com>          numismatika <numismatika@users.noreply.github.com>
+numismatika <numismatika@users.noreply.github.com>          Numismatika <anonymous@nowhere.com>
+numismatika <numismatika@users.noreply.github.com>          Numismatika <someone@anywhere.com>
+numismatika <numismatika@users.noreply.github.com>          Numismatika <anyone@nowhere.com>
+numismatika <numismatika@users.noreply.github.com>          Numi Smatika <numismatika-everywhere@eclipso.ch>
 Peter Eckersley <pde@eff.org>                               Peter Eckersley <pde@eff.org> 
 Peter Eckersley <pde@eff.org>                               Peter Eckersley <pde eff org>
 Peter Eckersley <pde@eff.org>                               Peter Eckersley <pde@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1,3 +1,7 @@
+Dan Auerbach <dan@eff.org>                                  Dan Auerbach <dan@eff.org>
+Dan Auerbach <dan@eff.org>                                  Dan Auerbach <dan@EFFs-MacBook-Pro.local>
+Dan Auerbach <dan@eff.org>                                  Dan Auerbach <dan@EFFs-MacBook-Pro-2.local>
+Dan Auerbach <dan@eff.org>                                  Dan Auerbach <dtauerbach@gmail.com>
 J0WI <J0WI@users.noreply.github.com>                        J0WI <J0WI@users.noreply.github.com>
 J0WI <J0WI@users.noreply.github.com>                        J0WI <sjw@gmx.ch>
 J0WI <J0WI@users.noreply.github.com>                        jowi <sjw@gmx.ch>

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,2 @@
+sampablokuper (aka modem_down) <sampablokuper@uclmail.net> <sampablokuper@uclmail.net>
+sampablokuper (aka modem_down) <sampablokuper@uclmail.net> modem_down <sampablokuper@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -7,6 +7,9 @@ Dominyk Tiller <DomT4@users.noreply.github.com>             Dominyk Tiller <domi
 J0WI <J0WI@users.noreply.github.com>                        J0WI <J0WI@users.noreply.github.com>
 J0WI <J0WI@users.noreply.github.com>                        J0WI <sjw@gmx.ch>
 J0WI <J0WI@users.noreply.github.com>                        jowi <sjw@gmx.ch>
+Micah Lee <micah@eff.org>                                   Micah Lee <micah@eff.org>
+Micah Lee <micah@eff.org>                                   Micah Lee <micah@micahflee.com>
+Micah Lee <micah@eff.org>                                   Micah Lee <micahflee@riseup.net>
 Peter Eckersley <pde@eff.org>                               Peter Eckersley <pde@eff.org> 
 Peter Eckersley <pde@eff.org>                               Peter Eckersley <pde eff org>
 Peter Eckersley <pde@eff.org>                               Peter Eckersley <pde@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1,2 +1,6 @@
-sampablokuper (aka modem_down) <sampablokuper@uclmail.net> <sampablokuper@uclmail.net>
-sampablokuper (aka modem_down) <sampablokuper@uclmail.net> modem_down <sampablokuper@users.noreply.github.com>
+Peter Eckersley <pde@eff.org>                               Peter Eckersley <pde@eff.org> 
+Peter Eckersley <pde@eff.org>                               Peter Eckersley <pde eff org>
+Peter Eckersley <pde@eff.org>                               Peter Eckersley <pde@users.noreply.github.com>
+Peter Eckersley <pde@eff.org>                               pde <pde@eff-pde>
+sampablokuper (aka modem_down) <sampablokuper@uclmail.net>  <sampablokuper@uclmail.net>
+sampablokuper (aka modem_down) <sampablokuper@uclmail.net>  modem_down <sampablokuper@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -15,6 +15,8 @@ J0WI <J0WI@users.noreply.github.com>                        jowi <sjw@gmx.ch>
 MB <kunjurcca@gmail.com>                                    MB <kunjurcca@gmail.com>
 MB <kunjurcca@gmail.com>                                    MB <loveithateit@users.noreply.github.com>
 MB <kunjurcca@gmail.com>                                    MB <newchain@users.noreply.github.com>
+MB <kunjurcca@gmail.com>                                    loveithateit <loveithateit@users.noreply.github.com>
+MB <kunjurcca@gmail.com>                                    2d1 <kunjurcca@gmail.com>
 Micah Lee <micah@eff.org>                                   Micah Lee <micah@eff.org>
 Micah Lee <micah@eff.org>                                   Micah Lee <micah@micahflee.com>
 Micah Lee <micah@eff.org>                                   Micah Lee <micahflee@riseup.net>


### PR DESCRIPTION
In addition to making `git shortlog` output more comprehensible, a `.mailmap` file should make it easier, in future, to do things like create a list of contributors, or contact contributors if relicensing is ever needed.

This is just a start; there is probably more deduplication that could be added.