### PR TITLE
Updates test sites for Solus-Project.com and makes it deafult to on

### DIFF
--- a/src/chrome/content/rules/Solus-Project.com.xml
+++ b/src/chrome/content/rules/Solus-Project.com.xml
@@ -1,25 +1,16 @@
-
-<!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://bugs.solus-project.com/ => https://bugs.solus-project.com/: (6, 'Could not resolve host: bugs.solus-project.com')
-
-	STS header includes includeSubdomains
-
--->
-<ruleset name="Solus-Project.com" default_off='failed ruleset test'>
+ <ruleset name="Solus-Project.com">
 
 	<target host="solus-project.com" />
 	<target host="*.solus-project.com" />
 
-		<test url="http://bugs.solus-project.com/" />
-		<test url="http://wiki.solus-project.com/" />
+		<test url="http://build.solus-project.com/" />
+		<test url="http://dev.solus-project.com/" />
 		<test url="http://www.solus-project.com/" />
 
 
 	<securecookie host=".+" name=".+" />
 
 
-	<rule from="^http:"
-		to="https:" />
+	<rule from="^http:"	to="https:" />
 
 </ruleset>


### PR DESCRIPTION
The error that made the rule error was because of "bugs.solus-project.com" and that site does not exist anymore. This PR makes it default on and it updates the test sites to sites that exists now in 2018. I have been using the old rule for a long time and it does not cause any site breakage so it should be fine to make it default to on :+1: 