### PR TITLE
Add bash.im ruleset

### DIFF
--- a/src/chrome/content/rules/Bash.im.xml
+++ b/src/chrome/content/rules/Bash.im.xml
@@ -1,0 +1,10 @@
+<!--
+  Does not connect over HTTPS:
+    lol.bash.im
+-->
+<ruleset name="Bash.im">
+	<target host="bash.im" />
+	<target host="www.bash.im" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/Bash.im.xml
+++ b/src/chrome/content/rules/Bash.im.xml
@@ -6,5 +6,7 @@
 	<target host="bash.im" />
 	<target host="www.bash.im" />
 
+	<securecookie host=".+" name=".+" />
+
 	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Bash.im.xml
+++ b/src/chrome/content/rules/Bash.im.xml
@@ -1,6 +1,6 @@
 <!--
-  Does not connect over HTTPS:
-    lol.bash.im
+	Does not connect over HTTPS:
+		lol.bash.im
 -->
 <ruleset name="Bash.im">
 	<target host="bash.im" />


### PR DESCRIPTION
Sublist3r also listed the `s.bash.im` domain name, but it does not seem to resolve to an IP address.