### PR TITLE
Add Option UI to Enable mixedcontent Rulesets Globally

### DIFF
--- a/chromium/background-scripts/background.js
+++ b/chromium/background-scripts/background.js
@@ -73,6 +73,11 @@ chrome.storage.onChanged.addListener(async function(changes, areaName) {
       isExtensionEnabled = changes.globalEnabled.newValue;
       updateState();
     }
+    if ('enableMixedRulesets' in changes) {
+      // Don't require users to restart the browsers
+      rules.settings.enableMixedRulesets = changes.enableMixedRulesets.newValue;
+      initializeAllRules();
+    }
     if ('debugging_rulesets' in changes) {
       initializeAllRules();
     }

--- a/chromium/pages/options/index.html
+++ b/chromium/pages/options/index.html
@@ -24,7 +24,7 @@
 
     <div id="import-confirmed" data-i18n="options_imported"></div>
 
-    <form>
+    <form id="import-settings-form">
       <div class="section-header"><span class="section-header-span" data-i18n="options_importSettings"></span></div>
       <section id="ImportSettings" class="options">
         <input id="import-settings" type="file" accept="application/json">

--- a/chromium/pages/options/index.html
+++ b/chromium/pages/options/index.html
@@ -7,13 +7,19 @@
   </head>
   <body>
     <div class="section-header"><span class="section-header-span" data-i18n="options_generalSettings"></span></div>
-    <div id='counter-wrapper' class='general-settings-wrapper'>
+    <div id="counter-wrapper" class="general-settings-wrapper">
       <input type="checkbox" id="showCounter">
-      <label for="showCounter" data-i18n="menu_showCounter"></label>
+      <label for="showCounter" data-i18n="options_showCounter"></label>
     </div>
-    <div id='update-wrapper' class='general-settings-wrapper'>
+    <div id="update-wrapper" class="general-settings-wrapper">
       <input type="checkbox" id="autoUpdateRulesets">
       <label for="autoUpdateRulesets" data-i18n="options_autoUpdateRulesets"></label>
+    </div>
+
+    <div class="section-header"><span class="section-header-span" data-i18n="options_advancedSettings"></span></div>
+    <div id="mixed-rulesets-wrapper" class="general-settings-wrapper">
+      <input type="checkbox" id="enableMixedRulesets">
+      <label for="enableMixedRulesets" data-i18n="options_enableMixedRulesets"></label>
     </div>
 
     <div id="import-confirmed" data-i18n="options_imported"></div>

--- a/chromium/pages/options/style.css
+++ b/chromium/pages/options/style.css
@@ -6,6 +6,10 @@
   margin-bottom: 20px;
 }
 
+.general-settings-wrapper#mixed-rulesets-wrapper{
+  margin-bottom: 20px;
+}
+
 .section-header{
   margin-bottom: 10px;
 }

--- a/chromium/pages/options/ux.js
+++ b/chromium/pages/options/ux.js
@@ -5,19 +5,19 @@
 document.addEventListener("DOMContentLoaded", () => {
 
   let json_data;
-  let import_button = document.querySelector("#import");
+  let import_button = document.getElementById("import");
 
   function import_json(e) {
     e.preventDefault();
 
     let settings = JSON.parse(json_data);
     sendMessage("import_settings", settings, () => {
-      document.querySelector("#import-confirmed").style.display = "block";
-      document.querySelector("form").style.display = "none";
+      document.getElementById("import-confirmed").style.display = "block";
+      document.getElementById("import-settings-form").style.display = "none";
     });
   }
 
-  document.querySelector("#import-settings").addEventListener("change", () => {
+  document.getElementById("import-settings").addEventListener("change", () => {
     const file = event.target.files[0];
     const reader = new FileReader();
     reader.addEventListener("load", event => {
@@ -28,7 +28,7 @@ document.addEventListener("DOMContentLoaded", () => {
     reader.readAsText(file);
   });
 
-  document.querySelector("form").addEventListener("submit", import_json);
+  document.getElementById("import-settings-form").addEventListener("submit", import_json);
 
   const showCounter = document.getElementById("showCounter");
   const autoUpdateRulesets = document.getElementById("autoUpdateRulesets");

--- a/chromium/pages/options/ux.js
+++ b/chromium/pages/options/ux.js
@@ -32,16 +32,30 @@ document.addEventListener("DOMContentLoaded", () => {
 
   const showCounter = document.getElementById("showCounter");
   const autoUpdateRulesets = document.getElementById("autoUpdateRulesets");
+  const enableMixedRulesets = document.getElementById("enableMixedRulesets");
 
-  sendMessage("get_option", { showCounter: true, autoUpdateRulesets: true }, item => {
+  const defaultOptions = {
+    showCounter: true,
+    autoUpdateRulesets: true,
+    enableMixedRulesets: false,
+  };
+
+  sendMessage("get_option", defaultOptions, item => {
     showCounter.checked = item.showCounter;
     autoUpdateRulesets.checked = item.autoUpdateRulesets;
+    enableMixedRulesets.checked = item.enableMixedRulesets;
+
     showCounter.addEventListener("change", () => {
       sendMessage("set_option", { showCounter: showCounter.checked });
     });
+
     autoUpdateRulesets.addEventListener("change", () => {
       sendMessage("set_option", { autoUpdateRulesets: autoUpdateRulesets.checked });
     });
+
+    enableMixedRulesets.addEventListener("change", () => {
+      sendMessage("set_option", { enableMixedRulesets: enableMixedRulesets.checked });
+    })
   });
 
   document.onkeydown = function(evt) {

--- a/src/chrome/locale/en/https-everywhere.dtd
+++ b/src/chrome/locale/en/https-everywhere.dtd
@@ -9,12 +9,14 @@
 <!ENTITY https-everywhere.menu.observatory "SSL Observatory Preferences">
 <!ENTITY https-everywhere.menu.globalEnable "Enable HTTPS Everywhere">
 <!ENTITY https-everywhere.menu.blockUnencryptedRequests "Block all unencrypted requests">
-<!ENTITY https-everywhere.menu.showCounter "Show Counter">
 <!ENTITY https-everywhere.menu.viewAllRules "View All Rules">
 
 <!ENTITY https-everywhere.options.generalSettings "General Settings">
+<!ENTITY https-everywhere.options.advancedSettings "Advanced Settings">
 <!ENTITY https-everywhere.options.importSettings "Import Settings">
 <!ENTITY https-everywhere.options.import "Import">
+<!ENTITY https-everywhere.options.showCounter "Show Counter">
+<!ENTITY https-everywhere.options.enableMixedRulesets "Enable mixed content rulesets">
 <!ENTITY https-everywhere.options.autoUpdateRulesets "Auto-update rulesets">
 <!ENTITY https-everywhere.options.imported "Your settings have been imported.">
 


### PR DESCRIPTION
This will allow advanced users to enable mixedcontent rulesets easily and globally, especially when `Block all unencrypted requests` mode is being used

Testing was performed with https://www.wwf.or.jp/. Apparently, mixedcontent rulesets will be shown in `Stable rules` section once this option is checked. 

Possibly related: https://trac.torproject.org/projects/tor/ticket/21323

cc @Hainish 