### PR TITLE
[Zerodayinitiative.com] supports HTTPS completely

### DIFF
--- a/src/chrome/content/rules/Trend_Micro.xml
+++ b/src/chrome/content/rules/Trend_Micro.xml
@@ -6,6 +6,7 @@
 
 		- Trend_Micro.de.xml
 		- Trend_Micro.eu.xml
+		- Zero_Day_Initiative.com.xml
 
 
 	CDN buckets:

--- a/src/chrome/content/rules/Zero_Day_Initiative.com.xml
+++ b/src/chrome/content/rules/Zero_Day_Initiative.com.xml
@@ -1,3 +1,7 @@
+<!--
+		For other Trend Micro coverage, see Trend_Micro.xml. 
+-->
+
 <ruleset name="Zero Day Initiative.com">
 
 	<target host="zerodayinitiative.com" />

--- a/src/chrome/content/rules/Zero_Day_Initiative.com.xml
+++ b/src/chrome/content/rules/Zero_Day_Initiative.com.xml
@@ -1,25 +1,8 @@
-<!--
-	For other Hewlett-Packard coverage, see Hewlett-Packard.xml.
-
-
-	Some pages redirect to http.
-
--->
-<ruleset name="Zero Day Initiative.com (partial)">
+<ruleset name="Zero Day Initiative.com">
 
 	<target host="zerodayinitiative.com" />
-	<target host="www.zerodayinitiative.com" />
-		<!--
-			Redirect to http:
-						-->
-		<!--exclusion pattern="^http://(www\.)?zerodayinitiative\.com/+($|\?)" /-->
-		<!--
-			Exceptions:
-					-->
-		<!--exclusion pattern="^http://(www\.)?zerodayinitiative\.com/+(css/|favicon\.ico|img/|portal($|[?/]))" /-->
+	<target host="*.zerodayinitiative.com" />
 
-
-	<rule from="^http://(www\.)?zerodayinitiative\.com/(?=css/|favicon\.ico|img/|portal(?:$|[?/]))"
-		to="https://$1zerodayinitiative.com/" />
+	<rule from="^http:" to="https:"/>
 
 </ruleset>

--- a/src/chrome/content/rules/Zero_Day_Initiative.com.xml
+++ b/src/chrome/content/rules/Zero_Day_Initiative.com.xml
@@ -1,5 +1,5 @@
 <!--
-		For other Trend Micro coverage, see Trend_Micro.xml. 
+	For other Trend Micro coverage, see Trend_Micro.xml. 
 -->
 
 <ruleset name="Zero Day Initiative.com">

--- a/src/chrome/content/rules/Zero_Day_Initiative.com.xml
+++ b/src/chrome/content/rules/Zero_Day_Initiative.com.xml
@@ -5,7 +5,7 @@
 <ruleset name="Zero Day Initiative.com">
 
 	<target host="zerodayinitiative.com" />
-	<target host="*.zerodayinitiative.com" />
+	<target host="www.zerodayinitiative.com" />
 
 	<rule from="^http:" to="https:"/>
 


### PR DESCRIPTION
The ZDI (https://zerodayinitiative.com) no longer redirects HTTPS to HTTP, and supports HSTS, but not preloaded yet. This PR updates the rulesets accordingly.

https://www.ssllabs.com/ssltest/analyze.html?d=zerodayinitiative.com

Also the ZDI is now operated by Trend Micro Security. HP sold it out 2 years ago.