### PR TITLE
Add Trump Organization rulesets

### DIFF
--- a/src/chrome/content/rules/Trump.com.xml
+++ b/src/chrome/content/rules/Trump.com.xml
@@ -1,0 +1,8 @@
+<ruleset name="Trump.com">
+  <target host="trump.com" />
+  <target host="www.trump.com" /> 
+
+  <securecookie host=".+" name=".+" />
+
+  <rule from="^http:" to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/Trump.com.xml
+++ b/src/chrome/content/rules/Trump.com.xml
@@ -1,8 +1,8 @@
 <ruleset name="Trump.com">
-  <target host="trump.com" />
-  <target host="www.trump.com" /> 
+	<target host="trump.com" />
+	<target host="www.trump.com" />
 
-  <securecookie host=".+" name=".+" />
+	<securecookie host=".+" name=".+" />
 
-  <rule from="^http:" to="https:" />
+	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/TrumpGolf.com.xml
+++ b/src/chrome/content/rules/TrumpGolf.com.xml
@@ -1,0 +1,8 @@
+<ruleset name="TrumpGolf.com">
+  <target host="trumpgolf.com" />
+  <target host="www.trumpgolf.com" /> 
+
+  <securecookie host=".+" name=".+" />
+
+  <rule from="^http:" to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/TrumpGolf.com.xml
+++ b/src/chrome/content/rules/TrumpGolf.com.xml
@@ -1,8 +1,8 @@
 <ruleset name="TrumpGolf.com">
-  <target host="trumpgolf.com" />
-  <target host="www.trumpgolf.com" /> 
+	<target host="trumpgolf.com" />
+	<target host="www.trumpgolf.com" />
 
-  <securecookie host=".+" name=".+" />
+	<securecookie host=".+" name=".+" />
 
-  <rule from="^http:" to="https:" />
+	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/TrumpHotels.com.xml
+++ b/src/chrome/content/rules/TrumpHotels.com.xml
@@ -1,0 +1,17 @@
+<!--
+  Does not connect:
+    remote.trumphotels.com
+    tbygp.trumphotels.com
+    tchgp.trumphotels.com
+    twagp.trumphotels.com
+-->
+<ruleset name="TrumpHotels.com">
+  <target host="trumphotels.com" />
+  <target host="www.trumphotels.com" />
+  <target host="trumpadmin.trumphotels.com" />
+  <target host="trumpcard.trumphotels.com" />
+
+  <securecookie host=".+" name=".+" />
+
+  <rule from="^http:" to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/TrumpHotels.com.xml
+++ b/src/chrome/content/rules/TrumpHotels.com.xml
@@ -1,17 +1,17 @@
 <!--
-  Does not connect:
-    remote.trumphotels.com
-    tbygp.trumphotels.com
-    tchgp.trumphotels.com
-    twagp.trumphotels.com
+	Does not connect:
+		remote.trumphotels.com
+		tbygp.trumphotels.com
+		tchgp.trumphotels.com
+		twagp.trumphotels.com
 -->
 <ruleset name="TrumpHotels.com">
-  <target host="trumphotels.com" />
-  <target host="www.trumphotels.com" />
-  <target host="trumpadmin.trumphotels.com" />
-  <target host="trumpcard.trumphotels.com" />
+	<target host="trumphotels.com" />
+	<target host="www.trumphotels.com" />
+	<target host="trumpadmin.trumphotels.com" />
+	<target host="trumpcard.trumphotels.com" />
 
-  <securecookie host=".+" name=".+" />
+	<securecookie host=".+" name=".+" />
 
-  <rule from="^http:" to="https:" />
+	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/TrumpInternationalRealty.com.xml
+++ b/src/chrome/content/rules/TrumpInternationalRealty.com.xml
@@ -1,0 +1,19 @@
+<ruleset name="TrumpInternationalRealty.com">
+  <target host="trumpinternationalrealty.com" />
+  <target host="www.trumpinternationalrealty.com" />
+  <target host="charlotte.trumpinternationalrealty.com" />
+  <target host="gardenstate.trumpinternationalrealty.com" />
+  <target host="jerseycity.trumpinternationalrealty.com" />
+  <target host="jerseyshore.trumpinternationalrealty.com" />
+  <target host="jupiter.trumpinternationalrealty.com" />
+  <target host="lasvegas.trumpinternationalrealty.com" />
+  <target host="miami.trumpinternationalrealty.com" />
+  <target host="northernjersey.trumpinternationalrealty.com" />
+  <target host="palmbeach.trumpinternationalrealty.com" />
+  <target host="virginia.trumpinternationalrealty.com" />
+  <target host="westchester.trumpinternationalrealty.com" />
+
+  <securecookie host=".+" name=".+" />
+
+  <rule from="^http:" to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/TrumpInternationalRealty.com.xml
+++ b/src/chrome/content/rules/TrumpInternationalRealty.com.xml
@@ -1,19 +1,19 @@
 <ruleset name="TrumpInternationalRealty.com">
