### PR TITLE
Remove duplicates of blogsmithmedia.com

### DIFF
--- a/src/chrome/content/rules/AOL-mismatches.xml
+++ b/src/chrome/content/rules/AOL-mismatches.xml
@@ -6,41 +6,15 @@
 
 -->
 <ruleset name="AOL (mismatches)" default_off="mismatched">
-
-	<!--	Akamai	-->
-	<!--	cert: misc.blogsmith.aol.com	-->
-	<!--	Cert: misc.blogsmith.aol.com	-->
-	<target host="blogsmithmedia.com" />
-	<target host="www.blogsmithmedia.com" />
 	<!--
 		Moved to Akamai and broke.
 	<target host="mydaily.co.uk" />
 	<target host="www.mydaily.co.uk" /-->
 	<target host="an.tacoda.net" />
 
-
-	<!--securecookie host="^(.*\.)?mydaily\.co\.uk$" name=".*" /-->
-
-
-	<!--	- !www doesn't work.
-		- Images throw "Service Unavailable".
-	
-		Two examples of working paths:
-
-			- blogsmithmedia.com/corp.aol.com/media/jquery-fancybox_1-3-1.css
-			- blogsmithmedia.com/corp.aol.com/media/screen.css?v=1
-										-->
-	<rule from="^http://(?:www\.)?blogsmithmedia\.com/corp\.aol\.com/media/([\w\-\.]+)\.css(\?v=\d)?$"
-		to="https://www.blogsmithmedia.com/corp.aol.com/media/$1.css$2" />
-
-	<rule from="^http://(?:www\.)?blogsmithmedia\.com/translogic\.aolautos\.com/media/"
-		to="https://translogic.aolautos.com/media/" />
-
 	<!--	Moved to Akamai and broke: "An error occurred"
 	<rule from="^http://(?:www\.)?mydaily\.co\.uk/"
 		to="https://www.mydaily.co.uk/" /-->
 
-	<rule from="^http://an\.tacoda\.net/"
-		to="https://an.tacoda.net/" />
-
+	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Moviefone.xml
+++ b/src/chrome/content/rules/Moviefone.xml
@@ -6,6 +6,6 @@
 	<target host="moviefone.com" />
 	<target host="www.moviefone.com" />
 
-	<rule from="^http://moviefone\.com/"
+	<rule from="^http://(www\.)?moviefone\.com/"
 			to="https://www.moviefone.com/" />
 </ruleset>

--- a/src/chrome/content/rules/Moviefone.xml
+++ b/src/chrome/content/rules/Moviefone.xml
@@ -1,27 +1,11 @@
 <!--
 	For othe AOL coverage, see AOL.xml.
-
-
-	!www doesn't work
-
 -->
-<ruleset name="Moviefone.com" default_off="redirects to http">
+<ruleset name="Moviefone.com">
 
-	<!--	Direct rewrites:
-				-->
+	<target host="moviefone.com" />
 	<target host="www.moviefone.com" />
 
-	<!--	Complications:
-				-->
-	<target host="www.blogsmithmedia.com" />
-	<target host="moviefone.com" />
-
-		<!--	Redirects to http:
-						-->
-		<exclusion pattern="^http://www\.moviefone\.com/(?:$|cache/)" />
-
-
-	<rule from="^http://(?:www\.blogsmithmedia\.com/)?(?:www\.)?moviefone\.com/"
-		to="https://www.moviefone.com/" />
-
+	<rule from="^http://moviefone\.com/"
+			to="https://www.moviefone.com/" />
 </ruleset>


### PR DESCRIPTION
there is a standalone ruleset for blogsmithmedia.com, however the domain itself does not seem to serve any content and HTTPS is not working properly. Maybe we should remove that as well?
