### PR TITLE
Create ruleset: SPI Inc

### DIFF
--- a/src/chrome/content/rules/spi-inc.org.xml
+++ b/src/chrome/content/rules/spi-inc.org.xml
@@ -1,0 +1,17 @@
+<!--
+	Mismatch:
+		oldwww.spi-inc.org
+	443 port closed:
+		lists.spi-inc.org
+-->
+<ruleset name="SPI Inc">
+	<target host="spi-inc.org" />
+	<target host="git.spi-inc.org" /> <!-- HTTP 302 -->
+	<target host="members.spi-inc.org" /> <!-- HSTS not preloaded -->
+	<target host="rt.spi-inc.org" /> <!-- HTTP 302 -->
+	<target host="www.spi-inc.org" />
+
+	<securecookie host=".+" name=".+" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>


### PR DESCRIPTION
I’m not sure whether I should include the redirecting sites and/or HSTS (non-preload) sites. Also note that some sites only supports TLS 1.0.