### PR TITLE
Re-activate Svenskakyrkan.se.xml (Swedish Church)

### DIFF
--- a/src/chrome/content/rules/Svenskakyrkan.se.xml
+++ b/src/chrome/content/rules/Svenskakyrkan.se.xml
@@ -1,7 +1,7 @@
-<ruleset name="Svenskakyrkan (broken)" default_off="https://trac.torproject.org/projects/tor/ticket/9613">
+<ruleset name="Svenskakyrkan.se">
 	<target host="svenskakyrkan.se" />
 	<target host="www.svenskakyrkan.se" />
-	<rule from="^http://svenskakyrkan\.se/" to="https://www.svenskakyrkan.se/"/>
-	<rule from="^http://www\.svenskakyrkan\.se/" to="https://www.svenskakyrkan.se/"/>
+
+	<rule from="^http:" to="https:" />
 </ruleset>
 

--- a/src/chrome/content/rules/Svenskakyrkan.se.xml
+++ b/src/chrome/content/rules/Svenskakyrkan.se.xml
@@ -4,4 +4,3 @@
 
 	<rule from="^http:" to="https:" />
 </ruleset>
-


### PR DESCRIPTION
#9906 https://trac.torproject.org/projects/tor/ticket/9613 is 5 years ago, and the site redirects to HTTPS by default 