### PR TITLE
Avoid unnecessary trivial rewrites in Chromium browsers

### DIFF
--- a/chromium/background-scripts/background.js
+++ b/chromium/background-scripts/background.js
@@ -337,7 +337,7 @@ function onBeforeRequest(details) {
     appliedRulesets.removeTab(details.tabId);
   }
 
-  var potentiallyApplicable = all_rules.potentiallyApplicableRulesets(uri.hostname);
+  let potentiallyApplicable = all_rules.potentiallyApplicableRulesets(uri.hostname);
 
   if (redirectCounter.get(details.requestId) >= 8) {
     util.log(util.NOTE, "Redirect counter hit for " + uri.href);
@@ -349,7 +349,7 @@ function onBeforeRequest(details) {
 
   // whether to use mozilla's upgradeToSecure BlockingResponse if available
   let upgradeToSecure = false;
-  var newuristr = null;
+  let newuristr = null;
 
   for (let ruleset of potentiallyApplicable) {
     appliedRulesets.addRulesetToTab(details.tabId, details.type, ruleset);

--- a/chromium/background-scripts/background.js
+++ b/chromium/background-scripts/background.js
@@ -350,18 +350,19 @@ function onBeforeRequest(details) {
   // whether to use mozilla's upgradeToSecure BlockingResponse if available
   let upgradeToSecure = false;
   var newuristr = null;
-  // check rewritten URIs against the trivially upgraded URI
-  let trivialUpgradeUri = uri.href.replace(/^http:/, "https:");
 
   for (let ruleset of potentiallyApplicable) {
     appliedRulesets.addRulesetToTab(details.tabId, details.type, ruleset);
     if (ruleset.active && !newuristr) {
       newuristr = ruleset.apply(uri.href);
-      // only use upgradeToSecure for trivial rulesets
-      if (newuristr == trivialUpgradeUri) {
-        upgradeToSecure = true;
-      }
     }
+  }
+
+  // only use upgradeToSecure for trivial rewrites
+  if (upgradeToSecureAvailable && newuristr) {
+    // check rewritten URIs against the trivially upgraded URI
+    const trivialUpgradeUri = uri.href.replace(/^http:/, "https:");
+    upgradeToSecure = (newuristr == trivialUpgradeUri);
   }
 
   // re-insert userpass info which was stripped temporarily


### PR DESCRIPTION
On chromium browser, `upgradeToSecure` is not available, avoid the unnecessary trivial rewrites should improve performance.  Besides, since `ruleset.apply` might return `null` when the URL is excluded by a ruleset, the checking might be performed more than once in Firefox/Chromium. Move the check outside of the loop avoid unused variables and assignments. 