### PR TITLE
Exclude n1.global.ssl.fastly.net

### DIFF
--- a/src/chrome/content/rules/Fastly.net.xml
+++ b/src/chrome/content/rules/Fastly.net.xml
@@ -48,6 +48,10 @@
 		<test url="http://virtual-host-discourse.global.ssl.fastly.net/assets/fontawesome-webfont-73827efc2a64a873027d05873d392cb6.eot?http://users.rust-lang.org&amp;amp;2&amp;v=4.3.0" />
 		<test url="http://boingboing.global.ssl.fastly.net/assets/fontawesome-webfont-743c128c2e48ae20145724e61f9998b4.ttf?http://bbs.boingboing.net" />
 
+		<!-- spanishdict.com breaks due to CORS bug -->
+		<exclusion pattern="^http://n1\.global\.ssl\.fastly\.net/" />
+		<test url="http://n1.global.ssl.fastly.net/" />
+	
 	<!-- Periscope.tv live streaming is broken by rewrite of player resources -->
 
 	<exclusion pattern="^http://periscope\-prod\-[\w.-]+\.global\.ssl\.fastly\.net" />


### PR DESCRIPTION
Fixes https://github.com/EFForg/https-everywhere/issues/14152