### PR TITLE
Remove 'import settings' ux from options page

### DIFF
--- a/chromium/background-scripts/background.js
+++ b/chromium/background-scripts/background.js
@@ -760,43 +760,11 @@ chrome.runtime.onMessage.addListener(function(message, sender, sendResponse){
     return true;
   } else if (message.type == "remove_rule") {
     all_rules.removeRuleAndStore(message.object);
-  } else if (message.type == "import_settings") {
-    // This is used when importing settings from the options ui
-    import_settings(message.object).then(() => {
-      sendResponse(true);
-    });
   } else if (message.type == "get_ruleset_timestamps") {
     update.getRulesetTimestamps().then(timestamps => sendResponse(timestamps));
     return true;
   }
 });
-
-/**
- * Import extension settings (custom rulesets, ruleset toggles, globals) from an object
- * @param settings the settings object
- */
-async function import_settings(settings) {
-  if (settings && settings.changed) {
-    let ruleActiveStates = {};
-    // Load all the ruleset toggles into memory and store
-    for (const ruleset_name in settings.rule_toggle) {
-      ruleActiveStates[ruleset_name] = (settings.rule_toggle[ruleset_name] == "true");
-    }
-
-    // Save settings
-    await new Promise(resolve => {
-      store.set({
-        legacy_custom_rulesets: settings.custom_rulesets,
-        httpNowhere: settings.prefs.http_nowhere_enabled,
-        showCounter: settings.prefs.show_counter,
-        globalEnabled: settings.prefs.global_enabled,
-        ruleActiveStates
-      }, resolve);
-    });
-
-    initializeAllRules();
-  }
-}
 
 /**
  * Clear any cache/ blacklist we have.

--- a/chromium/pages/options/index.html
+++ b/chromium/pages/options/index.html
@@ -26,16 +26,6 @@
       <label for="showDevtoolsTab" data-i18n="options_showDevtoolsTab"></label>
     </div>
 
-    <div id="import-confirmed" data-i18n="options_imported"></div>
-
-    <form>
-      <div class="section-header"><span class="section-header-span" data-i18n="options_importSettings"></span></div>
-      <section id="ImportSettings" class="options">
-        <input id="import-settings" type="file" accept="application/json">
-      </section>
-      <button type="submit" id="import" data-i18n="options_import" disabled></button>
-    </form>
-
     <script src="ux.js"></script>
     <script src="../translation.js"></script>
     <script src="../send-message.js"></script>

--- a/chromium/pages/options/ux.js
+++ b/chromium/pages/options/ux.js
@@ -4,32 +4,6 @@
 
 document.addEventListener("DOMContentLoaded", () => {
 
-  let json_data;
-  let import_button = document.querySelector("#import");
-
-  function import_json(e) {
-    e.preventDefault();
-
-    let settings = JSON.parse(json_data);
-    sendMessage("import_settings", settings, () => {
-      document.querySelector("#import-confirmed").style.display = "block";
-      document.querySelector("form").style.display = "none";
-    });
-  }
-
-  document.querySelector("#import-settings").addEventListener("change", () => {
-    const file = event.target.files[0];
-    const reader = new FileReader();
-    reader.addEventListener("load", event => {
-      json_data = event.target.result;
-      import_button.disabled = false;
-    });
-
-    reader.readAsText(file);
-  });
-
-  document.querySelector("form").addEventListener("submit", import_json);
-
   const showCounter = document.getElementById("showCounter");
   const autoUpdateRulesets = document.getElementById("autoUpdateRulesets");
   const enableMixedRulesets = document.getElementById("enableMixedRulesets");

--- a/src/chrome/locale/en/https-everywhere.dtd
+++ b/src/chrome/locale/en/https-everywhere.dtd
@@ -14,12 +14,9 @@
 
 <!ENTITY https-everywhere.options.generalSettings "General Settings">
 <!ENTITY https-everywhere.options.advancedSettings "Advanced Settings">
-<!ENTITY https-everywhere.options.importSettings "Import Settings">
-<!ENTITY https-everywhere.options.import "Import">
 <!ENTITY https-everywhere.options.enableMixedRulesets "Enable mixed content rulesets">
 <!ENTITY https-everywhere.options.showDevtoolsTab "Show Devtools tab">
 <!ENTITY https-everywhere.options.autoUpdateRulesets "Auto-update rulesets">
-<!ENTITY https-everywhere.options.imported "Your settings have been imported.">
 
 <!ENTITY https-everywhere.prefs.export_settings "Export Settings">
 <!ENTITY https-everywhere.prefs.reset_defaults "Reset to Defaults">


### PR DESCRIPTION
This is legacy code left over from the initial stages of planning the move from XPCOM to WebExtensions.  No longer used or needed.