### PR TITLE
[Mozilla.org] Update working or non-existent hosts

### DIFF
--- a/src/chrome/content/rules/Mozilla.xml
+++ b/src/chrome/content/rules/Mozilla.xml
@@ -160,6 +160,7 @@
 		- planet
 		- pulse
 		- quality
+		- release
 		- releases
 		- reps
 		- securitywiki
@@ -168,6 +169,7 @@
 		- status
 		- studentreps
 		- support
+		- symbols
 		- talkback-public	(→ crash-stats.mozilla.com)
 		- telemetry
 		- tbpl
@@ -222,20 +224,16 @@
 
 				https://mail1.eff.org/pipermail/https-everywhere-rules/2013-June/001635.html
 													-->
-		<exclusion pattern="^http://(europe|browserquest|trychooser\.pub\.build|bzr|(?!image)\w+\.e|graphs|iot|mig|release|sfx-images|symbolapi|symbols|alerts\.telemetry|w(ebsite|ww)-archive)\.mozilla\.org/" />
+		<exclusion pattern="^http://(europe|browserquest|trychooser\.pub\.build|bzr|(?!image)\w+\.e|iot|mig|symbolapi|alerts\.telemetry|w(ebsite|ww)-archive)\.mozilla\.org/" />
 
 			<test url="http://europe.mozilla.org/" />
 			<test url="http://browserquest.mozilla.org/" />
 			<test url="http://bzr.mozilla.org/" />
 			<test url="http://trychooser.pub.build.mozilla.org/" />
 			<test url="http://click.e.mozilla.org/" />
-			<test url="http://graphs.mozilla.org/" />
 			<test url="http://iot.mozilla.org/" />
 			<test url="http://mig.mozilla.org/" />
-			<test url="http://release.mozilla.org/" />
-			<test url="http://sfx-images.mozilla.org/" />
-			<test url="http://symbolapi.mozilla.org/" />
-			<test url="http://symbols.mozilla.org/" />
+			<test url="http://symbolapi.mozilla.org/" />			
 			<test url="http://alerts.telemetry.mozilla.org/" />
 			<test url="http://website-archive.mozilla.org/" />
 			<test url="http://www-archive.mozilla.org/" />
@@ -249,7 +247,6 @@
 		<test url="http://careers.mozilla.org/" />
 		<test url="http://developer.mozilla.org/" />
 		<test url="http://dxr.mozilla.org/" />
-		<test url="http://europe.mozilla.org/" />
 		<test url="http://ftp.mozilla.org/" />
 		<test url="http://git.mozilla.org/" />
 		<test url="http://hg.mozilla.org/" />
@@ -257,10 +254,12 @@
 		<test url="http://lists.mozilla.org/" />
 		<test url="http://planet.mozilla.org/" />
 		<test url="http://pulse.mozilla.org/" />
+		<test url="http://release.mozilla.org/" />
 		<test url="http://releases.mozilla.org/" />
 		<test url="http://sendto.mozilla.org/page/-/ssou-logos/twitter-bird-white-on-blue.png" />
 		<test url="http://start.mozilla.org/" />
 		<test url="http://support.mozilla.org/" />
+		<test url="http://symbols.mozilla.org/" />
 		<test url="http://telemetry.mozilla.org/" />
 		<test url="http://wiki.mozilla.org/" />
 		<test url="http://videos.mozilla.org/" />

--- a/src/chrome/content/rules/Mozilla.xml
+++ b/src/chrome/content/rules/Mozilla.xml
@@ -51,7 +51,6 @@
 
 			- bonsai ³
 			- browserquest ³
-			- view.e ¹
 			- graphs ³
 			- krakenbenchmark ³
 			- mig ³
@@ -60,7 +59,6 @@
 			- website-archive ³
 			- www-archive ³
 
-	¹ Dropped
 	³ Refused
 	* https://github.com/EFForg/https-everywhere/issues/1374
 
@@ -224,7 +222,7 @@
 
 				https://mail1.eff.org/pipermail/https-everywhere-rules/2013-June/001635.html
 													-->
-		<exclusion pattern="^http://(europe|browserquest|trychooser\.pub\.build|bzr|(?!image)\w+\.e|iot|mig|symbolapi|alerts\.telemetry|w(ebsite|ww)-archive)\.mozilla\.org/" />
+		<exclusion pattern="^http://(europe|browserquest|trychooser\.pub\.build|bzr|iot|mig|symbolapi|alerts\.telemetry|w(ebsite|ww)-archive)\.mozilla\.org/" />
 
 			<test url="http://europe.mozilla.org/" />
 			<test url="http://browserquest.mozilla.org/" />
@@ -245,11 +243,13 @@
 		<test url="http://archive.mozilla.org/" />
 		<test url="http://bugzilla.mozilla.org/" />
 		<test url="http://careers.mozilla.org/" />
+		<test url="http://click.e.mozilla.org/" />
 		<test url="http://developer.mozilla.org/" />
 		<test url="http://dxr.mozilla.org/" />
 		<test url="http://ftp.mozilla.org/" />
 		<test url="http://git.mozilla.org/" />
 		<test url="http://hg.mozilla.org/" />
+		<test url="http://image.e.mozilla.org/" />
 		<test url="http://krakenbenchmark.mozilla.org/" />
 		<test url="http://lists.mozilla.org/" />
 		<test url="http://planet.mozilla.org/" />
@@ -263,6 +263,7 @@
 		<test url="http://telemetry.mozilla.org/" />
 		<test url="http://wiki.mozilla.org/" />
 		<test url="http://videos.mozilla.org/" />
+		<test url="http://view.e.mozilla.org/" />
 		<test url="http://www.mozilla.org/" />
 
 

--- a/src/chrome/content/rules/Mozilla.xml
+++ b/src/chrome/content/rules/Mozilla.xml
@@ -51,10 +51,7 @@
 
 			- bonsai ³
 			- browserquest ³
-			- graphs ³
-			- krakenbenchmark ³
 			- mig ³
-			- sfx-images ³		(banners)
 			- alerts.telemetry *
 			- website-archive ³
 			- www-archive ³
@@ -69,7 +66,6 @@
 		- bzr ²
 		- iot ²
 		- labs ¹
-		- release ²
 		- talkback-public ⁴
 
 	¹ https://labs.mozilla.org refuses connections.
@@ -228,7 +224,6 @@
 			<test url="http://browserquest.mozilla.org/" />
 			<test url="http://bzr.mozilla.org/" />
 			<test url="http://trychooser.pub.build.mozilla.org/" />
-			<test url="http://click.e.mozilla.org/" />
 			<test url="http://iot.mozilla.org/" />
 			<test url="http://mig.mozilla.org/" />
 			<test url="http://symbolapi.mozilla.org/" />			


### PR DESCRIPTION
These domains now support HTTPS: https://symbols.mozilla.org, https://release.mozilla.org, https://view.e.mozilla.org, https://click.e.mozilla.org
These domains no longer exist: http://graphs.mozilla.org, http://sfx-images.mozilla.org