### PR TITLE
Slightly reduce default.rulesets size and memory usage

### DIFF
--- a/utils/merge-rulesets.py
+++ b/utils/merge-rulesets.py
@@ -77,7 +77,10 @@ for filename in sorted(files):
             ruleset["securecookie"].append(sc)
 
         elif child.tag == "exclusion":
-            ruleset["exclusion"].append(child.attrib["pattern"])
+            if len(ruleset["exclusion"]) == 0:
+                ruleset["exclusion"].append(child.attrib["pattern"])
+            else:
+                ruleset["exclusion"][0] = (ruleset["exclusion"][0] + "|" + child.attrib["pattern"])
 
     library.append(ruleset);
 


### PR DESCRIPTION
@Hainish @bcyphers This will merge ruleset exclusion into a single pattern as implemented in #15448. The memory improvement measure is as follow

Before:
Initial usage: 41.1 MB
Maximum usage: 80.3 MB

After:
Initial usage: 40.9 MB
Maximum usage: 80.1 MB

Related #12232 