### PR TITLE
Update and rename pirata.cat.xml to Pirata.cat.xml [#13290] [Audit default_off="missing certificate chain" rulesets.]

### DIFF
--- a/src/chrome/content/rules/Pirata.cat.xml
+++ b/src/chrome/content/rules/Pirata.cat.xml
@@ -13,7 +13,7 @@
 	ᶜ See https://owasp.org/index.php/SecureFlag
 
 -->
-<ruleset name="pirata.cat (partial)" default_off="missing certificate chain">
+<ruleset name="pirata.cat (partial)" >
 
 	<target host="xifrat.pirata.cat" />
 


### PR DESCRIPTION
https://github.com/EFForg/https-everywhere/issues/13290