### PR TITLE
Add releases.llvm.org to rules

### DIFF
--- a/src/chrome/content/rules/LLVM.org.xml
+++ b/src/chrome/content/rules/LLVM.org.xml
@@ -39,6 +39,7 @@
 	<target host="lldb.llvm.org" />
 	<target host="openmp.llvm.org" />
 	<target host="polly.llvm.org" />
+	<target host="releases.llvm.org" />
 	<target host="reviews.llvm.org" />
 	<target host="svn.llvm.org" />
 	<target host="vmkit.llvm.org" />


### PR DESCRIPTION
Downloading software should always be encrypted.