### PR TITLE
Fix explode-regexp

### DIFF
--- a/utils/trivialize-rules/explode-regexp.js
+++ b/utils/trivialize-rules/explode-regexp.js
@@ -14,13 +14,12 @@ function explodeRegExp(re, callback) {
     let [first, ...rest] = items;
 
     if (first.repeat) {
-      let repeat = first.repeat;
+      let { repeat, ...firstSub } = first;
       if (repeat.max !== 1) throw new UnsupportedRegExp(first.raw);
-      delete first.repeat;
       if (repeat.min === 0) {
         buildUrls(str, rest);
       }
-      return buildUrls(str, items);
+      return buildUrls(str, [ firstSub, ...rest ]);
     }
 
     switch (first.type) {


### PR DESCRIPTION
This fixes a bug in trivialize-rules script that affected "multiplication" of various repetitions like in `^http://(www\.)?(alliance)?bernstein\.com/` (it would miss some combinations of `www.` and `alliance.`).

cc @cschanaj 