### PR TITLE
Update ruleset: Github Pages

### DIFF
--- a/src/chrome/content/rules/Github-Pages.xml
+++ b/src/chrome/content/rules/Github-Pages.xml
@@ -27,7 +27,6 @@
 
 	<!-- See https://github.com/EFForg/https-everywhere/issues/14615 -->
 	<exclusion pattern="^http://awoodruff\.github\.io/dst-sunrise-sunset-map/$" />
-		<test url="http://andywoodruff.com/blog/where-to-hate-daylight-saving-time-and-where-to-love-it/" />
 		<test url="http://awoodruff.github.io/dst-sunrise-sunset-map/" />
 
 	<securecookie host=".+" name=".+" />

--- a/src/chrome/content/rules/Github-Pages.xml
+++ b/src/chrome/content/rules/Github-Pages.xml
@@ -20,6 +20,13 @@
 		<test url="http://googletrends.github.io/GOPDebate1/" />
 		<test url="http://googletrends.github.io/iframe-scaffolder/" />
 
+	<exclusion pattern="^http://schizoduckie\.github\.io/DuckieTorrent/?" />
+	<exclusion pattern="^http://schizoduckie\.github\.io/PimpMyuTorrent/?" />
+		<test url="http://schizoduckie.github.io/DuckieTorrent" />
+		<test url="http://schizoduckie.github.io/DuckieTorrent/" />
+		<test url="http://schizoduckie.github.io/PimpMyuTorrent" />
+		<test url="http://schizoduckie.github.io/PimpMyuTorrent/" />
+
 	<!-- Avoid mixed content blocking -->
 	<exclusion pattern="^http://katbailey\.github\.io/" />
 		<test url="http://katbailey.github.io/" />

--- a/src/chrome/content/rules/Github-Pages.xml
+++ b/src/chrome/content/rules/Github-Pages.xml
@@ -20,20 +20,17 @@
 		<test url="http://googletrends.github.io/GOPDebate1/" />
 		<test url="http://googletrends.github.io/iframe-scaffolder/" />
 
-	<exclusion pattern="^http://schizoduckie\.github\.io/DuckieTorrent/?" />
-	<exclusion pattern="^http://schizoduckie\.github\.io/PimpMyuTorrent/?" />
-		<test url="http://schizoduckie.github.io/DuckieTorrent" />
-		<test url="http://schizoduckie.github.io/DuckieTorrent/" />
-		<test url="http://schizoduckie.github.io/PimpMyuTorrent" />
-		<test url="http://schizoduckie.github.io/PimpMyuTorrent/" />
-
 	<!-- Avoid mixed content blocking -->
 	<exclusion pattern="^http://katbailey\.github\.io/" />
 		<test url="http://katbailey.github.io/" />
 		<test url="http://katbailey.github.io/post/gaussian-processes-for-dummies/" />
 
+	<!-- See https://github.com/EFForg/https-everywhere/issues/14615 -->
+	<exclusion pattern="^http://awoodruff\.github\.io/dst-sunrise-sunset-map/$" />
+		<test url="http://andywoodruff.com/blog/where-to-hate-daylight-saving-time-and-where-to-love-it/" />
+		<test url="http://awoodruff.github.io/dst-sunrise-sunset-map/" />
+
 	<securecookie host=".+" name=".+" />
 
 	<rule from="^http:"	to="https:"/>
-
 </ruleset>


### PR DESCRIPTION
- ~~Remove exclusion rules for `schizoduckie.github.io`, no breakage over HTTPS~~
- Fix #14615