### PR TITLE
Spring cleaning #3

### DIFF
--- a/src/chrome/content/rules/33Across.xml
+++ b/src/chrome/content/rules/33Across.xml
@@ -35,7 +35,6 @@
 	<securecookie host="^(?:.*\.)?33across\.com$" name=".+" />
 
 
-	<rule from="^http://(\w+\.)?33across\.com/"
-		to="https://$133across.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Acessoseguro.net.xml
+++ b/src/chrome/content/rules/Acessoseguro.net.xml
@@ -6,7 +6,6 @@
 	<securecookie host=".+\.acessoseguro\.net$" name=".+" />
 
 
-	<rule from="^http://([\w-]+)\.acessoseguro\.net/"
-		to="https://$1.acessoseguro.net/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/ActionKit.com.xml
+++ b/src/chrome/content/rules/ActionKit.com.xml
@@ -15,7 +15,6 @@
 	<securecookie host="^\w+\.actionkit\.com$" name=".+" />
 
 
-	<rule from="^http://(\w+)\.actionkit\.com/"
-		to="https://$1.actionkit.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Active-Events.xml
+++ b/src/chrome/content/rules/Active-Events.xml
@@ -14,7 +14,6 @@
 	<securecookie host="^.+\.activenetwork\.com$" name=".+" />
 
 
-	<rule from="^http://([\w\-]+)\.activeevents\.com/"
-		to="https://$1.activeevents.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/AdSpirit.xml
+++ b/src/chrome/content/rules/AdSpirit.xml
@@ -22,7 +22,6 @@ Fetch error: http://cdn6.adspirit.de/banner/1x1.gif => https://cdn6.adspirit.de/
 		<test url="http://urban.adspirit.de/adnoclick.php?pid=" />
 
 
-	<rule from="^http://([\w-]+)\.adspirit\.de/"
-		to="https://$1.adspirit.de/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Adverticum.xml
+++ b/src/chrome/content/rules/Adverticum.xml
@@ -1,5 +1,5 @@
 <ruleset name="Adverticum">
 	<target host="*.adverticum.net" />
 
-	<rule from="^http://([^@:/]*)\.adverticum\.net/" to="https://$1.adverticum.net/" />
+	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Airshow-Journal.xml
+++ b/src/chrome/content/rules/Airshow-Journal.xml
@@ -5,7 +5,6 @@
 
 
 	<!--	Unique subdomains for each gallery.	-->
-	<rule from="^http://(\w+)\.airshowjournal\.com/"
-		to="https://$1.airshowjournal.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Algonquin-College.xml
+++ b/src/chrome/content/rules/Algonquin-College.xml
@@ -10,8 +10,7 @@
 	<test url="http://m.algonquincollege.com/" />
 	<test url="http://myalgonquin2.algonquincollege.com/" />	
 
-	<rule from="^http://([\w.-]+)\.algonquincollege\.com/"
-		to="https://$1.algonquincollege.com/" />
+	<rule from="^http:" to="https:" />
 
 	<!-- Does not reply with any content to HTTPS. -->
 	<exclusion pattern="^http://myalgonquin2\.algonquincollege\.com/" />	

--- a/src/chrome/content/rules/AlliedMods.xml
+++ b/src/chrome/content/rules/AlliedMods.xml
@@ -4,8 +4,5 @@
 
 	<securecookie host="^(?:.*\.)?alliedmods\.net$" name=".+" />
 
-	<rule from="^http://([^/@:\.]+)\.alliedmods\.net/"
-		to="https://$1.alliedmods.net/" />
-
-	<rule from="^http://alliedmods\.net/" to="https://alliedmods.net/" />
+	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Alternate.xml
+++ b/src/chrome/content/rules/Alternate.xml
@@ -12,12 +12,5 @@ Fetch error: http://alternate-b2b.nl/ => https://alternate-b2b.nl/: (51, "SSL: n
   <target host="*.alternate-b2b.nl"/>
   <target host="alternate-b2b.nl"/>
 
-  <rule from="^http://([^/:@]*)\.alternate\.be/" to="https://$1.alternate.be/"/>
-  <rule from="^http://alternate\.be/" to="https://alternate.be/"/>
-
-  <rule from="^http://([^/:@]*)\.alternate\.nl/" to="https://$1.alternate.nl/"/>
-  <rule from="^http://alternate\.nl/" to="https://alternate.nl/"/>
-
-  <rule from="^http://([^/:@]*)\.alternate-b2b\.nl/" to="https://$1.alternate-b2b.nl/"/>
-  <rule from="^http://alternate-b2b\.nl/" to="https://alternate-b2b.nl/"/>
+  <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/American-Association-of-Neurological-Surgeons.xml
+++ b/src/chrome/content/rules/American-Association-of-Neurological-Surgeons.xml
@@ -30,7 +30,6 @@ Fetch error: http://aans.org/ => https://aans.org/: (60, 'SSL certificate proble
 			- online
 			- www
 				-->
-	<rule from="^http://(\w+\.)?aans\.org/"
-		to="https://$1aans.org/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Analytics.edgesuite.net.xml
+++ b/src/chrome/content/rules/Analytics.edgesuite.net.xml
@@ -3,7 +3,6 @@
 	<target host="*.analytics.edgekey.net" />
 
 
-	<rule from="^http://([\w-]+)\.analytics\.edgekey\.net/"
-		to="https://$1.analytics.edgekey.net/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/AnnualCreditReport.com.xml
+++ b/src/chrome/content/rules/AnnualCreditReport.com.xml
@@ -11,7 +11,6 @@
 	<securecookie host="^(?:.*\.)?annualcreditreport\.com$" name=".+" />
 
 
-	<rule from="^http://([\w-]+\.)?annualcreditreport\.com/"
-		to="https://$1annualcreditreport.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Atlantic.net.xml
+++ b/src/chrome/content/rules/Atlantic.net.xml
@@ -29,7 +29,6 @@
 	<securecookie host="^(?:.*\.)?atlantic\.net$" name=".+" />
 
 
-	<rule from="^http://([^/:@]+\.)?atlantic\.net/"
-		to="https://$1atlantic.net/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Attracta.xml
+++ b/src/chrome/content/rules/Attracta.xml
@@ -19,7 +19,6 @@
 	<securecookie host="^(?:.*\.)?attracta\.com$" name=".+" />
 
 
-	<rule from="^http://(\w+\.)?attracta\.com/"
-		to="https://$1attracta.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Audience-Ad-Network.xml
+++ b/src/chrome/content/rules/Audience-Ad-Network.xml
@@ -11,11 +11,7 @@ Fetch error: http://manage.audienceadnetwork.com/ => https://manage.audienceadne
 	<target host="manage.audienceadnetwork.com"/>
 	<target host="*.qwobl.net"/>
 
-	<rule from="^http://manage\.audienceadnetwork\.com/"
-		to="https://manage.audienceadnetwork.com/"/>
-
-	<rule from="^http://(\w+)\.qwobl\.net/"
-		to="https://$1.qwobl.net/"/>
+	<rule from="^http:" to="https:" />
 
 	<securecookie host="^manage\.audienceadnetwork\.com$" name=".+" />
 	<securecookie host="^\.qwobl\.net$" name=".+" />

--- a/src/chrome/content/rules/BCGolf.com-mismatches.xml
+++ b/src/chrome/content/rules/BCGolf.com-mismatches.xml
@@ -7,7 +7,6 @@
 
 	<securecookie host="^.*\.golf2go\.net$" name=".+" />
 
-	<rule from="^http://([\w\-]+)\.golf2go\.net/"
-		to="https://$1.golf2go.net/"/>
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/BLOX.xml
+++ b/src/chrome/content/rules/BLOX.xml
@@ -3,7 +3,6 @@
 	<target host="*.bloxcms.com" />
 
 
-	<rule from="^http://([\w\-]+)\.bloxcms\.com/"
-		to="https://$1.bloxcms.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Bernard_Hodes_Group.xml
+++ b/src/chrome/content/rules/Bernard_Hodes_Group.xml
@@ -19,10 +19,6 @@ Fetch error: http://jobmatcher.hodesiq.com/ => https://jobmatcher.hodesiq.com/: 
 	<securecookie host="^.+\.sc\.hodesdigital\.com$" name=".+" />
 
 
