### PR TITLE
install-dev-dependencies.sh: Fix default y/N prompt indication

### DIFF
--- a/install-dev-dependencies.sh
+++ b/install-dev-dependencies.sh
@@ -9,7 +9,7 @@ if [ "$1" != "--no-prompt" ]; then
   echo "may alter your system, installing requirements both within the package"
   echo "management system and also external binaries."
   echo
-  echo -n "Are you sure you want to continue? [Y/n]: "
+  echo -n "Are you sure you want to continue? [y/N]: "
   read CONTINUE
   CONTINUE=`echo $CONTINUE | xargs | head -c 1 | awk '{print tolower($0)}'`
   if [ "$CONTINUE" != "y" ]; then


### PR DESCRIPTION
The default when hitting enter is _not_ to continue.