### PR TITLE
A little more compact JSON representation in default.rulesets

### DIFF
--- a/utils/merge-rulesets.py
+++ b/utils/merge-rulesets.py
@@ -87,7 +87,7 @@ for filename in sorted(files):
 # Write to default.rulesets
 print(" * Writing JSON library to %s" % ofn)
 outfile = open(ofn, "w")
-outfile.write(json.dumps(library))
+outfile.write(json.dumps(library, separators=(",", ":")))
 outfile.close()
 
 # Everything is okay.


### PR DESCRIPTION
Before: 7390331 bytes
After: 6930115 bytes (93.77%) when uncompressed