### PR TITLE
[Stubhub.co.uk] Separate ruleset

### DIFF
--- a/src/chrome/content/rules/Stubhub.co.uk.xml
+++ b/src/chrome/content/rules/Stubhub.co.uk.xml
@@ -1,0 +1,40 @@
+<!--
+	For other Stubhub coverage, see Stubhub.com.xml
+
+
+	Non-functional subdomains:
+
+		- blog	(t)
+		- intl	(SSL connnection error)
+		- log	(t)
+		- secure	(SSL connnection error)
+
+	e: expired certificate
+	h: http redirect
+	i: invalid certificate chain
+	m: certificate mismatch
+	r: connection refused
+	s: self-signed certificate
+	t: timeout on https
+
+	Wildcard DNS and cert.
+-->
+<ruleset name="Stubhub.co.uk">
+
+	<target host="stubhub.co.uk" />
+	<target host="www.stubhub.co.uk" />
+	<target host="buy.stubhub.co.uk" />
+	<target host="data.stubhub.co.uk" />
+	<target host="iam.stubhub.co.uk" />
+	<target host="m.stubhub.co.uk" />
+	<target host="myaccount.stubhub.co.uk" />
+	<target host="pro.stubhub.co.uk" />
+	<target host="publicfeed.stubhub.co.uk" />
+	<target host="sell.stubhub.co.uk" />
+	<target host="smetrics.stubhub.co.uk" />
+	<target host="stubconnect.stubhub.co.uk" />
+	<target host="track.stubhub.co.uk" />
+
+	<rule from="^http:"
+		to="https:" />
+</ruleset>


### PR DESCRIPTION
depends on https://github.com/EFForg/https-everywhere/pull/14269 due to duplicate host error.