### PR TITLE
Fix some CORS issues in HTTP Nowhere mode

### DIFF
--- a/chromium/background-scripts/background.js
+++ b/chromium/background-scripts/background.js
@@ -614,7 +614,7 @@ function onHeadersReceived(details) {
 
         // If HTTP protocol is used, change it to HTTPS
         if (value.match(/http:/)) {
-          details.responseHeaders[idx].value = value.replace(/http:/, "https:");
+          details.responseHeaders[idx].value = value.replace(/http:/g, "https:");
           responseHeadersChanged = true;
         }
       }


### PR DESCRIPTION
 * Rewrite access-control-allow-origin to avoid the HTTP protocol in
HTTP Nowhere mode

This change make CORS issues like #14275 less likely to happen in HTTP Nowhere mode