### PR TITLE
Add "Show Devtools tab" option to hide CDT tab

### DIFF
--- a/chromium/pages/devtools/index.html
+++ b/chromium/pages/devtools/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title></title>
+    <script src="../send-message.js"></script>
     <script src="ux.js"></script>
   </head>
   <body></body>

--- a/chromium/pages/devtools/ux.js
+++ b/chromium/pages/devtools/ux.js
@@ -1,7 +1,17 @@
+/* global sendMessage */
+
 "use strict";
 
-chrome.devtools.panels.create("HTTPS Everywhere",
-  "/images/icons/icon-active-38.png",
-  "/pages/devtools/panel.html",
-  function() { }
-);
+const defaultOptions = {
+  showDevtoolsTab: true
+};
+
+sendMessage("get_option", defaultOptions, item => {
+  if (item.showDevtoolsTab) {
+    chrome.devtools.panels.create("HTTPS Everywhere",
+      "/images/icons/icon-active-38.png",
+      "/pages/devtools/panel.html",
+      function() { }
+    );
+  }
+});

--- a/chromium/pages/options/index.html
+++ b/chromium/pages/options/index.html
@@ -21,6 +21,10 @@
       <input type="checkbox" id="enableMixedRulesets">
       <label for="enableMixedRulesets" data-i18n="options_enableMixedRulesets"></label>
     </div>
+    <div id="show-devtools-tab-wrapper" class="general-settings-wrapper">
+      <input type="checkbox" id="showDevtoolsTab">
+      <label for="showDevtoolsTab" data-i18n="options_showDevtoolsTab"></label>
+    </div>
 
     <div id="import-confirmed" data-i18n="options_imported"></div>
 

--- a/chromium/pages/options/style.css
+++ b/chromium/pages/options/style.css
@@ -6,7 +6,7 @@
   margin-bottom: 20px;
 }
 
-.general-settings-wrapper#mixed-rulesets-wrapper{
+.general-settings-wrapper#show-devtools-tab-wrapper{
   margin-bottom: 20px;
 }
 

--- a/chromium/pages/options/ux.js
+++ b/chromium/pages/options/ux.js
@@ -33,17 +33,20 @@ document.addEventListener("DOMContentLoaded", () => {
   const showCounter = document.getElementById("showCounter");
   const autoUpdateRulesets = document.getElementById("autoUpdateRulesets");
   const enableMixedRulesets = document.getElementById("enableMixedRulesets");
+  const showDevtoolsTab = document.getElementById("showDevtoolsTab");
 
   const defaultOptions = {
     showCounter: true,
     autoUpdateRulesets: true,
     enableMixedRulesets: false,
+    showDevtoolsTab: true
   };
 
   sendMessage("get_option", defaultOptions, item => {
     showCounter.checked = item.showCounter;
     autoUpdateRulesets.checked = item.autoUpdateRulesets;
     enableMixedRulesets.checked = item.enableMixedRulesets;
+    showDevtoolsTab.checked = item.showDevtoolsTab;
 
     showCounter.addEventListener("change", () => {
       sendMessage("set_option", { showCounter: showCounter.checked });
@@ -55,7 +58,11 @@ document.addEventListener("DOMContentLoaded", () => {
 
     enableMixedRulesets.addEventListener("change", () => {
       sendMessage("set_option", { enableMixedRulesets: enableMixedRulesets.checked });
-    })
+    });
+
+    showDevtoolsTab.addEventListener("change", () => {
+      sendMessage("set_option", { showDevtoolsTab: showDevtoolsTab.checked });
+    });
   });
 
   document.onkeydown = function(evt) {

--- a/src/chrome/locale/en/https-everywhere.dtd
+++ b/src/chrome/locale/en/https-everywhere.dtd
@@ -17,6 +17,7 @@
 <!ENTITY https-everywhere.options.importSettings "Import Settings">
 <!ENTITY https-everywhere.options.import "Import">
 <!ENTITY https-everywhere.options.enableMixedRulesets "Enable mixed content rulesets">
+<!ENTITY https-everywhere.options.showDevtoolsTab "Show Devtools tab">
 <!ENTITY https-everywhere.options.autoUpdateRulesets "Auto-update rulesets">
 <!ENTITY https-everywhere.options.imported "Your settings have been imported.">
 


### PR DESCRIPTION
Adds "Show Devtools tab" to the extension options, defaulting to `true`.  Firefox itself lets users disable/hide devtools tabs out of the box, but Chromium does not.

Tested in Chromium 66 and Firefox 60b13 (Linux).

Rendered in Chromium 66:
![phobos-20180418_111540_pdt](https://user-images.githubusercontent.com/744538/38950903-c944218a-42fb-11e8-8d19-f0c560a36439.png)

Also see #13611, #13685.

/cc @Hainish