-  <target host="trumpinternationalrealty.com" />
-  <target host="www.trumpinternationalrealty.com" />
-  <target host="charlotte.trumpinternationalrealty.com" />
-  <target host="gardenstate.trumpinternationalrealty.com" />
-  <target host="jerseycity.trumpinternationalrealty.com" />
-  <target host="jerseyshore.trumpinternationalrealty.com" />
-  <target host="jupiter.trumpinternationalrealty.com" />
-  <target host="lasvegas.trumpinternationalrealty.com" />
-  <target host="miami.trumpinternationalrealty.com" />
-  <target host="northernjersey.trumpinternationalrealty.com" />
-  <target host="palmbeach.trumpinternationalrealty.com" />
-  <target host="virginia.trumpinternationalrealty.com" />
-  <target host="westchester.trumpinternationalrealty.com" />
+	<target host="trumpinternationalrealty.com" />
+	<target host="www.trumpinternationalrealty.com" />
+	<target host="charlotte.trumpinternationalrealty.com" />
+	<target host="gardenstate.trumpinternationalrealty.com" />
+	<target host="jerseycity.trumpinternationalrealty.com" />
+	<target host="jerseyshore.trumpinternationalrealty.com" />
+	<target host="jupiter.trumpinternationalrealty.com" />
+	<target host="lasvegas.trumpinternationalrealty.com" />
+	<target host="miami.trumpinternationalrealty.com" />
+	<target host="northernjersey.trumpinternationalrealty.com" />
+	<target host="palmbeach.trumpinternationalrealty.com" />
+	<target host="virginia.trumpinternationalrealty.com" />
+	<target host="westchester.trumpinternationalrealty.com" />
 
-  <securecookie host=".+" name=".+" />
+	<securecookie host=".+" name=".+" />
 
-  <rule from="^http:" to="https:" />
+	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/TrumpStore.com.xml
+++ b/src/chrome/content/rules/TrumpStore.com.xml
@@ -1,8 +1,8 @@
 <ruleset name="TrumpStore.com">
-  <target host="trumpstore.com" />
-  <target host="www.trumpstore.com" /> 
+	<target host="trumpstore.com" />
+	<target host="www.trumpstore.com" />
 
-  <securecookie host=".+" name=".+" />
+	<securecookie host=".+" name=".+" />
 
-  <rule from="^http:" to="https:" />
+	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/TrumpStore.com.xml
+++ b/src/chrome/content/rules/TrumpStore.com.xml
@@ -1,0 +1,8 @@
+<ruleset name="TrumpStore.com">
+  <target host="trumpstore.com" />
+  <target host="www.trumpstore.com" /> 
+
+  <securecookie host=".+" name=".+" />
+
+  <rule from="^http:" to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/TrumpWinery.com.xml
+++ b/src/chrome/content/rules/TrumpWinery.com.xml
@@ -1,0 +1,8 @@
+<ruleset name="TrumpWinery.com">
+  <target host="trumpwinery.com" />
+  <target host="www.trumpwinery.com" /> 
+
+  <securecookie host=".+" name=".+" />
+
+  <rule from="^http:" to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/TrumpWinery.com.xml
+++ b/src/chrome/content/rules/TrumpWinery.com.xml
@@ -1,8 +1,8 @@
 <ruleset name="TrumpWinery.com">
-  <target host="trumpwinery.com" />
-  <target host="www.trumpwinery.com" /> 
+	<target host="trumpwinery.com" />
+	<target host="www.trumpwinery.com" />
 
-  <securecookie host=".+" name=".+" />
+	<securecookie host=".+" name=".+" />
 
-  <rule from="^http:" to="https:" />
+	<rule from="^http:" to="https:" />
 </ruleset>


### PR DESCRIPTION
Sublist3r also shows the following subdomains, which do not resolve to IP addresses:
* `mail.trump.com`;
* `mail2.trump.com`;
* `mivsp2.trump.com`;
* `chi-operadb.trumphotels.com`;
* `ocis-app.trumphotels.com`;
* `njmls.trumpinternationalrealty.com`.

`virginia.trumpinternationalrealty.com` appears to have some weird redirect to `placester.com`, but still seems to be upgradeable.