### PR TITLE
Use upgradeToSecure when possible

### DIFF
--- a/chromium/background-scripts/util.js
+++ b/chromium/background-scripts/util.js
@@ -106,3 +106,48 @@ Object.assign(exports, {
 });
 
 })(typeof exports == 'undefined' ? require.scopes.util = {} : exports);
+
+// from
+// https://www.gregoryvarghese.com/how-to-get-browser-name-and-version-via-javascript/
+function getBrowserInfo() {
+  var agent = navigator.userAgent,
+    match = agent.match(/(opera|chrome|safari|firefox|msie|trident(?=\/))\/?\s*(\d+)/i);
+
+  if (!match) {
+    return {
+      name: null,
+      version: null
+    };
+  }
+
+  var name = match[1],
+    version = match[2];
+
+  if (/trident/i.test(name)) {
+    var ieMatch = /\brv[ :]+(\d+)/g.exec(agent) || []; 
+    return {
+      name: 'IE ', 
+      version: (ieMatch[1] || '')
+    };
+  }   
+
+  if (name === 'Chrome') {
+    var opMatch = agent.match(/\bOPR\/(\d+)/);
+    if (tem != null) {
+      return {
+        name: 'Opera', 
+        version: match[1]
+      };
+    }
+  }   
+
+  var vMatch = agent.match(/version\/(\d+)/i);
+  if (vMatch != null) {
+    version = vMatch[1];
+  }
+
+  return {
+    name: name,
+    version: version
+  };
+}


### PR DESCRIPTION
Closes #49. 

In Firefox, cross-origin resource sharing (CORS) requests that are approved for http urls are sometimes 
blocked after being rewritten to https. Firefox has recently added a new option to [webRequest.BlockingResponse](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/webRequest/BlockingResponse), upgradeToSecure, which performs a simple http --> https rewrite. This branch tries to use that flag instead of a standard rewrite whenever (1) the rewrite is trivial and (2) the browser is Firefox 59+.

Can be tested on this website: http://shop.decatorevista.ro/

With the current version of the extension in Firefox, a few calls to maxcdn.bootstrapcdn.com will be blocked, breaking styles on the page. This branch allows them to be rewritten successfully.