### PR TITLE
Improve issue bot wording

### DIFF
--- a/utils/issue-format-bot/lib/helptext.js
+++ b/utils/issue-format-bot/lib/helptext.js
@@ -1,0 +1,3 @@
+// Copyright 2017 AJ Jordan, AGPLv3+
+
+module.exports = '\n\nIf I\'m misbehaving, or if you have questions, feel free to ping `@strugee`. <!-- PING_STRUGEE_NOTE_POSTED -->';

--- a/utils/issue-format-bot/lib/issueedit.js
+++ b/utils/issue-format-bot/lib/issueedit.js
@@ -37,16 +37,16 @@ module.exports = function(robot, alexa) {
       let params;
       switch (data.message) {
       case 'invalid type':
-        params = context.issue({body: 'Sorry, I still couldn\'t understand the type of issue you specified. Did you look at the issue template?\n\nPlease try again.'});
+        params = context.issue({body: 'Sorry, I still couldn\'t understand the type of issue you specified. Did you look at the [issue template](https://github.com/EFForg/https-everywhere/blob/master/.github/ISSUE_TEMPLATE.md)?\n\nPlease try again.'});
         return context.github.issues.createComment(params);
       case 'multiple types':
         params = context.issue({body: 'Sorry, but I\'m still seeing more than one type. Can you edit your issue and delete all but one of the types in your issue?'});
         return context.github.issues.createComment(params);
       case 'no type':
-        params = context.issue({body: 'I still don\'t see the type of issue in your description. Can you edit your issue to add this (perhaps referring to the [issue template](https://github.com/EFForg/https-everywhere/blob/master/.github/ISSUE_TEMPLATE.md)?)'});
+        params = context.issue({body: 'I still don\'t see the type of issue in your description. Can you edit your issue to add this information (perhaps referring to the [issue template](https://github.com/EFForg/https-everywhere/blob/master/.github/ISSUE_TEMPLATE.md)?)\n\nAll I need is `Type: <type>` on its own line in the issue body. For example, `Type: new ruleset`. The issue template has a list of types I can understand.'});
         return context.github.issues.createComment(params);
       case 'null description':
-        params = context.issue({body: 'I still don\'t see any text in your description - please edit it to use the issue template. Thank you!'});
+        params = context.issue({body: 'I still don\'t see any text in your description - please edit it to use the [issue template](https://github.com/EFForg/https-everywhere/blob/master/.github/ISSUE_TEMPLATE.md). Thank you!'});
         return context.github.issues.createComment(params);
       default:
         throw data;

--- a/utils/issue-format-bot/lib/issueedit.js
+++ b/utils/issue-format-bot/lib/issueedit.js
@@ -5,6 +5,7 @@
 const parse = require('./parse'),
   validate = require('./validate'),
   labeler = require('./labeler'),
+  helptext = require('./helptext'),
   _ = require('lodash');
 
 // We do this outside the event handler to avoid setting up and tearing down this object each time a hook is received
@@ -37,16 +38,16 @@ module.exports = function(robot, alexa) {
       let params;
       switch (data.message) {
       case 'invalid type':
-        params = context.issue({body: 'Sorry, I still couldn\'t understand the type of issue you specified. Did you look at the [issue template](https://github.com/EFForg/https-everywhere/blob/master/.github/ISSUE_TEMPLATE.md)?\n\nPlease try again.'});
+        params = context.issue({body: 'Sorry, I still couldn\'t understand the type of issue you specified. Did you look at the [issue template](https://github.com/EFForg/https-everywhere/blob/master/.github/ISSUE_TEMPLATE.md)?\n\nPlease try again.' + helptext});
         return context.github.issues.createComment(params);
       case 'multiple types':
-        params = context.issue({body: 'Sorry, but I\'m still seeing more than one type. Can you edit your issue and delete all but one of the types in your issue?'});
+        params = context.issue({body: 'Sorry, but I\'m still seeing more than one type. Can you edit your issue and delete all but one of the types in your issue?' + helptext});
         return context.github.issues.createComment(params);
       case 'no type':
-        params = context.issue({body: 'I still don\'t see the type of issue in your description. Can you edit your issue to add this information (perhaps referring to the [issue template](https://github.com/EFForg/https-everywhere/blob/master/.github/ISSUE_TEMPLATE.md)?)\n\nAll I need is `Type: <type>` on its own line in the issue body. For example, `Type: new ruleset`. The issue template has a list of types I can understand.'});
+        params = context.issue({body: 'I still don\'t see the type of issue in your description. Can you edit your issue to add this information (perhaps referring to the [issue template](https://github.com/EFForg/https-everywhere/blob/master/.github/ISSUE_TEMPLATE.md)?)\n\nAll I need is `Type: <type>` on its own line in the issue body. For example, `Type: new ruleset`. The issue template has a list of types I can understand.' + helptext});
         return context.github.issues.createComment(params);
       case 'null description':
-        params = context.issue({body: 'I still don\'t see any text in your description - please edit it to use the [issue template](https://github.com/EFForg/https-everywhere/blob/master/.github/ISSUE_TEMPLATE.md). Thank you!'});
+        params = context.issue({body: 'I still don\'t see any text in your description - please edit it to use the [issue template](https://github.com/EFForg/https-everywhere/blob/master/.github/ISSUE_TEMPLATE.md). Thank you!' + helptext});
         return context.github.issues.createComment(params);
       default:
         throw data;
@@ -95,9 +96,9 @@ module.exports = function(robot, alexa) {
       comment += 'Here are the problems I ran into this time:\n\n';
       problems.forEach(problem => comment += ` * ${problem}\n`);
       comment += '\nIf you edit your issue again, I\'ll try again and report back if I have problems again.';
+      comment += helptext
       const params = context.issue({body: comment});
       return context.github.issues.createComment(params);
-
     }
   };
 };

--- a/utils/issue-format-bot/lib/newissue.js
+++ b/utils/issue-format-bot/lib/newissue.js
@@ -5,6 +5,7 @@
 const parse = require('./parse'),
   validate = require('./validate'),
   labeler = require('./labeler'),
+  helptext = require('./helptext'),
   _ = require('lodash');
 
 module.exports = function(robot, alexa) {
@@ -26,16 +27,16 @@ module.exports = function(robot, alexa) {
       let params;
       switch (data.message) {
       case 'invalid type':
-        params = context.issue({body: 'Hey there, I didn\'t understand the type of issue you specified. Please edit it and try again.'});
+        params = context.issue({body: 'Hey there, I didn\'t understand the type of issue you specified. Please edit it and try again.' + helptext});
         return context.github.issues.createComment(params);
       case 'multiple types':
-        params = context.issue({body: 'Hello! You seem to have specified more than one type. Can you edit your issue and delete all but one of the types in your issue?'});
+        params = context.issue({body: 'Hello! You seem to have specified more than one type. Can you edit your issue and delete all but one of the types in your issue?' + helptext});
         return context.github.issues.createComment(params);
       case 'no type':
-        params = context.issue({body: 'Hey, I couldn\'t find the type of issue in your description. Can you edit your issue to add this information (perhaps referring to the [issue template](https://github.com/EFForg/https-everywhere/blob/master/.github/ISSUE_TEMPLATE.md)?)\n\nFor this to work I need `Type: <type>` on its own line in the issue body. For example, `Type: new ruleset`. There\'s a list of types I understand in the issue template.'});
+        params = context.issue({body: 'Hey, I couldn\'t find the type of issue in your description. Can you edit your issue to add this information (perhaps referring to the [issue template](https://github.com/EFForg/https-everywhere/blob/master/.github/ISSUE_TEMPLATE.md)?)\n\nFor this to work I need `Type: <type>` on its own line in the issue body. For example, `Type: new ruleset`. There\'s a list of types I understand in the issue template.' + helptext});
         return context.github.issues.createComment(params);
       case 'null description':
-        params = context.issue({body: 'Hi! I can\'t find any text in your description - please edit it to use the [issue template](https://github.com/EFForg/https-everywhere/blob/master/.github/ISSUE_TEMPLATE.md).'});
+        params = context.issue({body: 'Hi! I can\'t find any text in your description - please edit it to use the [issue template](https://github.com/EFForg/https-everywhere/blob/master/.github/ISSUE_TEMPLATE.md).' + helptext});
         return context.github.issues.createComment(params);
       default:
         throw data;
@@ -55,9 +56,9 @@ module.exports = function(robot, alexa) {
       comment += 'Here are the problems I ran into:\n\n';
       problems.forEach(problem => comment += ` * ${problem}\n`);
       comment += '\nIf you edit your issue, I\'ll try again and report back if I have problems again.';
+      comment += helptext
       const params = context.issue({body: comment});
       return context.github.issues.createComment(params);
-
     }
   };
 };

--- a/utils/issue-format-bot/lib/newissue.js
+++ b/utils/issue-format-bot/lib/newissue.js
@@ -32,10 +32,10 @@ module.exports = function(robot, alexa) {
         params = context.issue({body: 'Hello! You seem to have specified more than one type. Can you edit your issue and delete all but one of the types in your issue?'});
         return context.github.issues.createComment(params);
       case 'no type':
-        params = context.issue({body: 'Hey, I couldn\'t find the type of issue in your description. Can you edit your issue to add this (perhaps referring to the [issue template](https://github.com/EFForg/https-everywhere/blob/master/.github/ISSUE_TEMPLATE.md)?)'});
+        params = context.issue({body: 'Hey, I couldn\'t find the type of issue in your description. Can you edit your issue to add this information (perhaps referring to the [issue template](https://github.com/EFForg/https-everywhere/blob/master/.github/ISSUE_TEMPLATE.md)?)\n\nFor this to work I need `Type: <type>` on its own line in the issue body. For example, `Type: new ruleset`. There\'s a list of types I understand in the issue template.'});
         return context.github.issues.createComment(params);
       case 'null description':
-        params = context.issue({body: 'Hi! I can\'t find any text in your description - please edit it to use the issue template.'});
+        params = context.issue({body: 'Hi! I can\'t find any text in your description - please edit it to use the [issue template](https://github.com/EFForg/https-everywhere/blob/master/.github/ISSUE_TEMPLATE.md).'});
         return context.github.issues.createComment(params);
       default:
         throw data;

--- a/utils/issue-format-bot/test/helptext-test.js
+++ b/utils/issue-format-bot/test/helptext-test.js
@@ -1,0 +1,20 @@
+// Copyright 2017 AJ Jordan, AGPLv3+
+
+'use strict';
+
+const vows = require('perjury'),
+  assert = vows.assert;
+
+vows.describe('help text constant module').addBatch({
+  'When we require the module': {
+    topic: function() {
+      return require('../lib/helptext');
+    },
+    'it works': function(err) {
+      assert.ifError(err);
+    },
+    'it\'s a string': function(err, helptext) {
+      assert.isString(helptext);
+    }
+  }
+}).export(module);


### PR DESCRIPTION
Suggested by @noloader in https://github.com/EFForg/https-everywhere/issues/14654#issuecomment-366416388. I also made it so that most interactions with the bot include a note to contact me in case of trouble, but I worry this could get repetitive in case the bot comments multiple times. See for example strugee/https-everywhere-test#49.

/cc @Hainish