### PR TITLE
fix orf.at rules for TEST=fetch; add rule for currently-broken teletext.orf.at

### DIFF
--- a/src/chrome/content/rules/ORF.at.xml
+++ b/src/chrome/content/rules/ORF.at.xml
@@ -26,6 +26,7 @@
 		
 	Cert expired:
 		- oe3verkehr.orf.at
+		- content.orf.at
 
 	Cert mismatch:
 		- burgenlandkalender.orf.at

--- a/src/chrome/content/rules/ORF.at.xml
+++ b/src/chrome/content/rules/ORF.at.xml
@@ -212,6 +212,7 @@
 	<target host="sms.orf.at" />
 	<target host="speedy.orf.at" />
 	<target host="sts.orf.at" />
+	<target host="teletext.orf.at" />
 	<target host="thredbo.orf.at" />
 	<target host="tickets.orf.at" />
 	<target host="tobago.orf.at" />

--- a/src/chrome/content/rules/ORF.at.xml
+++ b/src/chrome/content/rules/ORF.at.xml
@@ -58,15 +58,24 @@
 		- api-tvthek
 		- averell
 		- backstage
+		- bernard
+		- bianca
+		- brain
 		- brava
+		- clyde
 		- cook
 		- dalton
+		- dancingstars
 		- der
+		- drei
+		- echtjetzt
 		- extra
 		- files
 		- files2
 		- fm4
 		- go
+		- gutenmorgen
+		- help
 		- insider
 		- iptv
 		- jack
@@ -83,6 +92,7 @@
 		- oe3
 		- oe3dabei
 		- onepager
+		- pinky
 		- publikumsrat
 		- songcontest
 		- sport
@@ -91,9 +101,12 @@
 		- suche
 		- tonga
 		- totoya
+		- tube
+		- tv
 		- tv-thek
 		- tvportal
 		- tvthek
+		- unterwegs
 		- video
 		- webport7
 		- werbung
@@ -118,9 +131,7 @@
 	<target host="appfeeds.orf.at" />
 	<target host="audioapi.orf.at" />
 	<target host="autodiscover.orf.at" />
-	<target host="bernard.orf.at" />
 	<target host="bert.orf.at" />
-	<target host="bianca.orf.at" />
 	<target host="bikini.orf.at" />
 	<target host="bits.orf.at" />
 	<target host="boa.orf.at" />
@@ -128,23 +139,17 @@
 	<target host="book.orf.at" />
 	<target host="booking.orf.at" />
 	<target host="bpo.orf.at" />
-	<target host="brain.orf.at" />
 	<target host="buergerforumdb.orf.at" />
 	<target host="cloud.orf.at" />
-	<target host="clyde.orf.at" />
-	<target host="content.orf.at" />
 	<target host="crm.orf.at" />
 	<target host="crmtest.orf.at" />
 	<target host="crmweb.orf.at" />
 	<target host="ctest.orf.at" />
-	<target host="dancingstars.orf.at" />
 	<target host="debatte.orf.at" />
 	<target host="dev.orf.at" />
 	<target host="developer.orf.at" />
 	<target host="dialin.orf.at" />
 	<target host="digital.orf.at" />
-	<target host="drei.orf.at" />
-	<target host="echtjetzt.orf.at" />
 	<target host="ecommerce.orf.at" />
 	<target host="emm.orf.at" />
 	<target host="enterprise.orf.at" />
@@ -160,9 +165,7 @@
 	<target host="gonzales.orf.at" />
 	<target host="gromit.orf.at" />
 	<target host="guns.orf.at" />
-	<target host="gutenmorgen.orf.at" />
 	<target host="harris.orf.at" />
-	<target host="help.orf.at" />
 	<target host="hermes.orf.at" />
 	<target host="ibiza.orf.at" />
 	<target host="insiderservice.orf.at" />
@@ -190,7 +193,6 @@
 	<target host="oe3pinnwand.orf.at" />
 	<target host="okidoki.orf.at" />
 	<target host="our.orf.at" />
-	<target host="pinky.orf.at" />
 	<target host="pipe.orf.at" />
 	<target host="plovdiv.orf.at" />
 	<target host="preview.orf.at" />
@@ -219,10 +221,7 @@
 	<target host="trichter.orf.at" />
 	<target host="trinidad.orf.at" />
 	<target host="tts.orf.at" />
-	<target host="tube.orf.at" />
 	<target host="tubestatic.orf.at" />
-	<target host="tv.orf.at" />
-	<target host="unterwegs.orf.at" />
 	<target host="vote.orf.at" />
 	<target host="vpngate.orf.at" />
 	<target host="vpngate1.orf.at" />


### PR DESCRIPTION
the rules already contain a redirect for appfeeds.orf.at, which is
requested from teletext.orf.at. If one naviates to
`http://teletext.orf.at`, HTTPS-Everywhere upgrades the API request from
`http://appfeeds.orf.at` to `https://appfeeds.orf.at`, which results in the
following CORS-error:

    Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at http://appfeeds.orf.at/teletext/api/v2/mobile/channels/orf1/pages/100. (Reason: CORS header ‘Access-Control-Allow-Origin’ missing).

redirecting teletext.orf.at as well fixes that.

~~**EDIT:** `test=FETCH` fails, because the rule contains redirects for other subdomains that are currently unavailable. I do not want to delete them, since I don't know why they are not available at this time (might be just the `/` path that has not content) or if they will be publicly accessible in the future again.~~ should be fixed now. I went through all of them; see commit message for details