### PR TITLE
Update Broadcasthe.net domains

### DIFF
--- a/src/chrome/content/rules/Broadcasthe.net.xml
+++ b/src/chrome/content/rules/Broadcasthe.net.xml
@@ -1,21 +1,10 @@
-
-<!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://btnapps.net/ => https://btnapps.net/: (7, 'Failed to connect to btnapps.net port 443: Connection refused')
-Fetch error: http://www.btnapps.net/ => https://www.btnapps.net/: (7, 'Failed to connect to www.btnapps.net port 443: Connection refused')
-Fetch error: http://api.btnapps.net/ => https://api.btnapps.net/: (7, 'Failed to connect to api.btnapps.net port 443: Connection refused')
-
--->
-<ruleset name="BroadcasTheNet" default_off='failed ruleset test'>
+<ruleset name="BroadcasTheNet">
 	<target host="broadcasthe.net" />
 		<target host="www.broadcasthe.net" />
 		<target host="cdn.broadcasthe.net" />
 		<target host="cdn2.broadcasthe.net" />
 		<target host="piwik.broadcasthe.net" />
 		<target host="static.broadcasthe.net" />
-	<target host="btnapps.net" />
-		<target host="www.btnapps.net" />
-		<target host="api.btnapps.net" />
 
 	<securecookie host="^(?:.*\.)?broadcastthe\.net$" name=".+" />
 


### PR DESCRIPTION
Drop no longer maintained secondary domain and reactivate ruleset.