### PR TITLE
Update aastocks.com.xml

### DIFF
--- a/src/chrome/content/rules/aastocks.com.xml
+++ b/src/chrome/content/rules/aastocks.com.xml
@@ -94,8 +94,6 @@
 	<target host="fcadata.aastocks.com" />
 	<target host="fcsdata.aastocks.com" />
 	<target host="fctdata.aastocks.com" />
-	<!-- target host="fpdata.aastocks.com" / -->
-	<!-- target host="fxcharts.aastocks.com" / -->
 	<target host="chartdata1.internet.aastocks.com" />
 	
 	<target host="hkg.aastocks.com" />
@@ -139,7 +137,7 @@
 	<securecookie host="hkg8\.aastocks\.com" name=".+" />
 
 	<securecookie host="logon\.aastocks\.com" name=".+" />
-	<securecookie host="secure\.aastocks.com" name=".+" />
+	<securecookie host="secure\.aastocks\.com" name=".+" />
 
 	<rule from="^http://hkg1?\.aastocks\.com/"
 		  	to="https://hkg3.aastocks.com/" />

--- a/src/chrome/content/rules/aastocks.com.xml
+++ b/src/chrome/content/rules/aastocks.com.xml
@@ -74,6 +74,12 @@
 -->
 <ruleset name="AASTOCKS.com (partial)">
 	<target host="www.aastocks.com" />