-	<rule from="^http://(\w+)\.sc\.hodesdigital\.com/"
-		to="https://$1.sc.hodesdigital.com/" />
-
-	<rule from="^http://jobmatcher\.hodesiq\.com/"
-		to="https://jobmatcher.hodesiq.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Blau.de.xml
+++ b/src/chrome/content/rules/Blau.de.xml
@@ -19,7 +19,6 @@
 	<securecookie host="^(?:.+\.)?blau\.de$" name=".+" />
 
 
-	<rule from="^http://([^/:@]+\.)?blau\.de/"
-		to="https://$1blau.de/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Blazonco.com.xml
+++ b/src/chrome/content/rules/Blazonco.com.xml
@@ -17,7 +17,6 @@
 	<securecookie host="^(?:.*\.)?blazonco\.com$" name=".+" />
 
 
-	<rule from="^http://([\w-]+\.)?blazonco\.com/"
-		to="https://$1blazonco.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Bluehosting.pl.xml
+++ b/src/chrome/content/rules/Bluehosting.pl.xml
@@ -13,7 +13,6 @@
 	<securecookie host="^.+\.bho\.pl$" name=".+" />
 
 
-	<rule from="^http://([\w-]+\.)?bho\.pl/"
-		to="https://$1bho.pl/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Branchable.com.xml
+++ b/src/chrome/content/rules/Branchable.com.xml
@@ -15,7 +15,6 @@
 	<securecookie host=".+\.branchable\.com$" name=".+" />
 
 
-	<rule from="^http://([\w-]+\.)?branchable\.com/"
-		to="https://$1branchable.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/BuddyPress.org.xml
+++ b/src/chrome/content/rules/BuddyPress.org.xml
@@ -12,7 +12,6 @@
 	<target host="*.buddypress.org" />
 
 
-	<rule from="^http://(\w+\.)?buddypress\.org/"
-		to="https://$1buddypress.org/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/BuyBoard.xml
+++ b/src/chrome/content/rules/BuyBoard.xml
@@ -18,7 +18,6 @@ Fetch error: http://buyboard.com/ => https://buyboard.com/: (51, "SSL: no altern
 
 	<securecookie host="^.*\.buyboard\.com$" name=".+" />
 
-	<rule from="^http://(\w+\.)?buyboard\.com/"
-		to="https://$1buyboard.com/"/>
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/CDN77.com.xml
+++ b/src/chrome/content/rules/CDN77.com.xml
@@ -22,10 +22,6 @@
 	<target host="*.r.worldssl.net" />
 
 
-	<rule from="^http://client\.cdn77\.com/"
-		to="https://client.cdn77.com/" />
-
-	<rule from="^http://([\w-]+)\.r\.worldssl\.net/"
-		to="https://$1.r.worldssl.net/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/CIBC.xml
+++ b/src/chrome/content/rules/CIBC.xml
@@ -1,5 +1,4 @@
 <ruleset name="CIBC">
-	<target host="cibc.com" />
 	<target host="*.cibc.com" />
-	<rule from="^http://([^/:@\.]+)\.cibc\.com/" to="https://$1.cibc.com/"/>
+	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/CanadaPost.xml
+++ b/src/chrome/content/rules/CanadaPost.xml
@@ -1,6 +1,5 @@
 <ruleset name="Canada Post">
-  <target host="canadapost.ca" />
   <target host="*.canadapost.ca" />
 
-  <rule from="^http://([^/:@\.]+)\.canadapost\.ca/" to="https://$1.canadapost.ca/"/>
+  <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Check24.de.xml
+++ b/src/chrome/content/rules/Check24.de.xml
@@ -2,6 +2,5 @@
   <target host="check24.de" />
   <target host="*.check24.de" />
 
-  <rule from="^http://check24\.de/" to="https://check24.de/"/>
-  <rule from="^http://([^/:@]*)\.check24\.de/" to="https://$1.check24.de/"/>
+  <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/CloudSwitch.xml
+++ b/src/chrome/content/rules/CloudSwitch.xml
@@ -13,7 +13,6 @@ Fetch error: http://cloudswitch.com/ => https://cloudswitch.com/: (51, "SSL: no 
 
 	<securecookie host=".*cloudswitch\.com$" name=".+" />
 
-	<rule from="^http://(\w+\.)?cloudswitch\.com/"
-		to="https://$1cloudswitch.com/"/>
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Cloudimage.io.xml
+++ b/src/chrome/content/rules/Cloudimage.io.xml
@@ -12,7 +12,6 @@
 	<securecookie host="^(?:[\w-]+\.)?cloudimage\.io$" name=".+" />
 
 
-	<rule from="^http://([\w-]+\.)?cloudimage\.io/"
-		to="https://$1cloudimage.io/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Conduit-data.com.xml
+++ b/src/chrome/content/rules/Conduit-data.com.xml
@@ -20,7 +20,6 @@
 				-->
 	<securecookie host="^\.conduit-data\.com$" name=".+" />
 
-	<rule from="^http://([\w-]+)\.conduit-data\.com/"
-		to="https://$1.conduit-data.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Craigslist.org.xml
+++ b/src/chrome/content/rules/Craigslist.org.xml
@@ -20,8 +20,8 @@
 
 	<securecookie host=".+" name=".+" />
 
-	<rule from="^http://craigslist\.org/" to="https://craigslist.org/" />
+	<rule from="^http:" to="https:" />
 
 	<!-- As of 3/2017, 4th level craigslist.org domains do not support SSL. -->
-	<rule from="^http://([\w-]+)\.craigslist\.org/" to="https://$1.craigslist.org/" />
+	
 </ruleset>

--- a/src/chrome/content/rules/CyberGhost.xml
+++ b/src/chrome/content/rules/CyberGhost.xml
@@ -12,7 +12,6 @@
 			- blog
 			- support
 			- www		-->
-	<rule from="^http://(\w+\.)?cyberghostvpn\.com/"
-		to="https://$1cyberghostvpn.com/"/>
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/DKB.de.xml
+++ b/src/chrome/content/rules/DKB.de.xml
@@ -24,7 +24,6 @@
 	<securecookie host="^(?:banking|m|www)\.dkb\.de$" name=".+" />
 
 
-	<rule from="^http://([^/:@\.]+\.)?dkb\.de/"
-		to="https://$1dkb.de/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Data.fm.xml
+++ b/src/chrome/content/rules/Data.fm.xml
@@ -11,10 +11,6 @@ Fetch error: http://data.fm/ => https://data.fm/: (28, 'Connection timed out aft
 
 	<securecookie host=".*\.data\.fm$" name=".+" />
 
-	<rule from="^http://data\.fm/"
-		to="https://data.fm/"/>
-
-	<rule from="^http://([\w\-_]+)\.data\.fm/"
-		to="https://$1.data.fm/"/>
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Denh.am.xml
+++ b/src/chrome/content/rules/Denh.am.xml
@@ -4,7 +4,6 @@
 	<target host="*.denh.am" />
 
 
-	<rule from="^http://([^/:@\.]+\.)?denh\.am/"
-		to="https://$1denh.am/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/DotCOM-host.xml
+++ b/src/chrome/content/rules/DotCOM-host.xml
@@ -14,7 +14,6 @@
 			- webmail
 			- www
 				-->
-	<rule from="^http://(\w+\.)?dotcomhost\.com/"
-		to="https://$1dotcomhost.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Dotster.xml
+++ b/src/chrome/content/rules/Dotster.xml
@@ -7,7 +7,6 @@
 	<securecookie host="^\.dotster\.com$" name=".+" />
 
 
-	<rule from="^http://([^/:@\.]+\.)?dotster\.com/"
-		to="https://$1dotster.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Dovetail_Services.xml
+++ b/src/chrome/content/rules/Dovetail_Services.xml
@@ -17,7 +17,6 @@ Fetch error: http://subscribeonline.co.uk/ => https://subscribeonline.co.uk/: (3
 
 	<!--	Clients have unique subdomains.
 						-->
-	<rule from="^http://(\w+\.)?subscribeonline\.co\.uk/"
-		to="https://$1subscribeonline.co.uk/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Egnyte.xml
+++ b/src/chrome/content/rules/Egnyte.xml
@@ -8,7 +8,6 @@
 	<!--	encountered subdomains:
 			- blog
 			- helpdesk		-->
