### PR TITLE
Add two other domains for Bangumi

### DIFF
--- a/src/chrome/content/rules/Bgm.tv.xml
+++ b/src/chrome/content/rules/Bgm.tv.xml
@@ -1,9 +1,18 @@
+<!--
+	Mismatch:
+		doujin.chii.in
+		doujin.bangumi.tv
+-->
 <ruleset name="Bgm.tv">
+	<target host="bangumi.tv" />
+	<target host="www.bangumi.tv" />
 	<target host="bgm.tv" />
 	<target host="www.bgm.tv" />
 	<target host="doujin.bgm.tv" />
 	<target host="lain.bgm.tv" />
 	<target host="navi.bgm.tv" />
+	<target host="chii.in" />
+	<target host="www.chii.in" />
 
 	<securecookie host=".+" name=".+" />
 


### PR DESCRIPTION
I’m heavy user of this site: https://bgm.tv/user/franklinyu (see the GitHub link). The three domains are interchangeable.

In addition, I think it’s more appropriate to name it `Bangumi.xml`, because the official name is Bangumi. See [Chinese Wikipedia](https://zh.wikipedia.org/wiki/Bangumi_番组计划) for details (English Wikipedia page not available).