### PR TITLE
Modify the platform check in test/script.py

### DIFF
--- a/test/script.py
+++ b/test/script.py
@@ -35,11 +35,9 @@ if sys.argv[1] == "Chrome":
     # Find the path to chromedriver
     chromedriver_path = "chromedriver"
     if sys.platform.startswith("linux"):
-        if 'Ubuntu' in platform.linux_distribution():
+        if 'Ubuntu' in platform.uname().version:
             chromedriver_path = "/usr/lib/chromium-browser/chromedriver"
-        elif 'debian' in platform.linux_distribution():
-            #Debian is lowercase when platform.linux_distribution() is used.
-            #This is not a mistake.
+        elif 'Debian' in platform.uname().version:
             chromedriver_path = "/usr/lib/chromium/chromedriver"
 
     try:

--- a/test/script.py
+++ b/test/script.py
@@ -10,7 +10,7 @@
 # of linux is required for the script to run correctly as well.
 # Otherwise, use pyvirtualdisplay.
 
-import sys, os, platform, time
+import sys, os, time
 from selenium import webdriver
 from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.firefox.firefox_binary import FirefoxBinary

--- a/test/script.py
+++ b/test/script.py
@@ -35,10 +35,14 @@ if sys.argv[1] == "Chrome":
     # Find the path to chromedriver
     chromedriver_path = "chromedriver"
     if sys.platform.startswith("linux"):
-        if 'Ubuntu' in platform.uname().version:
-            chromedriver_path = "/usr/lib/chromium-browser/chromedriver"
-        elif 'Debian' in platform.uname().version:
-            chromedriver_path = "/usr/lib/chromium/chromedriver"
+        locations = (
+            "/usr/lib/chromium-browser/chromedriver",
+            "/usr/lib/chromium/chromedriver",
+        )
+        for location in locations:
+            if os.path.isfile(location):
+                chromedriver_path = location
+                break
 
     try:
         # First argument is optional, if not specified will search path.


### PR DESCRIPTION
This pull request changes how `test/script.py` identifies the platform when setting `chromedriver_path` on a Linux system. There are two reasons for this change:

* The technical reason is that `platform.linux_distribution` [is deprecated](https://docs.python.org/3.6/library/platform.html#platform.linux_distribution) as of Python 3.5.

* The actual reason is that `platform.linux_distribution` [doesn't correctly identify Ubuntu](https://stackoverflow.com/a/33997262) if you have built Python 3.6 from source, because you are, for example, using Ubuntu 16.04. As the link mentions, the Ubuntu developers patch the `platform` module that Ubuntu provides so it works as expected on Ubuntu. With the `platform` module built from source, the HTTPS Everywhere Chromium test process looks for `chromedriver` in the wrong place, and fails.