### PR TITLE
Create IGCD.net.xml

### DIFF
--- a/src/chrome/content/rules/IGCD.net.xml
+++ b/src/chrome/content/rules/IGCD.net.xml
@@ -1,0 +1,8 @@
+<ruleset name="IGCD.net">
+	<target host="igcd.net" />
+	<target host="www.igcd.net" />
+
+	<securecookie host=".+" name=".+" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>


### PR DESCRIPTION
Fix https://github.com/EFForg/https-everywhere/issues/15896

without mixedcontent, only fb and google ad are blocked, is that ok?