### PR TITLE
[Wikimedia.xml] Remove blog.wikimedia.de from exclusion

### DIFF
--- a/src/chrome/content/rules/Wikimedia.xml
+++ b/src/chrome/content/rules/Wikimedia.xml
@@ -72,6 +72,7 @@
 		<test url="http://ffw.wikimedia.de/" />
 		<test url="http://wke.wikimedia.de/" />
 		<test url="http://redmine.wikimedia.de/" />
+		<test url="http://blog.wikimedia.de/" />
 
 	<target host="wikimedia.es" />
 	<target host="*.wikimedia.es" />

--- a/src/chrome/content/rules/Wikimedia.xml
+++ b/src/chrome/content/rules/Wikimedia.xml
@@ -132,8 +132,8 @@
 	<rule from="^http://wikimedia\.cz/"
 		to="https://www.wikimedia.cz/" />
 	
-	<rule from="^http://www.wikimedia.org.uk/"
-		to="https://wikimedia.org.uk/" />
+	<rule from="^http://www\.wikimedia\.org\.uk/"
+		to="https://wikimedia\.org\.uk/" />
 
 	<rule from="^http:"
 		to="https:" />

--- a/src/chrome/content/rules/Wikimedia.xml
+++ b/src/chrome/content/rules/Wikimedia.xml
@@ -1,10 +1,5 @@
 
 <!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://donate.wikimedia.org.uk/ => https://donate.wikimedia.org.uk/: (60, 'SSL certificate problem: unable to get local issuer certificate')
-Fetch error: http://office.wikimedia.org.uk/ => https://office.wikimedia.org.uk/: (60, 'SSL certificate problem: unable to get local issuer certificate')
-Fetch error: http://tech.wikimedia.org.uk/ => https://tech.wikimedia.org.uk/: (60, 'SSL certificate problem: unable to get local issuer certificate')
-Fetch error: http://www.wikimedia.org.uk/ => https://www.wikimedia.org.uk/: (56, 'SSL read: error:00000000:lib(0):func(0):reason(0), errno 104')
 
 	Wikipedia and other Wikimedia Foundation wikis previously had no real HTTPS support, and
 	URLs had to be rewritten to https://secure.wikimedia.org/$wikitype/$language/ . This is no
@@ -135,6 +130,9 @@ Fetch error: http://www.wikimedia.org.uk/ => https://www.wikimedia.org.uk/: (56,
 
 	<rule from="^http://wikimedia\.cz/"
 		to="https://www.wikimedia.cz/" />
+	
+	<rule from="^http://www.wikimedia.org.uk/"
+		to="https://wikimedia.org.uk/" />
 
 	<rule from="^http:"
 		to="https:" />

--- a/src/chrome/content/rules/Wikimedia.xml
+++ b/src/chrome/content/rules/Wikimedia.xml
@@ -66,9 +66,6 @@ Fetch error: http://www.wikimedia.org.uk/ => https://www.wikimedia.org.uk/: (56,
 
 	<target host="wikimedia.de" />
 	<target host="*.wikimedia.de" />
-		<!-- mixed content issues on blog.wikimedia.de -->
-		<exclusion pattern="^http://blog\.wikimedia\.de/" />
-			<test url="http://blog.wikimedia.de/" />
 		<!-- mismatch on tools.wikimedia.de -->
 		<exclusion pattern="^http://tools\.wikimedia\.de/" />
 			<test url="http://tools.wikimedia.de/" />

--- a/src/chrome/content/rules/Wikimedia.xml
+++ b/src/chrome/content/rules/Wikimedia.xml
@@ -133,7 +133,7 @@
 		to="https://www.wikimedia.cz/" />
 	
 	<rule from="^http://www\.wikimedia\.org\.uk/"
-		to="https://wikimedia\.org\.uk/" />
+		to="https://wikimedia.org.uk/" />
 
 	<rule from="^http:"
 		to="https:" />

--- a/src/chrome/content/rules/Wikimedia.xml
+++ b/src/chrome/content/rules/Wikimedia.xml
@@ -24,7 +24,7 @@ Fetch error: http://www.wikimedia.org.uk/ => https://www.wikimedia.org.uk/: (56,
 
 
 -->
-<ruleset name="Wikimedia" default_off='failed ruleset test'>
+<ruleset name="Wikimedia">
 
 	<target host="enwp.org" />
 	<target host="frwp.org" />


### PR DESCRIPTION
https://blog.wikimedia.de/ probably no longer has mixed content. It uses HTTPS links to blog pages on its home page, e.g. https://blog.wikimedia.de/2018/03/01/neues-urheberrecht-fuer-bildung-eine-erleichterung-fuer-die-praxis/.