### PR TITLE
add IPFire.org rule

### DIFF
--- a/src/chrome/content/rules/IPFire.org.xml
+++ b/src/chrome/content/rules/IPFire.org.xml
@@ -1,12 +1,17 @@
 <ruleset name="IPFire.org">
 	<target host="ipfire.org" />
-	<target host="*.ipfire.org" />
+	<target host="www.ipfire.org" />
 
-	<test url="http://www.ipfire.org/" />
-	<test url="http://mirrors.ipfire.org/" />
-	<test url="http://bugzilla.ipfire.org/" />
-	<test url="http://wiki.ipfire.org/" />
-	<test url="http://forum.ipfire.org/" />
+	<target host="blog.ipfire.org" />
+	<target host="bugzilla.ipfire.org" />
+	<target host="cgit.ipfire.org" />
+	<target host="downloads.ipfire.org" />
+	<target host="forum.ipfire.org" />
+	<target host="git.ipfire.org" />
+	<target host="mirrors.ipfire.org" />
+	<target host="pakfire.ipfire.org" />
+	<target host="people.ipfire.org" />
+	<target host="wiki.ipfire.org" />
 
 	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/IPFire.org.xml
+++ b/src/chrome/content/rules/IPFire.org.xml
@@ -2,5 +2,11 @@
 	<target host="ipfire.org" />
 	<target host="*.ipfire.org" />
 
+	<test url="http://www.ipfire.org/" />
+	<test url="http://mirrors.ipfire.org/" />
+	<test url="http://bugzilla.ipfire.org/" />
+	<test url="http://wiki.ipfire.org/" />
+	<test url="http://forum.ipfire.org/" />
+
 	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/IPFire.org.xml
+++ b/src/chrome/content/rules/IPFire.org.xml
@@ -1,0 +1,6 @@
+<ruleset name="IPFire.org">
+	<target host="ipfire.org" />
+	<target host="*.ipfire.org" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/lightningwirelabs.com.xml
+++ b/src/chrome/content/rules/lightningwirelabs.com.xml
@@ -1,6 +1,0 @@
-<ruleset name="Lightning Wire Labs">
-	<target host="lightningwirelabs.com" />
-	<target host="*.lightningwirelabs.com" />
-
-	<rule from="^http:" to="https:" />
-</ruleset>

--- a/src/chrome/content/rules/lightningwirelabs.com.xml
+++ b/src/chrome/content/rules/lightningwirelabs.com.xml
@@ -1,0 +1,6 @@
+<ruleset name="Lightning Wire Labs">
+	<target host="lightningwirelabs.com" />
+	<target host="*.lightningwirelabs.com" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>


### PR DESCRIPTION
Add ruleset for domains of the IPFire project. Since all of them are reachable via HTTPS, this can be easily done by a wildcard rule.