-	<rule from="^http://(\w+\.)?egnyte\.com/"
-		to="https://$1egnyte.com/"/>
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/FOSSBazaar.org.xml
+++ b/src/chrome/content/rules/FOSSBazaar.org.xml
@@ -14,7 +14,6 @@
 	<securecookie host="^(?:.*\.)?fossbazaar\.org$" name=".+" />
 
 
-	<rule from="^http://(\w+\.)?fossbazaar\.org/"
-		to="https://$1fossbazaar.org/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Fast-Web-Media.xml
+++ b/src/chrome/content/rules/Fast-Web-Media.xml
@@ -27,12 +27,10 @@ Fetch error: http://fwmapps.co.uk/ => https://fwmapps.co.uk/: (6, 'Could not res
 	<securecookie host="^.+\.fwmapps\.co\.uk$" name=".+" />
 
 
-	<rule from="^http://(www\.)?fastwebmedia\.com/"
-		to="https://$1fastwebmedia.com/" />
+	<rule from="^http:" to="https:" />
 
 	<!--	Clients have unique subdomains.
 						-->
-	<rule from="^http://([\w\-]+\.)?fwmapps\.co\.uk/"
-		to="https://$1fwmapps.co.uk/" />
+	
 
 </ruleset>

--- a/src/chrome/content/rules/FindTheBest.xml
+++ b/src/chrome/content/rules/FindTheBest.xml
@@ -34,7 +34,6 @@ Fetch error: http://findthebest.com/ => https://findthebest.com/: (51, "SSL: no 
 	<target host="*.findthebest.com" />
 
 
-	<rule from="^http://([\w-]+\.)?findthebest\.com/"
-		to="https://$1findthebest.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/FoeBuD.xml
+++ b/src/chrome/content/rules/FoeBuD.xml
@@ -7,7 +7,6 @@
 	<securecookie host="^\.(?:shop\.)?foebud\.org$" name=".+" />
 
 
-	<rule from="^http://([^/:@\.]+\.)?foebud\.org/"
-		to="https://$1foebud.org/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Footholds.net.xml
+++ b/src/chrome/content/rules/Footholds.net.xml
@@ -11,7 +11,6 @@
 		<exclusion pattern="^http://www\." />
 
 
-	<rule from="^http://([\w-]+)\.footholds\.net/"
-		to="https://$1.footholds.net/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Forocoches.com.xml
+++ b/src/chrome/content/rules/Forocoches.com.xml
@@ -3,7 +3,6 @@
 	<target host="forocoches.com" />
 	<target host="*.forocoches.com" />
 
-  <rule from="^http://forocoches\.com/" to="https://forocoches.com/"/>
-  <rule from="^http://([^/:@]*)\.forocoches\.com/" to="https://$1.forocoches.com/"/>
+  <rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/FreshBooks.xml
+++ b/src/chrome/content/rules/FreshBooks.xml
@@ -28,10 +28,6 @@ Fetch error: http://www.fb-assets.com/ => https://www.fb-assets.com/: (28, 'Conn
 	<securecookie host="^(?!www\.).+\.freshbooks\.com$" name=".+" />
 
 
-	<rule from="^http://(www\.)?fb-assets\.com/"
-		to="https://$1fb-assets.com/" />
-
-	<rule from="^http://([\w-]+\.)?freshbooks\.com/"
-		to="https://$1freshbooks.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Fwdcdn.com.xml
+++ b/src/chrome/content/rules/Fwdcdn.com.xml
@@ -3,7 +3,6 @@
 	<target host="*.fwdcdn.com" />
 
 
-	<rule from="^http://([\w-]+)\.fwdcdn\.com/"
-		to="https://$1.fwdcdn.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Gateway-State-Bank.xml
+++ b/src/chrome/content/rules/Gateway-State-Bank.xml
@@ -22,7 +22,6 @@
 	<securecookie host=".+" name=".+" />
 
 
-	<rule from="^http://([\w-]+\.)?gatewaysb\.com/"
-		to="https://$1gatewaysb.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Gigaserver.xml
+++ b/src/chrome/content/rules/Gigaserver.xml
@@ -28,7 +28,6 @@
 			- mail
 			- www
 				-->
-	<rule from="^http://(\w+\.)?gigaserver\.cz/"
-		to="https://$1gigaserver.cz/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/GitLab.io.xml
+++ b/src/chrome/content/rules/GitLab.io.xml
@@ -29,10 +29,6 @@
 		<test url="http://jordi.torne.gitlab.io/csvio-f90/" />
 	-->
 
-	<rule from="^http://([\w-]+)\.gitlab\.io/"
-		to="https://$1.gitlab.io/"/>
-
-	<rule from="^http://gitlab\.io/"
-		to="https://gitlab.io/"/>
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Groupon.gr.xml
+++ b/src/chrome/content/rules/Groupon.gr.xml
@@ -11,5 +11,5 @@ Fetch error: http://groupon.gr/ => https://groupon.gr/: (51, "SSL: no alternativ
 
 	<securecookie host="^(?:.*\.)?groupon\.gr$" name=".+" />
 
-  <rule from="^http://(\w+\.)?groupon\.gr/" to="https://$1groupon.gr/"/>
+  <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/HRsmart.xml
+++ b/src/chrome/content/rules/HRsmart.xml
@@ -11,10 +11,6 @@
 
 
 	<!--	Clients have unique subdomains.	-->
-	<rule from="^http://(\w+)\.(mua|tms)\.hrdepartment\.com/"
-		to="https://$1.$2.hrdepartment.com/" />
-
-	<rule from="^http://(www\.)?hrsmart\.com/"
-		to="https://$1hrsmart.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Hackpad.xml
+++ b/src/chrome/content/rules/Hackpad.xml
@@ -11,7 +11,6 @@
 	<securecookie host=".*\.hackpad\.com$" name=".+" />
 
 
-	<rule from="^http://([\w-]+\.)?hackpad\.com/"
-		to="https://$1hackpad.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/HelpOcean.xml
+++ b/src/chrome/content/rules/HelpOcean.xml
@@ -17,7 +17,6 @@ Fetch error: http://helpocean.com/ => https://helpocean.com/: (51, "SSL: no alte
 	<securecookie host="^\.helpocean\.com$" name=".+" />
 
 
-	<rule from="^http://([\w\-]+\.)?helpocean\.com/"
-		to="https://$1helpocean.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Helpshift.com.xml
+++ b/src/chrome/content/rules/Helpshift.com.xml
@@ -42,7 +42,6 @@
 	<securecookie host=".+\.helpshift\.com" name=".+" />
 
 
-	<rule from="^http://([\w-]+\.)?helpshift\.com/"
-		to="https://$1helpshift.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Heroku.xml
+++ b/src/chrome/content/rules/Heroku.xml
@@ -17,7 +17,6 @@
 
 	<securecookie host="^[\w\-]+\.herokuapp\.com$" name=".+" />
 
-	<rule from="^http://([\w-]+\.)?herokuapp\.com/"
-		to="https://$1herokuapp.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Hesecure.com.xml
+++ b/src/chrome/content/rules/Hesecure.com.xml
@@ -10,7 +10,6 @@
 	<securecookie host=".+\.c13\.hesecure\.com$" name=".+" />
 
 
-	<rule from="^http://([\w-]+)\.c13\.hesecure\.com/"
-		to="https://$1.c13.hesecure.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Hobsons-EMT.xml
+++ b/src/chrome/content/rules/Hobsons-EMT.xml
@@ -12,7 +12,6 @@
 	<securecookie host="^\w.*\.askadmissions\.net$" name=".+" />
 
 
-	<rule from="^http://([\w-]+)\.askadmissions\.net/"
-		to="https://$1.askadmissions.net/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Host1Plus.xml
+++ b/src/chrome/content/rules/Host1Plus.xml
@@ -9,7 +9,6 @@ Fetch error: http://host1plus.com/ => https://host1plus.com/: Cycle detected - U
 
 	<securecookie host="^(?:.*\.)?host1plus\.com$" name=".+" />
 
-	<rule from="^http://(\w+\.)?host1plus\.com/"
-		to="https://$1host1plus.com/"/>
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/IGrasp.xml
+++ b/src/chrome/content/rules/IGrasp.xml
@@ -6,7 +6,6 @@
 	<securecookie host="^.+\.i-grasp\.com$" name=".+" />
 
 
