### PR TITLE
Fix settings on new versions of Chrome.

### DIFF
--- a/chromium/background-scripts/store.js
+++ b/chromium/background-scripts/store.js
@@ -58,8 +58,8 @@ async function performMigrations() {
 
 function setStorage(store) {
   Object.assign(exports, {
-    get: store.get,
-    set: store.set,
+    get: store.get.bind(store),
+    set: store.set.bind(store),
     get_promise,
     set_promise
   });


### PR DESCRIPTION
On Chrome Canary, the checkboxes in the HTTPS Everywhere popup are missing and this error shows up in the background page's console every time the popup loads: 

> `Error in event handler: TypeError: Error processing argument at index -1, conversion failure from undefined`

It looks like this is because `chrome.storage`'s methods no longer work unbound. The fix is to bind them to the `StorageArea ` when they get pulled out.