### PR TITLE
Use upgradeToSecure when possible

### DIFF
--- a/chromium/background-scripts/background.js
+++ b/chromium/background-scripts/background.js
@@ -15,6 +15,7 @@ async function initialize() {
   await store.initialize();
   await store.performMigrations();
   await initializeStoredGlobals();
+  await getUpgradeToSecureAvailable();
   await update.initialize(store, initializeAllRules);
   await all_rules.loadFromBrowserStorage(store, update.applyStoredRulesets);
   await incognito.onIncognitoDestruction(destroy_caches);
@@ -57,6 +58,26 @@ function initializeStoredGlobals(){
       resolve();
     });
   });
+}
+
+var upgradeToSecureAvailable;
+
+function getUpgradeToSecureAvailable() {
+  if (typeof browser !== 'undefined') {
+    return browser.runtime.getBrowserInfo().then(function(info) {
+      var version = info.version.match(/^(\d+)/)[1];
+      if (info.name == "Firefox" && version >= 59) {
+        upgradeToSecureAvailable = true;
+      } else {
+        upgradeToSecureAvailable = false;
+      }
+    });
+  } else {
+    return new Promise(resolve => {
+      upgradeToSecureAvailable = false;
+      resolve();
+    });
+  }
 }
 
 chrome.storage.onChanged.addListener(async function(changes, areaName) {
@@ -276,6 +297,8 @@ function onBeforeRequest(details) {
   }
 
   // Should the request be canceled?
+  // true if the URL is a http:// connection to a remote canonical host, and not
+  // a tor hidden service
   const shouldCancel = httpNowhereOn &&
     uri.protocol === 'http:' &&
     uri.hostname.slice(-6) !== '.onion' &&
@@ -320,12 +343,20 @@ function onBeforeRequest(details) {
     return {cancel: shouldCancel};
   }
 
+  // whether to use mozilla's upgradeToSecure BlockingResponse if available
+  var upgradeToSecure = false;
   var newuristr = null;
+  // check rewritten URIs against the trivially upgraded URI
+  var trivialUpgradeUri = canonical_url.replace(/^http:/, "https:");
 
   for (let ruleset of potentiallyApplicable) {
     appliedRulesets.addRulesetToTab(details.tabId, details.type, ruleset);
     if (ruleset.active && !newuristr) {
       newuristr = ruleset.apply(canonical_url);
+      // only use upgradeToSecure for trivial rulesets
+      if (newuristr == trivialUpgradeUri) {
+        upgradeToSecure = true;
+      }
     }
   }
 
@@ -358,10 +389,11 @@ function onBeforeRequest(details) {
     // If loading a main frame, try the HTTPS version as an alternative to
     // failing.
     if (shouldCancel) {
+      upgradeToSecure = true;
       if (!newuristr) {
-        return {redirectUrl: canonical_url.replace(/^http:/, "https:")};
+        newuristr = canonical_url.replace(/^http:/, "https:");
       } else {
-        return {redirectUrl: newuristr.replace(/^http:/, "https:")};
+        newuristr = newuristr.replace(/^http:/, "https:");
       }
     }
     if (newuristr && newuristr.substring(0, 5) === "http:") {
@@ -370,9 +402,14 @@ function onBeforeRequest(details) {
     }
   }
 
-  if (newuristr) {
+  if (upgradeToSecureAvailable && upgradeToSecure) {
+    util.log(util.INFO, 'onBeforeRequest returning upgradeToSecure: true');
+    return {upgradeToSecure: true};
+  } else if (newuristr) {
+    util.log(util.INFO, 'onBeforeRequest returning redirectUrl: ' + newuristr);
     return {redirectUrl: newuristr};
   } else {
+    util.log(util.INFO, 'onBeforeRequest returning shouldCancel: ' + shouldCancel);
     return {cancel: shouldCancel};
   }
 }

--- a/chromium/background-scripts/background.js
+++ b/chromium/background-scripts/background.js
@@ -60,12 +60,12 @@ function initializeStoredGlobals(){
   });
 }
 
-var upgradeToSecureAvailable;
+let upgradeToSecureAvailable;
 
 function getUpgradeToSecureAvailable() {
   if (typeof browser !== 'undefined') {
     return browser.runtime.getBrowserInfo().then(function(info) {
-      var version = info.version.match(/^(\d+)/)[1];
+      let version = info.version.match(/^(\d+)/)[1];
       if (info.name == "Firefox" && version >= 59) {
         upgradeToSecureAvailable = true;
       } else {
@@ -344,10 +344,10 @@ function onBeforeRequest(details) {
   }
 
   // whether to use mozilla's upgradeToSecure BlockingResponse if available
-  var upgradeToSecure = false;
+  let upgradeToSecure = false;
   var newuristr = null;
   // check rewritten URIs against the trivially upgraded URI
-  var trivialUpgradeUri = canonical_url.replace(/^http:/, "https:");
+  let trivialUpgradeUri = canonical_url.replace(/^http:/, "https:");
 
   for (let ruleset of potentiallyApplicable) {
     appliedRulesets.addRulesetToTab(details.tabId, details.type, ruleset);


### PR DESCRIPTION
Closes #49.

Builds on https://github.com/EFForg/https-everywhere/pull/15092.

In Firefox, cross-origin resource sharing (CORS) requests that are approved for http urls are sometimes
blocked after being rewritten to https. Firefox has recently added a new option to webRequest.BlockingResponse, upgradeToSecure, which performs a simple http --> https rewrite. This branch tries to use that flag instead of a standard rewrite whenever (1) the rewrite is trivial and (2) the browser is Firefox 59+.

Can be tested on this website: http://shop.decatorevista.ro/

With the current version of the extension in Firefox, a few calls to maxcdn.bootstrapcdn.com will be blocked, breaking styles on the page. This branch allows them to be rewritten successfully. Turn on logging in the background page and look for "onBeforeRequest returning upgradeToSecure: true" messages, and filter outgoing requests to cdnjs.cloudflare.com to make sure they're being rewritten to https.

This PR uses the [browser.runtime.getBrowserInfo API](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/runtime/getBrowserInfo) to determine the type and version of the browser. Since browser.* APIs aren't in chrome, it first checks whether `browser` is defined, then checks the browser name and version number accordingly. Unfortunately, since *all* browser.runtime.* APIs are implemented as promises, I had to add a new initialization function to the background page that figures out whether onBeforeRequest is available on load and saves it as a global(ish) variable.