### PR TITLE
[Zhihu.xml] worldcup2014 doesn't redirect to http now

### DIFF
--- a/src/chrome/content/rules/Zhihu.xml
+++ b/src/chrome/content/rules/Zhihu.xml
@@ -35,13 +35,10 @@
 	<target host="zhstatic.zhihu.com" />
 	<target host="zhuanlan.zhihu.com" />
 
-	<target host="pic.zhimg.com" />
 	<target host="pic1.zhimg.com" />
 	<target host="pic2.zhimg.com" />
 	<target host="pic3.zhimg.com" />
 	<target host="pic4.zhimg.com" />
-	<target host="z1.zhimg.com" />
-		<test url="http://z1.zhimg.com/scripts/c76214ae.scripts.js" />
 
 	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Zhihu.xml
+++ b/src/chrome/content/rules/Zhihu.xml
@@ -11,8 +11,6 @@
 	Mixcontent but no function issue:
 		daily.zhihu.com
 		news-at.zhihu.com
-
-	Redirect to http:
 		worldcup2014.zhihu.com
 -->
 
@@ -32,6 +30,7 @@
 	<target host="news-at.zhihu.com" />
 	<target host="static.zhihu.com" />
 	<target host="sugar.zhihu.com" />
+	<target host="worldcup2014.zhihu.com" />
 	<target host="zhihu-web-analytics.zhihu.com" />
 	<target host="zhstatic.zhihu.com" />
 	<target host="zhuanlan.zhihu.com" />


### PR DESCRIPTION
https://worldcup2014.zhihu.com no longer redirects to http, but it still has mixed content though.