### PR TITLE
Removed seemingly redundant colors in script.py

### DIFF
--- a/test/script.py
+++ b/test/script.py
@@ -16,14 +16,9 @@ from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.firefox.firefox_binary import FirefoxBinary
 
 class bcolors:
-    HEADER = '\033[95m'
-    OKBLUE = '\033[94m'
     OKGREEN = '\033[92m'
-    WARNING = '\033[93m'
     FAIL = '\033[91m'
     ENDC = '\033[0m'
-    BOLD = '\033[1m'
-    UNDERLINE = '\033[4m'
 
 
 if sys.argv[1] == "Chrome":


### PR DESCRIPTION
Correct me if I'm wrong, but these colors codes that we placed in `script.py` didn't seem to be used for anything. 