-	<rule from="^http://([\w-]+)\.i-grasp\.com/"
-		to="https://$1.i-grasp.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Iberia.xml
+++ b/src/chrome/content/rules/Iberia.xml
@@ -10,6 +10,5 @@ Fetch error: http://iberia.com/ => https://iberia.com/: (28, 'Operation timed ou
   <target host="iberia.com" />
   <target host="*.iberia.com" />
   
-  <rule from="^http://iberia\.com/" to="https://iberia.com/"/>
-  <rule from="^http://([^/:@\.]+)\.iberia\.com/" to="https://$1.iberia.com/"/>
+  <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Iljmp.com.xml
+++ b/src/chrome/content/rules/Iljmp.com.xml
@@ -18,7 +18,6 @@ Fetch error: http://iljmp.com/ => https://iljmp.com/: (51, "SSL: no alternative 
 	<securecookie host="(?:.*\.)?iljmp\.com$" name=".+" />
 
 
-	<rule from="^http://([\w-]+\.)?iljmp\.com/"
-		to="https://$1iljmp.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Innovation-Interactive.xml
+++ b/src/chrome/content/rules/Innovation-Interactive.xml
@@ -14,7 +14,6 @@
 	<securecookie host="^[\w-]+\.netmng\.com$" name="^evo5_[\w-]+$" />
 
 
-	<rule from="^http://([\w-]+)\.netmng\.com/"
-		to="https://$1.netmng.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Intelli-direct.com.xml
+++ b/src/chrome/content/rules/Intelli-direct.com.xml
@@ -13,7 +13,6 @@
 	<securecookie host="^\.intelli-direct\.com$" name=".+" />
 
 
-	<rule from="^http://([\w-]+\.)?intelli-direct\.com/"
-		to="https://$1intelli-direct.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Introweb.xml
+++ b/src/chrome/content/rules/Introweb.xml
@@ -2,5 +2,5 @@
 	<target host="*.introweb.hu" />
 
 	<securecookie host="^www\.introweb\.hu$" name=".+" />
-	<rule from="^http://([^@:/]*)\.introweb\.hu/" to="https://$1.introweb.hu/" />
+	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Intuitiv.xml
+++ b/src/chrome/content/rules/Intuitiv.xml
@@ -3,7 +3,6 @@
 	<target host="*.csmres.co.uk"/>
 		<exclusion pattern="^http://www\.csmres\.co\.uk/"/>
 
-	<rule from="^http://(\w+)\.csmres\.co\.uk/"
-		to="https://$1.csmres.co.uk/"/>
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Ivwbox.de.xml
+++ b/src/chrome/content/rules/Ivwbox.de.xml
@@ -23,7 +23,6 @@
 	<securecookie host=".+\.ivwbox\.de$" name=".+" />
 
 
-	<rule from="^http://([\w-]+)\.ivwbox\.de/"
-		to="https://$1.ivwbox.de/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Jappix.xml
+++ b/src/chrome/content/rules/Jappix.xml
@@ -30,7 +30,6 @@ Fetch error: http://jappix.com/ => https://jappix.com/: (51, "SSL: no alternativ
 	<target host="*.jappix.com" />
 
 
-	<rule from="^http://(\w+\.)?jappix\.com/"
-		to="https://$1jappix.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Job_a_matic.com.xml
+++ b/src/chrome/content/rules/Job_a_matic.com.xml
@@ -45,7 +45,6 @@ Fetch error: http://jobamatic.com/ => https://jobamatic.com/: (7, 'Failed to con
 
 	<!--	clients have unique subdomains
 						-->
-	<rule from="^http://([\w-]+\.)?jobamatic\.com/"
-		to="https://$1jobamatic.com/"/>
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Jobs2Web.xml
+++ b/src/chrome/content/rules/Jobs2Web.xml
@@ -23,7 +23,6 @@ Fetch error: http://jobs2web.com/ => https://jobs2web.com/: (51, "SSL: no altern
 	<securecookie host="^(?:.*\.)?jobs2web\.com$" name=".+" />
 
 
-	<rule from="^http://([\w-]+\.)?jobs2web\.com/"
-		to="https://$1jobs2web.com/"/>
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Joyent.xml
+++ b/src/chrome/content/rules/Joyent.xml
@@ -63,7 +63,6 @@
 	<!--rule from="^http://lpage\.joyent\.com/"
 		to="https://na-sjf.marketo.com/" /-->
 
-	<rule from="^http://([\w-]+\.)?joyent\.com/"
-		to="https://$1joyent.com/"/>
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Jumptap.xml
+++ b/src/chrome/content/rules/Jumptap.xml
@@ -7,5 +7,5 @@
 	<target host="*.jumptap.com" />
 
 	<exclusion pattern="^http://(?:db02|dine|reporting).jumptap.com" />
-	<rule from="^http://([^@:/]*)\.jumptap\.com/" to="https://$1.jumptap.com/" />
+	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/KLDP.net.xml
+++ b/src/chrome/content/rules/KLDP.net.xml
@@ -51,7 +51,6 @@ Fetch error: http://qmail.kldp.net/ => https://qmail.kldp.net/: (7, 'Failed to c
 		<test url="http://www.kldp.net/" />
 
 
-	<rule from="^http://([\w-]+\.)?kldp\.net/"
-		to="https://$1kldp.net/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/KLDP.org.xml
+++ b/src/chrome/content/rules/KLDP.org.xml
@@ -63,7 +63,6 @@ Fetch error: http://weblog.kldp.org/ => https://weblog.kldp.org/: (51, "SSL: no 
 		<test url="http://www.kldp.org/" />
 
 
-	<rule from="^http://([\w-]+\.)?kldp\.org/"
-		to="https://$1kldp.org/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Kayako-clients.xml
+++ b/src/chrome/content/rules/Kayako-clients.xml
@@ -16,7 +16,6 @@
 
 			robotshop.helpserve.com
 					-->
-	<rule from="^http://([\w\-]+)\.helpserve\.com/"
-		to="https://$1.helpserve.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Koding.xml
+++ b/src/chrome/content/rules/Koding.xml
@@ -7,7 +7,6 @@
 	<securecookie host="^(?:.+\.)?koding\.com$" name=".+" />
 
 
-	<rule from="^http://(\w+\.)?koding\.com/"
-		to="https://$1koding.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Kryptronic.xml
+++ b/src/chrome/content/rules/Kryptronic.xml
@@ -6,7 +6,6 @@
 
 	<securecookie host="^(?:.*\.)?kryptronic\.com$" name=".+" />
 
-	<rule from="^http://(\w+\.)?kryptronic\.com/"
-		to="https://$1kryptronic.com/"/>
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Labaia.xml
+++ b/src/chrome/content/rules/Labaia.xml
@@ -25,7 +25,6 @@ Fetch error: http://labaia.ws/ => https://labaia.ws/: (7, 'Failed to connect to 
 			- torrents
 			- upload
 					-->
-	<rule from="^http://(\w+\.)?labaia\.ws/"
-		to="https://$1labaia.ws/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/LibGuides.xml
+++ b/src/chrome/content/rules/LibGuides.xml
@@ -19,7 +19,6 @@ Fetch error: http://libguides.com/ => https://libguides.com/: Cycle detected - U
 	<target host="*.libguides.com" />
 
 
-	<rule from="^http://(\w+\.)?libguides\.com/"
-		to="https://$1libguides.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Limelight-Networks.xml
+++ b/src/chrome/content/rules/Limelight-Networks.xml
@@ -17,7 +17,6 @@
 		<test url="http://wsba.vo.llnwd.net/v1/CLE%20Documents/Post/17516_FinalAgenda.pdf" />
 	-->
 
-	<rule from="^http://([\w\-]+)\.hs\.llnwd\.net/"
-		to="https://$1.hs.llnwd.net/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/LogicBox_Software.xml
+++ b/src/chrome/content/rules/LogicBox_Software.xml
@@ -11,7 +11,6 @@
 	<securecookie host=".+\.logicboxsoftware\.com$" name=".+" />
 
 
-	<rule from="^http://([\w-]+\.)?logicboxsoftware\.com/"
-		to="https://$1logicboxsoftware.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Loopia_secure.com.xml
+++ b/src/chrome/content/rules/Loopia_secure.com.xml
@@ -7,7 +7,6 @@
 	<target host="*.loopiasecure.com" />
 
 
-	<rule from="^http://([\w-]+)\.loopiasecure\.com/"
-		to="https://$1.loopiasecure.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/MDNX.xml
+++ b/src/chrome/content/rules/MDNX.xml
@@ -2,7 +2,6 @@
 
 	<target host="*.stcllctrs.com"/>
 
