### PR TITLE
add ruleset dragongoserver.net

### DIFF
--- a/src/chrome/content/rules/Dragongoserver.net.xml
+++ b/src/chrome/content/rules/Dragongoserver.net.xml
@@ -1,0 +1,8 @@
+<ruleset name="Dragongoserver.net">
+	<target host="www.dragongoserver.net" />
+
+	<rule from="^http:" to="https:" />
+
+	<test url="http://www.dragongoserver.net/index.php" />
+</ruleset>
+


### PR DESCRIPTION
This PR adds a rule for https://www.dragongoserver.net. To be honest, given the lack of a suitable dev-environment at the moment, currently untested, though I hope the eight lines are mostly acceptable as they are.

BR