### PR TITLE
[Stubhub.de] Separate ruleset

### DIFF
--- a/src/chrome/content/rules/Stubhub.de.xml
+++ b/src/chrome/content/rules/Stubhub.de.xml
@@ -1,0 +1,39 @@
+<!--
+	For other Stubhub coverage, see Stubhub.com.xml
+
+
+	Non-functional subdomains:
+
+		- static	(t)
+
+	e: expired certificate
+	h: http redirect
+	i: invalid certificate chain
+	m: certificate mismatch
+	r: connection refused
+	s: self-signed certificate
+	t: timeout on https
+
+	Wildcard DNS and cert.
+-->
+<ruleset name="Stubhub.de">
+
+	<target host="stubhub.de" />
+	<target host="www.stubhub.de" />
+	<target host="apipublish.stubhub.de" />
+	<target host="buy.stubhub.de" />
+	<target host="data.stubhub.de" />
+	<target host="developer.stubhub.de" />
+	<target host="iam.stubhub.de" />
+	<target host="log.stubhub.de" />
+	<target host="m.stubhub.de" />
+	<target host="myaccount.stubhub.de" />
+	<target host="pro.stubhub.de" />
+	<target host="publicfeed.stubhub.de" />
+	<target host="sell.stubhub.de" />
+	<target host="stubconnect.stubhub.de" />
+	<target host="track.stubhub.de" />
+
+	<rule from="^http:"
+		to="https:" />
+</ruleset>


### PR DESCRIPTION
depends on https://github.com/EFForg/https-everywhere/pull/14269 due to duplicate host error.