-	<rule from="^http://(\w+)\.stcllctrs\.com/"
-		to="https://$1.stcllctrs.com/"/>
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Magserv.com.xml
+++ b/src/chrome/content/rules/Magserv.com.xml
@@ -8,7 +8,6 @@
 	<target host="*.magserv.com" />
 
 
-	<rule from="^http://([\w-]+\.)?magserv\.com/"
-		to="https://$1magserv.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/MarkRuler.xml
+++ b/src/chrome/content/rules/MarkRuler.xml
@@ -7,7 +7,6 @@
 	<securecookie host="^(?:.*\.)?conversionruler\.com$" name=".+" />
 
 
-	<rule from="^http://(\w+\.)?conversionruler\.com/"
-		to="https://$1conversionruler.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Mdgms.com.xml
+++ b/src/chrome/content/rules/Mdgms.com.xml
@@ -25,7 +25,6 @@
 	<securecookie host="^gateway\.mdgms\.com$" name=".+" />
 
 
-	<rule from="^http://(\w+)\.mdgms\.com/"
-		to="https://$1.mdgms.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Media_Factory.xml
+++ b/src/chrome/content/rules/Media_Factory.xml
@@ -17,7 +17,6 @@
 	<securecookie host="^(?:www\.)?mediafactory\.fm$" name=".+" />
 
 
-	<rule from="^http://(\w+\.)?mediafactory\.fm/"
-		to="https://$1mediafactory.fm/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/MemberClicks.net.xml
+++ b/src/chrome/content/rules/MemberClicks.net.xml
@@ -15,7 +15,6 @@
 	<securecookie host="^[\w-]+\.memberclicks\.net$" name=".+" />
 
 
-	<rule from="^http://([\w-]+\.)?memberclicks\.net/"
-		to="https://$1memberclicks.net/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Memset.xml
+++ b/src/chrome/content/rules/Memset.xml
@@ -23,7 +23,6 @@
 
 	<securecookie host="^(?:.*\.)?memset\.com$" name=".+" />
 
-	<rule from="^http://(\w+\.)?memset\.com/"
-		to="https://$1memset.com/"/>
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Merchantquest.net.xml
+++ b/src/chrome/content/rules/Merchantquest.net.xml
@@ -7,7 +7,6 @@
 	<securecookie host=".+\.merchantquest\.net$" name=".+" />
 
 
-	<rule from="^http://([\w-]+)\.merchantquest\.net/"
-		to="https://$1.merchantquest.net/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Microsec.xml
+++ b/src/chrome/content/rules/Microsec.xml
@@ -1,5 +1,5 @@
 <ruleset name="Microsec">
 	<target host="*.microsec.hu" />
 
-	<rule from="^http://([^@:/]*)\.microsec\.hu/" to="https://$1.microsec.hu/" />
+	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Mirror_Image_Internet.xml
+++ b/src/chrome/content/rules/Mirror_Image_Internet.xml
@@ -5,7 +5,6 @@
 
 	<!--	Clients have unique subdomains.
 						-->
-	<rule from="^http://(\w+)\.service\.mirror-image\.net/"
-		to="https://$1.service.mirror-image.net/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Mochimedia.xml
+++ b/src/chrome/content/rules/Mochimedia.xml
@@ -2,5 +2,5 @@
 	<target host="*.mochimedia.com" />
 
 	<exclusion pattern="^http://(?:games|wiki)\.mochimedia\.com/" />
-	<rule from="^http://([^@:/]*)\.mochimedia\.com/" to="https://$1.mochimedia.com/" />
+	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Moikrug.ru.xml
+++ b/src/chrome/content/rules/Moikrug.ru.xml
@@ -48,7 +48,6 @@
 	<securecookie host=".+" name=".+" />
 
 
-	<rule from="^http://([\w-]+\.)?moikrug\.ru/"
-		to="https://$1moikrug.ru/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Mozdev-mismatches.xml
+++ b/src/chrome/content/rules/Mozdev-mismatches.xml
@@ -15,7 +15,6 @@
 
 	<securecookie host="^.*\.mozdev\.org$" name=".+" />
 
-	<rule from="^http://([\w\-]+)\.mozdev\.org/"
-		to="https://$1.mozdev.org/"/>
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Msecnd.net.xml
+++ b/src/chrome/content/rules/Msecnd.net.xml
@@ -39,7 +39,6 @@
 		<exclusion pattern="^http://(?:az(?!83882\.|94986\.|623152\.)\d+|msnchansea|msrvideo)\.vo\.msecnd\.net/" />
 
 
-	<rule from="^http://(\w+)\.vo\.msecnd\.net/"
-		to="https://$1.vo.msecnd.net/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/NetFronts.xml
+++ b/src/chrome/content/rules/NetFronts.xml
@@ -32,7 +32,6 @@ Fetch error: http://hosting-advantage.com/ => https://hosting-advantage.com/: (6
 			- order
 			- www
 				-->
-	<rule from="^http://(\w+\.)?hosting-advantage\.com/"
-		to="https://$1hosting-advantage.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/NetflixCanada.xml
+++ b/src/chrome/content/rules/NetflixCanada.xml
@@ -1,6 +1,6 @@
 <ruleset name="NetflixCanada" default_off="Certificate mismatch">
   <target host="*.movies.netflix.com" />
 
-  <rule from="^http://([^/:@]*)\.movies\.netflix\.com/" to="https://$1.movies.netflix.com/"/>
+  <rule from="^http:" to="https:" />
 </ruleset>
 

--- a/src/chrome/content/rules/Network-for-Good.xml
+++ b/src/chrome/content/rules/Network-for-Good.xml
@@ -45,7 +45,6 @@
 	<securecookie host="^\w+\.networkforgood\.org$" name=".+" />
 
 
-	<rule from="^http://(\w+\.)?networkforgood\.org/"
-		to="https://$1networkforgood.org/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Next-Update.xml
+++ b/src/chrome/content/rules/Next-Update.xml
@@ -4,7 +4,6 @@
 	<target host="*.sifterapp.com"/>
 		<exclusion pattern="^http://(?:journal|status)\."/>
 
-	<rule from="^http://(\w+\.)?sifterapp\.com/"
-		to="https://$1sifterapp.com/"/>
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Non_Profit_Soapbox.com.xml
+++ b/src/chrome/content/rules/Non_Profit_Soapbox.com.xml
@@ -10,7 +10,6 @@
 	<securecookie host="^\w+\.secure\.nonprofitsoapbox\.com$" name=".+" />
 
 
-	<rule from="^http://(\w+)\.secure\.nonprofitsoapbox\.com/"
-		to="https://$1.secure.nonprofitsoapbox.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Ntwk45.xml
+++ b/src/chrome/content/rules/Ntwk45.xml
@@ -2,7 +2,6 @@
 
 	<target host="*.ntwk45.com"/>
 
-	<rule from="^http://(\w+)\.ntwk45\.com/"
-		to="https://$1.ntwk45.com/"/>
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/OVPN.xml
+++ b/src/chrome/content/rules/OVPN.xml
@@ -20,7 +20,6 @@
 			- cp
 			- static
 				-->
-	<rule from="^http://(\w+)\.ovpn\.to/"
-		to="https://$1.ovpn.to/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Omeda.xml
+++ b/src/chrome/content/rules/Omeda.xml
@@ -9,7 +9,6 @@
 
 	<!--	Clients have unique subdomains, e.g.
 			https://prometheus.omeda.com/cgi-win/nthr.cgi?mode=gift&p=HPRC0112	-->
-	<rule from="^http://(\w+)\.omeda\.com/"
-		to="https://$1.omeda.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Onion.to.xml
+++ b/src/chrome/content/rules/Onion.to.xml
@@ -9,8 +9,7 @@
 		<test url="http://static.propub3r6espa33w.onion.to/" />
 
 	-->
-	<rule from="^http://(\w+\.)?onion\.to/"
-		to="https://$1onion.to/" />
+	<rule from="^http:" to="https:" />
 
 	<test url="http://duskgytldkxiuqc6.onion.to/" />
 	<test url="http://5nca3wxl33tzlzj5.onion.to/" />

--- a/src/chrome/content/rules/Onstream_secure.com.xml
+++ b/src/chrome/content/rules/Onstream_secure.com.xml
@@ -10,7 +10,6 @@
 	<target host="*.onstreamsecure.com" />
 
 
