### PR TITLE
Avoid depreciated synchronous XHR in the main thread

### DIFF
--- a/chromium/background-scripts/rules.js
+++ b/chromium/background-scripts/rules.js
@@ -216,7 +216,11 @@ RuleSets.prototype = {
   loadFromBrowserStorage: async function(store) {
     this.store = store;
     this.ruleActiveStates = await this.store.get_promise('ruleActiveStates', {});
-    this.addFromJson(util.loadExtensionFile('rules/default.rulesets', 'json'));
+
+    await util.loadExtensionFile('rules/default.rulesets', 'json')
+      .then(ruleJson => this.addFromJson(ruleJson))
+      .catch(error => util.log(util.WARN, 'Error loading extension file: ' + error));
+
     this.loadStoredUserRules();
     await this.addStoredCustomRulesets();
   },

--- a/chromium/background-scripts/util.js
+++ b/chromium/background-scripts/util.js
@@ -41,23 +41,14 @@ function getDefaultLogLevel() {
  *
  * @param url: a relative URL to local file
  */
-function loadExtensionFile(url, returnType) {
-  var xhr = new XMLHttpRequest();
-  // Use blocking XHR to ensure everything is loaded by the time
-  // we return.
-  xhr.open("GET", chrome.extension.getURL(url), false);
-  xhr.send(null);
-  // Get file contents
-  if (xhr.readyState !== 4) {
-    return;
-  }
-  if (returnType === 'xml') {
-    return xhr.responseXML;
-  }
-  if (returnType === 'json') {
-    return JSON.parse(xhr.responseText);
-  }
-  return xhr.responseText;
+async function loadExtensionFile(url, returnType) {
+  return fetch(chrome.extension.getURL(url))
+    .then(res => {
+      if (returnType == 'json') {
+        return res.json();
+      }
+      return res.text();
+    });
 }
 
 Object.assign(exports, {


### PR DESCRIPTION
@Hainish This will remove the browser warning in the extension console.

P.S. manual testing on `chrome-beta` and `chrome-canary` works, I'm not really sure why Travis is failing... 