+	<!-- 
+		On Firefox, enforcing HTTPS on the homepages will break the "Real-time
+		Latest Quote" functionalities because the Access-Control-Allow-Origin
+		header requiring HTTP. This bug has do not affect Chromium browser (by 
+		default) or Firefox in HTTP Nowhere mode (#15606)
+	-->
 	<exclusion pattern="^http://www\.aastocks\.com/(tc|sc|en)/$" />
 	<exclusion pattern="^http://www\.aastocks\.com/(tc|sc|en)/.+\.as[hp]x" />
 	<test url="http://www.aastocks.com/sc/" />
@@ -97,6 +103,8 @@
 	<target host="chartdata1.internet.aastocks.com" />
 	
 	<target host="hkg.aastocks.com" />
+	<test url="http://hkg.aastocks.com/cms/commentary/commentator_photo_chi_17.jpg" />
+	<test url="http://hkg.aastocks.com/cms/commentary/commentator_photo_chi_76.png" />
 	<target host="hkg1.aastocks.com" />
 	<target host="hkg3.aastocks.com" />
 	<target host="hkg8.aastocks.com" />

--- a/src/chrome/content/rules/aastocks.com.xml
+++ b/src/chrome/content/rules/aastocks.com.xml
@@ -11,6 +11,7 @@
 			 - stanjson-uat.aastocks.com
 
 		Connection refused:
+			 - fxcharts.aastocks.com
 			 - hkg.aastocks.com
 			 - hkg1.aastocks.com
 			 - m.aastocks.com
@@ -93,7 +94,7 @@
 	<target host="fcsdata.aastocks.com" />
 	<target host="fctdata.aastocks.com" />
 	<target host="fpdata.aastocks.com" />
-	<target host="fxcharts.aastocks.com" />
+	<!-- target host="fxcharts.aastocks.com" / -->
 	<target host="chartdata1.internet.aastocks.com" />
 	
 	<target host="hkg.aastocks.com" />

--- a/src/chrome/content/rules/aastocks.com.xml
+++ b/src/chrome/content/rules/aastocks.com.xml
@@ -10,16 +10,10 @@
 			 - stanjson.aastocks.com
 			 - stanjson-uat.aastocks.com
 
-		Couldn't resolve host name:
-			 - sccharts.aastocks.com
-			 - sccharts-uat.aastocks.com
-			 - standardchartered.aastocks.com
-			 - standardchartered-uat.aastocks.com
-
-		Couldn't connect to server:
-			 - mail.cn.aastocks.com
-			 - smtp.cn.aastocks.com
-			 - smtp1.cn.aastocks.com
+		Connection refused:
+			 - hkg.aastocks.com
+			 - hkg1.aastocks.com
+			 - m.aastocks.com
 
 		Timeout was reached:
 			 - bb.aastocks.com
@@ -32,8 +26,6 @@
 			 - fund.aastocks.com
 			 - fx.aastocks.com
 			 - payment.aastocks.com
-			 - smtp.aastocks.com
-			 - smtp2.aastocks.com
 			 - tldata.aastocks.com
 			 - ws2.aastocks.com
 			 - wss-uat.aastocks.com
@@ -116,7 +108,7 @@
 	<target host="logon.aastocks.com" />
 	<test url="http://logon.aastocks.com/payment/tc/termsconditions.aspx" />
 	
-	<target host="m.aastocks.com" />
+	<!-- target host="m.aastocks.com" / -->
 	<target host="mpdata.aastocks.com" />
 	
 	<target host="plib.aastocks.com" />
@@ -147,5 +139,9 @@
 	<securecookie host="logon\.aastocks\.com" name=".+" />
 	<securecookie host="secure\.aastocks.com" name=".+" />
 
-	<rule from="^http:" to="https:" />
+	<rule from="^http://hkg1?\.aastocks\.com/"
+		  	to="https://hkg3.aastocks.com/" />
+	
+	<rule from="^http:" 
+		  	to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/aastocks.com.xml
+++ b/src/chrome/content/rules/aastocks.com.xml
@@ -77,7 +77,7 @@
 	<!-- 
 		On Firefox, enforcing HTTPS on the homepages will break the "Real-time
 		Latest Quote" functionalities because the Access-Control-Allow-Origin
-		header requiring HTTP. This bug has do not affect Chromium browser (by 
+		header requiring HTTP. This bug does not affect Chromium browser (by 
 		default) or Firefox in HTTP Nowhere mode (#15606)
 	-->
 	<exclusion pattern="^http://www\.aastocks\.com/(tc|sc|en)/$" />

--- a/src/chrome/content/rules/aastocks.com.xml
+++ b/src/chrome/content/rules/aastocks.com.xml
@@ -80,6 +80,7 @@
 -->
 <ruleset name="AASTOCKS.com (partial)">
 	<target host="www.aastocks.com" />
+	<exclusion pattern="^http://www\.aastocks\.com/(tc|sc|en)/$" />
 	<exclusion pattern="^http://www\.aastocks\.com/(tc|sc|en)/.+\.as[hp]x" />
 	<test url="http://www.aastocks.com/sc/default.aspx" />
 	<test url="http://www.aastocks.com/tc/ltp/rtquote.aspx?symbol=00005" />

--- a/src/chrome/content/rules/aastocks.com.xml
+++ b/src/chrome/content/rules/aastocks.com.xml
@@ -11,6 +11,7 @@
 			 - stanjson-uat.aastocks.com
 
 		Connection refused:
+			 - fpdata.aastocks.com
 			 - fxcharts.aastocks.com
 			 - hkg.aastocks.com
 			 - hkg1.aastocks.com
@@ -93,7 +94,7 @@
 	<target host="fcadata.aastocks.com" />
 	<target host="fcsdata.aastocks.com" />
 	<target host="fctdata.aastocks.com" />
-	<target host="fpdata.aastocks.com" />
+	<!-- target host="fpdata.aastocks.com" / -->
 	<!-- target host="fxcharts.aastocks.com" / -->
 	<target host="chartdata1.internet.aastocks.com" />
 	

--- a/src/chrome/content/rules/aastocks.com.xml
+++ b/src/chrome/content/rules/aastocks.com.xml
@@ -82,6 +82,9 @@
 	<target host="www.aastocks.com" />
 	<exclusion pattern="^http://www\.aastocks\.com/(tc|sc|en)/$" />
 	<exclusion pattern="^http://www\.aastocks\.com/(tc|sc|en)/.+\.as[hp]x" />
+	<test url="http://www.aastocks.com/sc/" />
+	<test url="http://www.aastocks.com/tc/" />
+	<test url="http://www.aastocks.com/en/" />
 	<test url="http://www.aastocks.com/sc/default.aspx" />
 	<test url="http://www.aastocks.com/tc/ltp/rtquote.aspx?symbol=00005" />
 	<test url="http://www.aastocks.com/en/stocks/quote/detail-quote.aspx?symbol=02822" />


### PR DESCRIPTION
- Do not force HTTPS on the homepage as this break the "Real-time Latest Quote" functionality
- Regarding #14275, it seems to happen only on Chromium browser with CORS issues (partially resolved in #15606). 