### PR TITLE
[Google.xml] Google.cn no longer redirects to http

### DIFF
--- a/src/chrome/content/rules/Google.xml
+++ b/src/chrome/content/rules/Google.xml
@@ -2,8 +2,6 @@
 	This ruleset only covers (www.)?google.tld
 	For other Google coverage, see GoogleServices.xml
 
-	*** Google Images related paths are covered in GoogleImages.xml ***
-
 -->
 
 <ruleset name="Google">

--- a/src/chrome/content/rules/Google.xml
+++ b/src/chrome/content/rules/Google.xml
@@ -4,10 +4,6 @@
 
 	*** Google Images related paths are covered in GoogleImages.xml ***
 
-	Problematic domains:
-		- google.cn *
-	
-	* Redirects to HTTP outside CN (https://github.com/EFForg/https-everywhere/issues/2747)
 -->
 
 <ruleset name="Google">
@@ -40,6 +36,8 @@
 	<test url="http://google.co.za/" />
 	<test url="http://www.google.co.za/" />
 
+	<test url="http://google.cn/" />
+	<test url="http://www.google.cn/" />
 	<test url="http://google.co/" />
 	<test url="http://www.google.co/" />
 	<test url="http://google.fr/" />
@@ -103,11 +101,6 @@
 	<test url="http://www.google.com/search?q=test&amp;tbm=isch" />
 	<test url="http://www.google.com/search?q=foobar&amp;tbm=isch" />
 	<test url="http://www.google.com/search?q=foobar&amp;tbm=isch&amp;something=baz" />
-
-
-	<!-- https://github.com/EFForg/https-everywhere/issues/2747 -->
-	<!--<exclusion pattern="^http://(www\.)?google\.cn" />-->
-
 
 	<securecookie host=".+" name=".+" />
 


### PR DESCRIPTION
#2747 mentions that https://www.google.cn and https://google.cn don't support HTTPS outside China. It seems this has been fixed. https://google.cn still redirects to http://www.google.cn, but no circular redirects at least.

* https://www.ssllabs.com/ssltest/analyze.html?d=google.cn&s=216.58.194.163
* https://www.ssllabs.com/ssltest/analyze.html?d=www.google.cn&s=74.125.135.94

Fixes #2747

Also deleted a comment about GoogleImages.xml. It was deleted in #12555.