### PR TITLE
Detect static securecookies to trivialize more rules

### DIFF
--- a/utils/trivialize-rules/explode-regexp.js
+++ b/utils/trivialize-rules/explode-regexp.js
@@ -4,8 +4,8 @@ const { parse } = require('regulex');
 
 class UnsupportedRegExp extends Error {}
 
-function explodeRegExp (re, callback) {
-  (function buildUrls (str, items) {
+function explodeRegExp(re, callback) {
+  (function buildUrls(str, items) {
     if (items.length === 0) {
       callback(str + '*');
       return;
@@ -79,7 +79,7 @@ function explodeRegExp (re, callback) {
 
     throw new UnsupportedRegExp(first.raw);
   })('*', parse(re).tree);
-}
+};
 
 module.exports = {
   UnsupportedRegExp,

--- a/utils/trivialize-rules/explode-regexp.js
+++ b/utils/trivialize-rules/explode-regexp.js
@@ -4,8 +4,8 @@ const { parse } = require('regulex');
 
 class UnsupportedRegExp extends Error {}
 
-function explodeRegExp(re, callback) {
-  (function buildUrls(str, items) {
+function explodeRegExp (re, callback) {
+  (function buildUrls (str, items) {
     if (items.length === 0) {
       callback(str + '*');
       return;
@@ -79,7 +79,7 @@ function explodeRegExp(re, callback) {
 
     throw new UnsupportedRegExp(first.raw);
   })('*', parse(re).tree);
-};
+}
 
 module.exports = {
   UnsupportedRegExp,

--- a/utils/trivialize-rules/package.json
+++ b/utils/trivialize-rules/package.json
@@ -4,6 +4,7 @@
   "main": "trivialize-rules.js",
   "dependencies": {
     "chalk": "^2.1.0",
+    "escape-string-regexp": "^1.0.5",
     "highland": "^2.7.1",
     "regulex": "0.0.2",
     "xml2js": "^0.4.16"

--- a/utils/trivialize-rules/trivialize-rules.js
+++ b/utils/trivialize-rules/trivialize-rules.js
@@ -258,9 +258,9 @@ files.fork().zipAll([ sources.fork(), rules ]).map(([name, source, ruleset]) => 
 
   if (domains.slice().sort().join('\n') !== targets.sort().join('\n')) {
     // For each securecookie rule, check if it is a static securecookie.
-    // If it is non-static, remove the securecookie rule if it contains
-    // dangling rules. This removal is better done one by one to avoid
-    // unwanted side effects.
+    // If it is non-static, we do not trivialize the ruleset; Otherwise,
+    // we remove the securecookie if it contain only unsupported hosts.
+    // This removal is better done one by one to avoid side effects.
     // Else if ALL securecookie rules are static, trivialize the targets.
     for (const securecookie of securecookies) {
       let [isStatic, shouldRemove] = isStaticCookie(securecookie);
@@ -269,12 +269,7 @@ files.fork().zipAll([ sources.fork(), rules ]).map(([name, source, ruleset]) => 
         if (shouldRemove) {
           let scReSrc = `\n([\t ]*)<securecookie\\s*host=\\s*"${escapeStringRegexp(securecookie.host)}"(\\s*)name=\\s*"${escapeStringRegexp(securecookie.name)}"\\s*?/>[\t ]*\n`;
           let scRe = new RegExp(scReSrc);
-          if (scRe && scRe.test(source)) {
-            source = source.replace(scRe, '');
-          } else {
-            fail`Failed to construct regexp which matches securecookie: ${JSON.stringify(securecookie)}`;
-            return;
-          }
+          source = source.replace(scRe, '');
         }
       } else {
         // Skip this ruleset as it contain non-static securecookies

--- a/utils/trivialize-rules/trivialize-rules.js
+++ b/utils/trivialize-rules/trivialize-rules.js
@@ -16,7 +16,7 @@ const rulesDir = `${__dirname}/../../src/chrome/content/rules`;
 
 const tagsRegExps = new Map();
 
-function createTagsRegexp(tag) {
+function createTagsRegexp (tag) {
   let re = tagsRegExps.get(tag);
   if (!re) {
     const tagRe = `<${tag}(?:\\s+\\w+=".*?")*\\s*\\/>`;
@@ -26,7 +26,7 @@ function createTagsRegexp(tag) {
   return re;
 }
 
-function replaceXML(source, tag, newXML) {
+function replaceXML (source, tag, newXML) {
   let pos, indent;
   let re = createTagsRegexp(tag);
 
@@ -75,12 +75,12 @@ const rules =
             }
           });
 
-function isTrivial(rule) {
+function isTrivial (rule) {
   return rule.from === '^http:' && rule.to === 'https:';
 }
 
 files.fork().zipAll([ sources.fork(), rules ]).map(([name, source, ruleset]) => {
-  function createTag(tagName, colour, print) {
+  function createTag (tagName, colour, print) {
     return (strings, ...values) => {
       let result = `[${tagName}] ${chalk.bold(name)}: ${strings[0]}`;
       for (let i = 1; i < strings.length; i++) {
@@ -103,8 +103,6 @@ files.fork().zipAll([ sources.fork(), rules ]).map(([name, source, ruleset]) => 
   let securecookies = ruleset.securecookie ? ruleset.securecookie.map(sc => sc.$) : new Array();
   let rules = ruleset.rule.map(rule => rule.$);
 
-  let shouldRemoveSecurecookies = false;
-
   if (rules.length === 1 && isTrivial(rules[0])) {
     return;
   }
@@ -112,7 +110,7 @@ files.fork().zipAll([ sources.fork(), rules ]).map(([name, source, ruleset]) => 
   let targetRe = new RegExp(`^(?:${targets.map(target => target.replace(/\./g, '\\.').replace(/\*/g, '.*')).join('|')})$`);
   let domains = new Set();
 
-  function isStatic(rule) {
+  function isStatic (rule) {
     if (isTrivial(rule)) {
       for (let target of targets) {
         domains.add(target);
@@ -201,7 +199,7 @@ files.fork().zipAll([ sources.fork(), rules ]).map(([name, source, ruleset]) => 
   // 3. Each exploded securecookie.host should be included in ruleset.target/
   // exploded target. Otherwise, this ruleset is likely problematic itself. It
   // is dangerous for a rewrite.
-  function isStaticCookie(securecookie) {
+  function isStaticCookie (securecookie) {
     if (securecookie.host === '.+' && securecookie.name === '.+') {
       return [true, false];
     }
@@ -227,7 +225,7 @@ files.fork().zipAll([ sources.fork(), rules ]).map(([name, source, ruleset]) => 
       warn`Unsupported regexp part ${e.message} while traversing securecookie : ${JSON.stringify(securecookie)}`;
       return [false, false];
     }
-  
+
     for (const domain of localDomains) {
       if (domains.indexOf(domain) === -1) {
         warn`Ruleset does not cover target ${domain} for securecookie : ${JSON.stringify(securecookie)}`;
@@ -271,17 +269,17 @@ files.fork().zipAll([ sources.fork(), rules ]).map(([name, source, ruleset]) => 
         if (shouldRemove) {
           let scReSrc = `\n([\t ]*)<securecookie\\s*host=\\s*"${escapeStringRegexp(securecookie.host)}"(\\s*)name=\\s*"${escapeStringRegexp(securecookie.name)}"\\s*?/>[\t ]*\n`;
           let scRe = new RegExp(scReSrc);
-          
+
           if (scRe && scRe.test(source)) {
             source = source.replace(scRe, '');
           } else {
             fail`Failed to construct regexp which matches securecookie: ${JSON.stringify(securecookie)}`;
-            return ;
+            return;
           }
         }
       } else {
         // Skip this ruleset as it contain non-static securecookies
-        return ;
+        return;
       }
     }
 
@@ -293,7 +291,6 @@ files.fork().zipAll([ sources.fork(), rules ]).map(([name, source, ruleset]) => 
   info`trivialized`;
 
   return writeFile(`${rulesDir}/${name}`, source);
-
 })
   .filter(Boolean)
   .parallel(10)

--- a/utils/trivialize-rules/trivialize-rules.js
+++ b/utils/trivialize-rules/trivialize-rules.js
@@ -182,6 +182,22 @@ files.fork().zipAll([ sources.fork(), rules ]).map(([name, source, ruleset]) => 
 
   domains = Array.from(domains);
 
+  // It is assumed that if all securecookies are static,
+  // they can be safely ignored.
+  //
+  // A securecookie is called to be static either it is a trivial securecookie or ALL
+  // of the following conditions are satisfied:
+  //
+  // 1. securecookie.host match cookie.host from the beginning ^ to the end $.
+  // Otherwise, it might match subdomains/ partial patterns, thus a non-trivial
+  // securecookie.
+  //
+  // 2. securecookie.host will not throw an error when passed to explodeRegExp().
+  // Otherwise, it might match patterns too complicated for our interests.
+  //
+  // 3. Each exploded securecookie.host should be included in ruleset.target/
+  // exploded target. Otherwise, this ruleset is likely problematic itself. It is
+  // dangerous for a rewrite.
   function isStaticCookie(securecookie) {
     if (securecookie.host === '.+' && securecookie.name === '.+') {
       return true;

--- a/utils/trivialize-rules/trivialize-rules.js
+++ b/utils/trivialize-rules/trivialize-rules.js
@@ -250,7 +250,6 @@ files.fork().zipAll([ sources.fork(), rules ]).map(([name, source, ruleset]) => 
       if (unsupportedDomains.size === localDomains.size) {
         return [true, true];
       }
-      // TODO: Can we remove partial dangling securecookie rules???
       fail`Tag securecookie ${JSON.stringify(securecookie)} matches ${unsupportedDomains} which are not in targets ${targets}`;
     }
     return [true, false];

--- a/utils/trivialize-rules/trivialize-rules.js
+++ b/utils/trivialize-rules/trivialize-rules.js
@@ -187,8 +187,8 @@ files.fork().zipAll([ sources.fork(), rules ]).map(([name, source, ruleset]) => 
   // It is assumed that if all securecookies are static,
   // they can be safely ignored.
   //
-  // A securecookie is called to be static either it is a trivial securecookie or ALL
-  // of the following conditions are satisfied:
+  // A securecookie is called to be static either it is a trivial securecookie
+  // or ALL of the following conditions are satisfied:
   //
   // 1. securecookie.host match cookie.host from the beginning ^ to the end $.
   // Otherwise, it might match subdomains/ partial patterns, thus a non-trivial
@@ -198,8 +198,8 @@ files.fork().zipAll([ sources.fork(), rules ]).map(([name, source, ruleset]) => 
   // Otherwise, it might match patterns too complicated for our interests.
   //
   // 3. Each exploded securecookie.host should be included in ruleset.target/
-  // exploded target. Otherwise, this ruleset is likely problematic itself. It is
-  // dangerous for a rewrite.
+  // exploded target. Otherwise, this ruleset is likely problematic itself. It
+  // is dangerous for a rewrite.
   function isStaticCookie(securecookie) {
     if (securecookie.host === '.+' && securecookie.name === '.+') {
       return true;
@@ -234,8 +234,20 @@ files.fork().zipAll([ sources.fork(), rules ]).map(([name, source, ruleset]) => 
       }
     }
 
+    // For cookies to be covered, there must be at least one rule covering the
+    // same domain. This is guaranteed by safeToSecureCookie(cookie) in rules.js
+    //
+    // Since securecookie.host will only match cookie.domain if there there is
+    // a rule covers cookie.domain. Given the target are trivial, cookie.domain
+    // cannot be anything other than domain.example.com and .domain.example.com
+    // (possibly with more leading dots) for a securecookie rule ever to take
+    // place.
+    //
+    // With condition (1) effective, securecookie.host should explode to either
+    // one of the aforementioned patterns. Otherwise, the securecookie rules
+    // will never be applied. Such dangling securecookie rules can be removed
+    // safely.
     if (unsupportedDomains.size > 0) {
-      // all securecookie tags are non effective
       if (unsupportedDomains.size === localDomains.size) {
         shouldRemoveSecurecookies = true;
         return true;

--- a/utils/trivialize-rules/trivialize-rules.js
+++ b/utils/trivialize-rules/trivialize-rules.js
@@ -103,8 +103,6 @@ files.fork().zipAll([ sources.fork(), rules ]).map(([name, source, ruleset]) => 
   let securecookies = ruleset.securecookie ? ruleset.securecookie.map(sc => sc.$) : new Array();
   let rules = ruleset.rule.map(rule => rule.$);
 
-  let shouldRemoveSecurecookies = false;
-
   if (rules.length === 1 && isTrivial(rules[0])) {
     return;
   }
@@ -227,7 +225,7 @@ files.fork().zipAll([ sources.fork(), rules ]).map(([name, source, ruleset]) => 
       warn`Unsupported regexp part ${e.message} while traversing securecookie : ${JSON.stringify(securecookie)}`;
       return [false, false];
     }
-  
+
     for (const domain of localDomains) {
       if (domains.indexOf(domain) === -1) {
         warn`Ruleset does not cover target ${domain} for securecookie : ${JSON.stringify(securecookie)}`;
@@ -271,17 +269,16 @@ files.fork().zipAll([ sources.fork(), rules ]).map(([name, source, ruleset]) => 
         if (shouldRemove) {
           let scReSrc = `\n([\t ]*)<securecookie\\s*host=\\s*"${escapeStringRegexp(securecookie.host)}"(\\s*)name=\\s*"${escapeStringRegexp(securecookie.name)}"\\s*?/>[\t ]*\n`;
           let scRe = new RegExp(scReSrc);
-          
           if (scRe && scRe.test(source)) {
             source = source.replace(scRe, '');
           } else {
             fail`Failed to construct regexp which matches securecookie: ${JSON.stringify(securecookie)}`;
-            return ;
+            return;
           }
         }
       } else {
         // Skip this ruleset as it contain non-static securecookies
-        return ;
+        return;
       }
     }
 
@@ -293,7 +290,6 @@ files.fork().zipAll([ sources.fork(), rules ]).map(([name, source, ruleset]) => 
   info`trivialized`;
 
   return writeFile(`${rulesDir}/${name}`, source);
-
 })
   .filter(Boolean)
   .parallel(10)


### PR DESCRIPTION
This PR modify `trivialize-rules.js` to detect _static_ `securecookie` to trivialize more rules. It also trivialize the `securecookie` tags if all the `securecookie` domain and `target` domain are strictly identical.  This will further trivializes about 100+ rulesets when ran against 8cfabe52e659fe0f0fb091f83e3b8004134d884f

cc @RReverser @Hainish @Bisaloo @J0WI 