### PR TITLE
Properly installing `chromedriver` on Mac

### DIFF
--- a/install-dev-dependencies.sh
+++ b/install-dev-dependencies.sh
@@ -50,7 +50,8 @@ if type apt-get >/dev/null ; then
   fi
 elif type brew >/dev/null ; then
   brew list python &>/dev/null || brew install python
-  brew install libxml2 gnu-sed chromedriver
+  brew cask install chromedriver
+  brew install libxml2 gnu-sed
   if ! echo $PATH | grep -ql /usr/local/bin ; then
     echo '/usr/local/bin not found in $PATH, please add it.'
   fi


### PR DESCRIPTION
On newer versions of Mac, chromedriver can be installed using `brew cask install chromedriver`