-	<rule from="^http://([\w-]+)\.onstreamsecure\.com/"
-		to="https://$1.onstreamsecure.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/OpenTTD.xml
+++ b/src/chrome/content/rules/OpenTTD.xml
@@ -19,8 +19,7 @@
 	<securecookie host="^(?:.*\.)?openttdcoop\.org$" name=".+" />
 
 
-	<rule from="^http://(\w+\.)?openttd\.org/"
-		to="https://$1openttd.org/" />
+	<rule from="^http:" to="https:" />
 <!--
 Rules for binaries are disabled after an IRC request from the site's admins:
 
@@ -29,7 +28,6 @@ Rules for binaries are disabled after an IRC request from the site's admins:
 		to="https://secure.openttd.org/binaries/"/>
 -->
 
-	<rule from="^http://((?:blog|dev|paste|www)\.)?openttdcoop\.org/"
-		to="https://$1openttdcoop.org/" />
+	
 
 </ruleset>

--- a/src/chrome/content/rules/PSZAF.xml
+++ b/src/chrome/content/rules/PSZAF.xml
@@ -1,5 +1,5 @@
 <ruleset name="PSZ&#193;F">
 	<target host="*.pszaf.hu" />
 
-	<rule from="^http://([^/:@]*)\.pszaf\.hu/" to="https://$1.pszaf.hu/" />
+	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Peninsula-College-of-Medicine-and-Dentistry.xml
+++ b/src/chrome/content/rules/Peninsula-College-of-Medicine-and-Dentistry.xml
@@ -25,7 +25,6 @@
 			- hr
 			- www
 				-->
-	<rule from="^http://(\w+\.)?pcmd\.ac\.uk/"
-		to="https://$1pcmd.ac.uk/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Pimg.net.xml
+++ b/src/chrome/content/rules/Pimg.net.xml
@@ -14,7 +14,6 @@
 	<target host="*.pimg.net" />
 
 
-	<rule from="^http://([\w-]+)\.pimg\.net/"
-		to="https://$1.pimg.net/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Potager.org.xml
+++ b/src/chrome/content/rules/Potager.org.xml
@@ -29,16 +29,6 @@
 	<securecookie host="^mail\.potager\.org$" name=".+" />
 
 
-	<rule from="^http://([^/:@\.]+\.)?pimienta\.org/"
-		to="https://$1pimienta.org/" />
-
-	<rule from="^http://([^/:@\.]+\.)?poivron\.org/"
-		to="https://$1poivron.org/" />
-
-	<rule from="^http://([^/:@\.]+\.)?potager\.org/"
-		to="https://$1potager.org/" />
-
-	<rule from="^http://([^/:@\.]+\.)?sweetpepper\.org/"
-		to="https://$1sweetpepper.org/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/PressLabs_SSL.xml
+++ b/src/chrome/content/rules/PressLabs_SSL.xml
@@ -15,7 +15,6 @@ Fetch error: http://plssl.com/ => https://plssl.com/: (7, 'Failed to connect to 
 	<target host="*.plssl.com" />
 
 
-	<rule from="^http://([\w-]+\.)?plssl\.com/"
-		to="https://$1plssl.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/PrivatePaste.xml
+++ b/src/chrome/content/rules/PrivatePaste.xml
@@ -14,5 +14,5 @@ Fetch error: http://privatepaste.com/ => https://privatepaste.com/: (60, 'SSL ce
   <target host="privatepaste.com" />
   <target host="*.privatepaste.com" />
 
-  <rule from="^http://([\w-]+\.)?privatepaste\.com/" to="https://$1privatepaste.com/"/>
+  <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Quattroplay.com.xml
+++ b/src/chrome/content/rules/Quattroplay.com.xml
@@ -7,7 +7,6 @@
 	<securecookie host="^(?:.*\.)?quattroplay\.com$" name=".+" />
 
 
-	<rule from="^http://([\w-]+\.)?quattroplay\.com/"
-		to="https://$1quattroplay.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Radical_Designs.xml
+++ b/src/chrome/content/rules/Radical_Designs.xml
@@ -13,7 +13,6 @@
 	<securecookie host="^.+\.rdsecure\.org$" name=".+" />
 
 
-	<rule from="^http://([\w-]+\.)?rdsecure\.org/"
-		to="https://$1rdsecure.org/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Reformal.xml
+++ b/src/chrome/content/rules/Reformal.xml
@@ -16,7 +16,6 @@ Fetch error: http://reformal.ru/ => https://reformal.ru/: (60, 'SSL certificate 
 	<securecookie host="^\.reformal\.ru$" name=".+" />
 
 
-	<rule from="^http://([\w-]+\.)?reformal\.ru/"
-		to="https://$1reformal.ru/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Riga.xml
+++ b/src/chrome/content/rules/Riga.xml
@@ -12,8 +12,5 @@ Non-2xx HTTP code: http://eriga.lv/ (200) => https://eriga.lv/ (404)
   <target host="eriga.lv" />
   <target host="www.eriga.lv" />
 
-  <rule from="^http://riga\.lv/" to="https://riga.lv/"/>
-  <rule from="^http://([^/:@\.]+)\.riga\.lv/" to="https://$1.riga.lv/"/>
-  <rule from="^http://eriga\.lv/" to="https://eriga.lv/"/>
-  <rule from="^http://www\.eriga\.lv/" to="https://www.eriga.lv/"/>
+  <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Righthaven.xml
+++ b/src/chrome/content/rules/Righthaven.xml
@@ -22,7 +22,6 @@ Fetch error: http://righthaven.com/ => https://righthaven.com/: (28, 'Connection
 			- plutus
 			- www
 				-->
-	<rule from="^http://(\w+\.)?righthaven\.com/"
-		to="https://$1righthaven.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Rigzone.xml
+++ b/src/chrome/content/rules/Rigzone.xml
@@ -39,7 +39,6 @@ Fetch error: http://rigzone.com/ => https://rigzone.com/: Too many redirects whi
 	<securecookie host="^(?:.+\.)?rigzone\.com$" name=".+" />
 
 
-	<rule from="^http://(\w+\.)?rigzone\.com/"
-		to="https://$1rigzone.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Secure-donor.com.xml
+++ b/src/chrome/content/rules/Secure-donor.com.xml
@@ -13,7 +13,6 @@
 	<securecookie host="^\w" name=".+" />
 
 
-	<rule from="^http://([\w-]+\.)?secure-donor\.com/"
-		to="https://$1secure-donor.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Secure-payment-processing.com.xml
+++ b/src/chrome/content/rules/Secure-payment-processing.com.xml
@@ -3,7 +3,6 @@
 	<target host="*.secure-payment-processing.com" />
 
 
-	<rule from="^http://([\w-]+)\.secure-payment-processing\.com/"
-		to="https://$1.secure-payment-processing.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Securepicssl.com.xml
+++ b/src/chrome/content/rules/Securepicssl.com.xml
@@ -11,7 +11,6 @@
 	<securecookie host="^(?:.*\.)?securepicssl\.com$" name=".+" />
 
 
-	<rule from="^http://([\w-]+\.)?securepcissl\.com/"
-		to="https://$1securepcissl.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Server314.com.xml
+++ b/src/chrome/content/rules/Server314.com.xml
@@ -7,7 +7,6 @@
 	<securecookie host="^.+\.server314\.com$" name=".+" />
 
 
-	<rule from="^http://([\w\.-]+\.)?server314\.com/"
-		to="https://$1server314.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Service-now.com.xml
+++ b/src/chrome/content/rules/Service-now.com.xml
@@ -26,7 +26,6 @@
 	<securecookie host=".\.service-now\.com$" name=".+" />
 
 
-	<rule from="^http://([\w-]+\.)?service-now\.com/"
-		to="https://$1service-now.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Simplekb.com.xml
+++ b/src/chrome/content/rules/Simplekb.com.xml
@@ -18,7 +18,6 @@
 	<securecookie host="^[\w-]+\.simplekb\.com$" name=".+" />
 
 
-	<rule from="^http://([\w-]+\.)?simplekb\.com/"
-		to="https://$1simplekb.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Site5.xml
+++ b/src/chrome/content/rules/Site5.xml
@@ -19,7 +19,6 @@
 	<securecookie host=".*\.site5\.com$" name=".+" />
 
 
