### PR TITLE
[Microsoft.xml] Remove obsolete exclusion

### DIFF
--- a/src/chrome/content/rules/Microsoft.xml
+++ b/src/chrome/content/rules/Microsoft.xml
@@ -503,6 +503,8 @@
 					-->
 			<test url="http://search.microsoft.com/default.aspx" />
 			<test url="http://search.microsoft.com/search/results.aspx" />
+			<test url="http://search.microsoft.com/global/oneMscomSettings/" />
+			<test url="http://search.microsoft.com/shared/" />
 
 
 		<!--	Redirect to http:

--- a/src/chrome/content/rules/Microsoft.xml
+++ b/src/chrome/content/rules/Microsoft.xml
@@ -448,10 +448,6 @@
 	
 	<target host="blogs.msdn.com" />
 
-		<!-- Produces a 502 Gateway Timeout on HTTPS.
-				 Reported by tweet: https://twitter.com/MarcGLib/status/620931025653342208 -->
-		<exclusion pattern="^http://www\.microsoft\.com/en-us/software-recovery" />
-			<test url="http://www.microsoft.com/en-us/software-recovery" />
 		<!--exclusion pattern="^http://msdn\.microsoft\.com/" /-->
 
 		<!--	https://mail1.eff.org/pipermail/https-everywhere-rules/2012-June/001189.html

--- a/src/chrome/content/rules/Microsoft.xml
+++ b/src/chrome/content/rules/Microsoft.xml
@@ -506,7 +506,6 @@
 			<test url="http://search.microsoft.com/global/oneMscomSettings/" />
 			<test url="http://search.microsoft.com/shared/" />
 
-
 		<!--	Redirect to http:
 						-->
 		<exclusion pattern="^http://careers\.microsoft\.com/careers/\w\w/\w\w/" />

--- a/src/chrome/content/rules/Microsoft.xml
+++ b/src/chrome/content/rules/Microsoft.xml
@@ -489,7 +489,6 @@
 
 			<!--	+ve:
 					-->
-			<test url="http://msdn.microsoft.com/" />
 			<test url="http://msdn.microsoft.com/en-us/" />
 
 		<!--exclusion pattern="^http://code\.msdn\.microsoft\.com/(?![cC]content/|RequestReduceContent/)" /-->
@@ -504,6 +503,7 @@
 					-->
 			<test url="http://search.microsoft.com/default.aspx" />
 			<test url="http://search.microsoft.com/search/results.aspx" />
+			<test url="http://search.microsoft.com/de-de/" />
 
 		<!--	Redirect to http:
 						-->

--- a/src/chrome/content/rules/Microsoft.xml
+++ b/src/chrome/content/rules/Microsoft.xml
@@ -503,7 +503,7 @@
 					-->
 			<test url="http://search.microsoft.com/default.aspx" />
 			<test url="http://search.microsoft.com/search/results.aspx" />
-			<test url="http://search.microsoft.com/de-de/" />
+
 
 		<!--	Redirect to http:
 						-->
@@ -628,6 +628,8 @@
 		to="https://www.microsoft.com/" />
 
 		<test url="http://scache.microsoft.com//" />
+		<test url="http://search.microsoft.com//" />
+		<test url="http://spcache.microsoft.com//" />
 
 	<!--	Redirect drops path, args, and forward slash:
 								-->


### PR DESCRIPTION
Since www.microsoft.com sends HSTS, excluding http://www.microsoft.com/en-us/software-recovery is unnecessary. Also this page (both http and https) now redirects to https://www.microsoft.com/software-download/home.