### PR TITLE
Fix ruleset for Hatena

### DIFF
--- a/src/chrome/content/rules/Hatena.xml
+++ b/src/chrome/content/rules/Hatena.xml
@@ -62,7 +62,7 @@
 
 
 	<rule from="^http://www\.hatena\.ne\.jp/(css/|images/|login($|\?|/)|statics/)"
-		to="https://www.hatena.ne.jp/$2" />
+		to="https://www.hatena.ne.jp/$1" />
 
 		<test url="http://www.hatena.ne.jp/css/" />
 		<test url="http://www.hatena.ne.jp/images/" />


### PR DESCRIPTION
I fixed replace pattern.
Currently, broken CSS loading. http://www.hatena.ne.jp/

* For example, from http://www.hatena.ne.jp/css/hatenaportal/portal2012.css?t=1487038420 redirect to...
  * Before: https://www.hatena.ne.jp/hatenaportal/portal2012.css?t=1487038420 (404)
  * After: https://www.hatena.ne.jp/css/hatenaportal/portal2012.css?t=1487038420