-	<rule from="^http://(\w+\.)?site5\.com/"
-		to="https://$1site5.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Skydsl.eu.xml
+++ b/src/chrome/content/rules/Skydsl.eu.xml
@@ -6,6 +6,5 @@ Fetch error: http://skydsl.eu/ => https://skydsl.eu/: Redirect for 'http://www.s
   <target host="skydsl.eu" />
   <target host="*.skydsl.eu" />
 
-  <rule from="^http://skydsl\.eu/" to="https://skydsl.eu/" />
-  <rule from="^http://([^/:@\.]+)\.skydsl\.eu/" to="https://$1.skydsl.eu/" />
+  <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Sloan-Digital-Sky-Survey.xml
+++ b/src/chrome/content/rules/Sloan-Digital-Sky-Survey.xml
@@ -12,7 +12,6 @@ Fetch error: http://sdss3.org/ => https://sdss3.org/: (51, "SSL: no alternative 
 
 	<securecookie host="^(?:.*\.)?sdss3\.org$" name=".+" />
 
-	<rule from="^http://(\w+\.)?sdss3\.org/"
-		to="https://$1sdss3.org/"/>
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/SocialTwist.xml
+++ b/src/chrome/content/rules/SocialTwist.xml
@@ -25,7 +25,6 @@ Fetch error: http://socialtwist.com/ => https://socialtwist.com/: (51, "SSL: no 
 			- tellafriend
 			- www
 					-->
-	<rule from="^http://([\w\-]+\.)?socialtwist\.com/"
-		to="https://$1socialtwist.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Socialbakers.xml
+++ b/src/chrome/content/rules/Socialbakers.xml
@@ -12,7 +12,6 @@ Fetch error: http://socialbakers.com/ => https://socialbakers.com/: (52, 'Empty 
 	<!--	encountered subdomains:
 			- analytics
 			- cms		-->
-	<rule from="^http://(\w+\.)?socialbakers\.com/"
-		to="https://$1socialbakers.com/"/>
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/SourceForge.net.xml
+++ b/src/chrome/content/rules/SourceForge.net.xml
@@ -41,10 +41,9 @@
 		<test url="http://ufpr.dl.sourceforge.net/" />
 
 	<target host="*.svn.sourceforge.net" />
-	<rule from="^http://(\w+)\.svn\.sourceforge\.net/"
-			to="https://$1.svn.sourceforge.net/" />
+	<rule from="^http:" to="https:" />
 		<test url="http://ancestrar.svn.sourceforge.net/svnroot/ancestrar" />
 		<test url="http://scummvm.svn.sourceforge.net/svnroot/scummvm/" />
 
-	<rule from="^http:" to="https:" />
+	
 </ruleset>

--- a/src/chrome/content/rules/Ssldomain.com.xml
+++ b/src/chrome/content/rules/Ssldomain.com.xml
@@ -13,7 +13,6 @@
 	<securecookie host=".+\.ssldomain\.com$" name=".+" />
 
 
-	<rule from="^http://([\w-]+)\.ssldomain\.com/"
-		to="https://$1.ssldomain.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/StaticWars.com.xml
+++ b/src/chrome/content/rules/StaticWars.com.xml
@@ -7,7 +7,6 @@
 	<target host="*.staticwars.com" />
 
 
-	<rule from="^http://(\w+)\.staticwars\.com/"
-		to="https://$1.staticwars.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Stevens.xml
+++ b/src/chrome/content/rules/Stevens.xml
@@ -1,6 +1,5 @@
 <ruleset name="Stevens">
 	<target host="*.stevens.edu" />
 	<exclusion pattern="^http://(?:personal|www.math|www.cs|www.acc|guinness.cs|tarantula.phy|www.phy|tarantula.srcit|www.srcit|debian.srcit|ubuntu.srcit)\.stevens\.edu/.*" />
-		<rule from="^http://([^/:@\.]+)\.stevens\.edu/"
-				  to="https://$1.stevens.edu/" />
+		<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Surveydaddy.xml
+++ b/src/chrome/content/rules/Surveydaddy.xml
@@ -12,8 +12,5 @@ Fetch error: http://surveydaddy.com/ => https://surveydaddy.com/: (60, 'SSL cert
 
   <exclusion pattern="^http://support\.surveydaddy\.com/"/>
 
-  <rule from="^http://surveydaddy\.com/"
-	to="https://surveydaddy.com/" />
-  <rule from="^http://([^@:\./]+)\.surveydaddy\.com/"
-	to="https://$1.surveydaddy.com/" />
+  <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Tent.is.xml
+++ b/src/chrome/content/rules/Tent.is.xml
@@ -24,7 +24,6 @@ Fetch error: http://tent.is/ => https://tent.is/: (6, 'Could not resolve host: t
 	<target host="*.tent.is" />
 
 
-	<rule from="^http://([\w-]+\.)?tent\.is/"
-		to="https://$1tent.is/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Thankyou4caring.org.xml
+++ b/src/chrome/content/rules/Thankyou4caring.org.xml
@@ -18,7 +18,6 @@
 	<securecookie host="^\w+" name=".+" />
 
 
-	<rule from="^http://(\w+)\.thankyou4caring\.org/"
-		to="https://$1.thankyou4caring.org/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Tilt.com.xml
+++ b/src/chrome/content/rules/Tilt.com.xml
@@ -35,7 +35,6 @@
 		<test url="http://open.tilt.com/" />
 		<test url="http://www.tilt.com/" />
 
-	<rule from="^http://([\w-]+\.)?tilt\.com/"
-		to="https://$1tilt.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Tlsfun.de.xml
+++ b/src/chrome/content/rules/Tlsfun.de.xml
@@ -4,7 +4,6 @@
 	<target host="*.tlsfun.de" />
 
 
-	<rule from="^http://([\w-]+\.)?tlsfun\.de/"
-		to="https://$1tlsfun.de/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Versus-Technologies.xml
+++ b/src/chrome/content/rules/Versus-Technologies.xml
@@ -9,7 +9,6 @@ Fetch error: http://vstech.net/ => https://vstech.net/: Cycle detected - URL alr
 
 	<securecookie host="^(?:.*\.)?vstech\.net$" name=".+" />
 
-	<rule from="^http://(\w+\.)?vstech\.net/"
-		to="https://$1vstech.net/"/>
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Vueling.xml
+++ b/src/chrome/content/rules/Vueling.xml
@@ -2,6 +2,5 @@
   <target host="vueling.com" />
   <target host="*.vueling.com" />
   
-  <rule from="^http://vueling\.com/" to="https://vueling.com/"/>
-  <rule from="^http://([^/:@\.]+)\.vueling\.com/" to="https://$1.vueling.com/"/>
+  <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/WLxrs.com.xml
+++ b/src/chrome/content/rules/WLxrs.com.xml
@@ -25,7 +25,6 @@ Fetch error: http://secure.wlxrs.com/ => https://secure.wlxrs.com/: (51, "SSL: n
 		<test url="http://secure.wlxrs.com/" />
 
 
-	<rule from="^http://(\w+)\.wlxrs\.com/"
-		to="https://$1.wlxrs.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/WebShopRevolution.com.xml
+++ b/src/chrome/content/rules/WebShopRevolution.com.xml
@@ -11,9 +11,9 @@ Fetch error: http://webshoprevolution.com/ => https://webshoprevolution.com/: (6
     <target host="*.webshoprevolution.com" />
 
     <!-- Rule for no subdomain - http://webshoprevolution.com -->
-    <rule from="^http://webshoprevolution\.com/" to="https://webshoprevolution.com/" />
+    <rule from="^http:" to="https:" />
     
     <!-- Rule for any subdomain - http://*.webshoprevolution.com -->
-    <rule from="^http://([\w-]+)\.webshoprevolution\.com/" to="https://$1.webshoprevolution.com/" />
+    
 
 </ruleset>

--- a/src/chrome/content/rules/Webcontrolcenter.com.xml
+++ b/src/chrome/content/rules/Webcontrolcenter.com.xml
@@ -13,7 +13,6 @@
 	<securecookie host="^(?:.+\.)?webcontrolcenter\.com$" name=".+" />
 
 
-	<rule from="^http://([\w-]+\.)?webcontrolcenter\.com/"
-		to="https://$1webcontrolcenter.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Webshopapp.com.xml
+++ b/src/chrome/content/rules/Webshopapp.com.xml
@@ -4,7 +4,6 @@
 	<target host="*.webshopapp.com" />
 
 
