### PR TITLE
Re-enable trezor.io

### DIFF
--- a/src/chrome/content/rules/trezor.io.xml
+++ b/src/chrome/content/rules/trezor.io.xml
@@ -1,10 +1,4 @@
-
-<!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://old-wallet.trezor.io/ => https://old-wallet.trezor.io/: (6, 'Could not resolve host: old-wallet.trezor.io')
-
--->
-<ruleset name="trezor.io" default_off='failed ruleset test'>
+<ruleset name="trezor.io">
 	<target host="trezor.io" />
 	<target host="www.trezor.io" />
 	<target host="beta-wallet.trezor.io" />


### PR DESCRIPTION
We probably had the domain disabled at the time of the check.  All the domains should be working now.