-	<rule from="^http://([\w-]+\.)?webshopapp\.com/"
-		to="https://$1webshopapp.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Wikispooks.xml
+++ b/src/chrome/content/rules/Wikispooks.xml
@@ -7,7 +7,6 @@
 	<securecookie host="^(?:.*\.)?wikispooks\.com$" name=".+" />
 
 
-	<rule from="^http://([^/:@]+\.)?wikispooks\.com/"
-		to="https://$1wikispooks.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/With_Google.com.xml
+++ b/src/chrome/content/rules/With_Google.com.xml
@@ -17,7 +17,6 @@
 
 	<securecookie host="^[\w-]+\.withgoogle\.com$" name=".+" />
 
-	<rule from="^http://([\w-]+\.)?withgoogle\.com/"
-		to="https://$1withgoogle.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Withknown.com.xml
+++ b/src/chrome/content/rules/Withknown.com.xml
@@ -11,5 +11,5 @@
 		<test url="http://fee.withknown.com/" />
 		<test url="http://mlncn.withknown.com/" />
 
-  <rule from="^http://([\w-]+\.)?withknown\.com/" to="https://$1withknown.com/" />
+  <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Wrapadviser.co.uk.xml
+++ b/src/chrome/content/rules/Wrapadviser.co.uk.xml
@@ -6,7 +6,6 @@
 	<securecookie host=".+\.wrapadviser\.co\.uk$" name=".+" />
 
 
-	<rule from="^http://([\w-]+)\.wrapadviser\.co\.uk/"
-		to="https://$1.wrapadviser.co.uk/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Wservices.ch.xml
+++ b/src/chrome/content/rules/Wservices.ch.xml
@@ -15,7 +15,6 @@
 	<securecookie host=".+\.wservices\.ch$" name=".+" />
 
 
-	<rule from="^http://([\w-]+\.)?wservices\.ch/"
-		to="https://$1wservices.ch/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Wufoo.xml
+++ b/src/chrome/content/rules/Wufoo.xml
@@ -41,7 +41,6 @@
 	<securecookie host=".+" name=".+" />
 
 
-	<rule from="^http://([\w-]+\.)?wufoo\.com/"
-		to="https://$1wufoo.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Xing.xml
+++ b/src/chrome/content/rules/Xing.xml
@@ -32,10 +32,6 @@
 	<securecookie host=".*\.xing\.com$" name=".+" />
 
 
-	<rule from="^http://([\w-]+\.)?xing\.com/"
-		to="https://$1xing.com/" />
-
-	<rule from="^http://x1\.xingassets\.com/"
-		to="https://x1.xingassets.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Xtenit.xml
+++ b/src/chrome/content/rules/Xtenit.xml
@@ -18,7 +18,6 @@
 	<target host="*.secure.xtenit.com" />
 
 
-	<rule from="^http://([\w-]+)\.secure\.xtenit\.com/"
-		to="https://$1.secure.xtenit.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/Zerista.xml
+++ b/src/chrome/content/rules/Zerista.xml
@@ -23,7 +23,6 @@
 
 	<!--	Clients have unique subdomains.
 						-->
-	<rule from="^http://(\w+)\.zerista\.com/"
-		to="https://$1.zerista.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/bookware3000.ca.xml
+++ b/src/chrome/content/rules/bookware3000.ca.xml
@@ -12,8 +12,7 @@
 	<test url="http://englishcentral.bookware3000.ca/" />
 	<test url="http://canbead.bookware3000.ca/" />
 
-	<rule from="^http://([\w-]+)\.bookware3000\.ca/"
-		to="https://$1.bookware3000.ca/" />
+	<rule from="^http:" to="https:" />
 
 	<!-- Invalid common name, certificate from *.fastlanepos.ca. -->
 	<exclusion pattern="^http://canbead\.bookware3000\.ca/" />

--- a/src/chrome/content/rules/eHarmony.xml
+++ b/src/chrome/content/rules/eHarmony.xml
@@ -23,7 +23,6 @@
 	<securecookie host="^(?:.*\.)?eharmony\.com$" name=".+" />
 
 	<!--	affiliates have unique subdomains	-->
-	<rule from="^http://([\w\-]+)\.eharmony\.com/"
-		to="https://$1.eharmony.com/"/>
+	<rule from="^http:" to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/strongSwan.xml
+++ b/src/chrome/content/rules/strongSwan.xml
@@ -16,6 +16,5 @@
             - wiki
             - www
     -->
-    <rule from="^http://(\w+\.)?strongswan\.org/"
-        to="https://$1strongswan.org/" />
+    <rule from="^http:" to="https:" />
 </ruleset>

--- a/utils/memusage.js
+++ b/utils/memusage.js
@@ -7,7 +7,7 @@ if (typeof gc !== 'function') {
 	throw new Error('Please re-run with `node --expose-gc utils/memusage.js`');
 }
 
-const { RuleSets } = require('../chromium/rules');
+const { RuleSets } = require('../chromium/background-scripts/rules');
 const { readFileSync } = require('fs');
 const json = JSON.parse(readFileSync(`${__dirname}/../rules/default.rulesets`, 'utf-8'));
 

--- a/utils/trivialize-rules/explode-regexp.js
+++ b/utils/trivialize-rules/explode-regexp.js
@@ -13,6 +13,21 @@ function explodeRegExp(re, callback) {
 
     let [first, ...rest] = items;
 
+    if (
+      str.endsWith('://') &&
+      first.repeat &&
+      first.repeat.min <= 1 &&
+      first.repeat.max === Infinity &&
+      first.type === 'charset' &&
+      ((!first.exclude && (first.classes.includes('w') || first.classes.includes('S'))) ||
+        (first.exclude &&
+          first.classes.length === 0 &&
+          first.ranges.length === 0 &&
+          /^[@/:.]*$/.test(first.chars)))
+    ) {
+      return buildUrls(str + 'PREFIX', rest);
+    }
+
     if (first.repeat) {
       let repeat = first.repeat;
       if (repeat.max !== 1) throw new UnsupportedRegExp(first.raw);
@@ -79,7 +94,7 @@ function explodeRegExp(re, callback) {
 
     throw new UnsupportedRegExp(first.raw);
   })('*', parse(re).tree);
-};
+}
 
 module.exports = {
   UnsupportedRegExp,

--- a/utils/trivialize-rules/trivialize-rules.js
+++ b/utils/trivialize-rules/trivialize-rules.js
@@ -105,7 +105,7 @@ files.fork().zipAll([ sources.fork(), rules ]).map(([name, source, ruleset]) => 
     return;
   }
 
-  let targetRe = new RegExp(`^(?:${targets.map(target => target.replace(/\./g, '\\.').replace(/\*/g, '.*')).join('|')})$`);
+  let targetRe = new RegExp(`^(?:${targets.map(target => target.replace(/^\*\./, '[\\w-]+.').replace(/\./g, '\\.').replace(/\*/g, '.*')).join('|')})$`);
   let domains = new Set();
 
   function isStatic(rule) {
@@ -134,7 +134,7 @@ files.fork().zipAll([ sources.fork(), rules ]).map(([name, source, ruleset]) => 
         if (!targetRe.test(host)) {
           unknownDomains.add(host);
         } else if (!secure && port === '80' && path === '*' && url.replace(fromRe, to) === url.replace(/^http:/, 'https:')) {
-          localDomains.add(host);
+          localDomains.add(host.replace(/^PREFIX\./, '*.'));
         } else {
           nonTrivialUrls.add(url);
         }


### PR DESCRIPTION
This is yet another follow-up to https://github.com/EFForg/https-everywhere/pull/4400 and https://github.com/EFForg/https-everywhere/pull/12294. This time with fewer changes, just added special case to recognise commonly used generic subdomain patterns in regexps and transform them to `*.example.org` targets as it has the same behaviour per guidelines.

As usual, aside from stylistic change, this slightly decreases memory usage as well since such rulesets become "trivial".

Before:
Initial usage: 41.3 MB
Maximum usage: 79 MB
After:
Initial usage: 41.3 MB
Maximum usage: 78.5 MB

Also, as usual with previous automated runs, this will require updating `ruleset-whitelist.csv` to avoid CI failures, but looks like the format has changed since I last checked it and I will need help with figuring out how to update it.