### PR TITLE
Fix an invalid securecookie pattern

### DIFF
--- a/src/chrome/content/rules/1PipFix.xml
+++ b/src/chrome/content/rules/1PipFix.xml
@@ -11,7 +11,7 @@ Fetch error: http://www.1pipfix.com/ => https://www.1pipfix.com/: (28, 'Connecti
 	<target host="www.1pipfix.com" />
 
 
-	<securecookie host="^(?:w*\.)?1pipfix\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?1pipfix\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/1xbet.com.xml
+++ b/src/chrome/content/rules/1xbet.com.xml
@@ -12,7 +12,7 @@
 	<target host="www.1xbet.com" />
 
 
-	<securecookie host="^(?:w*\.)?1xbet\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?1xbet\.com$" name=".+" />
 
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/23Systems.xml
+++ b/src/chrome/content/rules/23Systems.xml
@@ -4,7 +4,7 @@
 	<target host="www.23systems.net" />
 
 
-	<securecookie host="^(?:w*\.)?23systems\.net$" name=".+" />
+	<securecookie host="^(?:\w*\.)?23systems\.net$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/A14_Electronics.com.xml
+++ b/src/chrome/content/rules/A14_Electronics.com.xml
@@ -12,7 +12,7 @@ Fetch error: http://a14electronics.com/ => https://a14electronics.com/: (51, "SS
 
 	<!--	Not secured by server:
 					-->
-	<securecookie host="^(?:w*\.)?a14electronics\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?a14electronics\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/A_Bigger_Society.com.xml
+++ b/src/chrome/content/rules/A_Bigger_Society.com.xml
@@ -16,7 +16,7 @@
 
 	<!--	Server doesn't set Secure for:
 						-->
-	<securecookie host="^(?:w*\.)?abiggersociety\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?abiggersociety\.com$" name=".+" />
 
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/Aaron_Brothers.xml
+++ b/src/chrome/content/rules/Aaron_Brothers.xml
@@ -4,7 +4,7 @@
 	<target host="www.aaronbrotherscircular.com" />
 
 
-	<securecookie host="^(?:w*\.)?aaronbrotherscircular.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?aaronbrotherscircular.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/AbcLinuxu.cz.xml
+++ b/src/chrome/content/rules/AbcLinuxu.cz.xml
@@ -37,7 +37,7 @@
 					-->
 	<!--securecookie host="^www\.abclinuxu\.cz$" name="^JSESSIONID$" /-->
 
-	<securecookie host="^(?:w*\.)?abclinuxu\.cz$" name=".+" />
+	<securecookie host="^(?:\w*\.)?abclinuxu\.cz$" name=".+" />
 
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/Abine.xml
+++ b/src/chrome/content/rules/Abine.xml
@@ -16,9 +16,9 @@
 
 	<!--	Not secured by server:
 					-->
-	<!--securecookie host="^(?:www\.)?abine\.com$" name="^SERVERID$" /-->
+	<!--securecookie host="^(?:\www\.)?abine\.com$" name="^SERVERID$" /-->
 
-	<securecookie host="^(?:w*\.)?abine\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?abine\.com$" name=".+" />
 
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/AccessPrivacy.ca.xml
+++ b/src/chrome/content/rules/AccessPrivacy.ca.xml
@@ -20,7 +20,7 @@ Fetch error: http://www.accessprivacy.ca/ => https://www.accessprivacy.ca/: (7, 
 	<target host="www.accessprivacy.ca" />
 
 
-	<securecookie host="^(?:w*\.)?accessprivacy\.ca$" name=".+" />
+	<securecookie host="^(?:\w*\.)?accessprivacy\.ca$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Access_Privacy.com.xml
+++ b/src/chrome/content/rules/Access_Privacy.com.xml
@@ -22,7 +22,7 @@
 	<target host="www.accessprivacy.com" />
 
 
-	<securecookie host="^(?:w*\.)?accessprivacy\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?accessprivacy\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/AdXpansion.com.xml
+++ b/src/chrome/content/rules/AdXpansion.com.xml
@@ -11,7 +11,7 @@
 	<target host="www.adxpansion.com" />
 
 
-	<securecookie host="^(?:w*\.)?adxpansion\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?adxpansion\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Ady_Advantage.com-falsemixed.xml
+++ b/src/chrome/content/rules/Ady_Advantage.com-falsemixed.xml
@@ -10,7 +10,7 @@
 
 	<!--	Server doesn't set Secure for:
 						-->
-	<securecookie host="^(?:w*\.)?adyadvantage\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?adyadvantage\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Aera.net.xml
+++ b/src/chrome/content/rules/Aera.net.xml
@@ -14,7 +14,7 @@
 	<target host="www.aera.at" />
 
 
-	<securecookie host="^(?:w*\.)?aera\.net$" name=".+" />
+	<securecookie host="^(?:\w*\.)?aera\.net$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Agari.xml
+++ b/src/chrome/content/rules/Agari.xml
@@ -12,7 +12,7 @@ Fetch error: http://agari.com/ => https://agari.com/: (51, "SSL: no alternative 
 	<target host="*.agari.com" />
 
 
-	<securecookie host="^(?:w*\.)?agari\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?agari\.com$" name=".+" />
 
 
 	<rule from="^http://(app\.|www\.)?agari\.com/"

--- a/src/chrome/content/rules/Amnesty_International_Norway.xml
+++ b/src/chrome/content/rules/Amnesty_International_Norway.xml
@@ -56,7 +56,7 @@
 	<!--securecookie host="^\.amnesty\.no$" name="^SESS[\da-f]{32}$" /-->
 	<!--securecookie host="^minside\.amnesty\.no$" name="^ASP\.NET_SessionId$" /-->
 
-	<!--securecookie host="^(?:w*\.)?amnesty\.no$" name=".+" /-->
+	<!--securecookie host="^(?:\w*\.)?amnesty\.no$" name=".+" /-->
 	<securecookie host="^minside\.amnesty\.no$" name=".+" />
 
 

--- a/src/chrome/content/rules/Amsterdam_Internet_Exchange.xml
+++ b/src/chrome/content/rules/Amsterdam_Internet_Exchange.xml
@@ -12,7 +12,7 @@
 	<target host="www.ams-ix.net" />
 
 
-	<securecookie host="^(?:w*\.)?ams-ix\.net$" name=".+" />
+	<securecookie host="^(?:\w*\.)?ams-ix\.net$" name=".+" />
 
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/Anybots.com.xml
+++ b/src/chrome/content/rules/Anybots.com.xml
@@ -12,7 +12,7 @@
 	<target host="www.anybots.com" />
 
 
-	<securecookie host="^(?:w*\.)?anybots\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?anybots\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Art2pO.com.xml
+++ b/src/chrome/content/rules/Art2pO.com.xml
@@ -15,7 +15,7 @@
 	<target host="www.art2po.com" />
 
 
-	<securecookie host="^(?:w*\.)?art2po\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?art2po\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/ArtSkills.xml
+++ b/src/chrome/content/rules/ArtSkills.xml
@@ -5,7 +5,7 @@
 	<target host="www.artskills.com" />
 
 
-	<securecookie host="^(?:w*\.)?artskills\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?artskills\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Atheists.xml
+++ b/src/chrome/content/rules/Atheists.xml
@@ -13,7 +13,7 @@
 	<target host="www.atheists.org" />
 
 
-	<securecookie host="^(?:w*\.)?atheists\.org$" name=".+" />
+	<securecookie host="^(?:\w*\.)?atheists\.org$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Avonmaquiagem.com.br.xml
+++ b/src/chrome/content/rules/Avonmaquiagem.com.br.xml
@@ -13,7 +13,7 @@ Fetch error: http://www.avonmaquiagem.com.br/ => https://www.avonmaquiagem.com.b
 	<target host="www.avonmaquiagem.com.br" />
 
 
-	<securecookie host="^(?:w*\.)?avonmaquiagem\.com\.br$" name=".+" />
+	<securecookie host="^(?:\w*\.)?avonmaquiagem\.com\.br$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/BTC_Gear.com.xml
+++ b/src/chrome/content/rules/BTC_Gear.com.xml
@@ -19,7 +19,7 @@ Fetch error: http://btcgear.com/ => https://btcgear.com/: (60, 'SSL certificate 
 	<target host="www.btcgear.com" />
 
 
-	<securecookie host="^(?:w*\.)?btcgear\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?btcgear\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Bargains_4_Business.xml
+++ b/src/chrome/content/rules/Bargains_4_Business.xml
@@ -8,7 +8,7 @@
 	<target host="www.bargains4business.com.au" />
 
 
-	<securecookie host="^(?:w*\.)?bargains4business\.com\.au$" name=".+" />
+	<securecookie host="^(?:\w*\.)?bargains4business\.com\.au$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Be_Diff.com.br.xml
+++ b/src/chrome/content/rules/Be_Diff.com.br.xml
@@ -10,7 +10,7 @@ Fetch error: http://bediff.com.br/ => https://bediff.com.br/: (28, 'Operation ti
 	<target host="www.bediff.com.br" />
 
 
-	<securecookie host="^(?:w*\.)?bediff\.com\.br$" name=".+" />
+	<securecookie host="^(?:\w*\.)?bediff\.com\.br$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Bet555.xml
+++ b/src/chrome/content/rules/Bet555.xml
@@ -4,7 +4,7 @@
 	<target host="www.bet555.eu" />
 
 
-	<securecookie host="^(?:w*\.)?bet555\.eu$" name=".+" />
+	<securecookie host="^(?:\w*\.)?bet555\.eu$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/BidItBob.com.xml
+++ b/src/chrome/content/rules/BidItBob.com.xml
@@ -8,7 +8,7 @@
 	<target host="www.biditbob.com" />
 
 
-	<securecookie host="^(?:w*\.)?biditbob\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?biditbob\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Bircko.com.xml
+++ b/src/chrome/content/rules/Bircko.com.xml
@@ -4,7 +4,7 @@
 	<target host="www.bircko.com" />
 
 
-	<securecookie host="^(?:w*\.)?bircko\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?bircko\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Bored_to_Death.xml
+++ b/src/chrome/content/rules/Bored_to_Death.xml
@@ -4,7 +4,7 @@
 	<target host="www.boredtodeath.me" />
 
 
-	<securecookie host="^(?:w*\.)?boredtodeath\.me$" name=".+" />
+	<securecookie host="^(?:\w*\.)?boredtodeath\.me$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Boston_Review.net.xml
+++ b/src/chrome/content/rules/Boston_Review.net.xml
@@ -14,7 +14,7 @@
 
 	<!--	Server doesn't set Secure for:
 						-->
-	<securecookie host="^(?:w*\.)?bostonreview\.net$" name=".+" />
+	<securecookie host="^(?:\w*\.)?bostonreview\.net$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Bruce-Perens.xml
+++ b/src/chrome/content/rules/Bruce-Perens.xml
@@ -4,7 +4,7 @@
 	<target host="www.perens.com" />
 
 
-	<securecookie host="^(?:w*\.)?perens\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?perens\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/CCRjustice.org.xml
+++ b/src/chrome/content/rules/CCRjustice.org.xml
@@ -8,7 +8,7 @@
 	<target host="www.ccrjustice.org" />
 
 
-	<securecookie host="^(?:w*\.)?ccrjustice\.org$" name=".+" />
+	<securecookie host="^(?:\w*\.)?ccrjustice\.org$" name=".+" />
 
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/California_United_Bank.xml
+++ b/src/chrome/content/rules/California_United_Bank.xml
@@ -21,13 +21,13 @@ Fetch error: http://pcboc.com/ => https://pcboc.com/: (51, "SSL: no alternative 
 	<target host="*.pcboc.com" />
 
 
-	<securecookie host="^(?:w*\.)?(?:californiaunitedbank|cunb|pcboc)\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?(?:californiaunitedbank|cunb|pcboc)\.com$" name=".+" />
 
 
 	<rule from="^http://(www\.)?c(aliforniaunitedbank|unb)\.com/"
 		to="https://$1c$2.com/" />
 
-	<rule from="^http://(?:www\.)?pcboc\.com/"
+	<rule from="^http://(?:\www\.)?pcboc\.com/"
 		to="https://pcboc.com/" />
 
 </ruleset>

--- a/src/chrome/content/rules/Cdig.me.xml
+++ b/src/chrome/content/rules/Cdig.me.xml
@@ -15,7 +15,7 @@
 	<target host="www.cdig.me" />
 
 
-	<securecookie host="^(?:w*\.)?cdig\.me$" name=".+" />
+	<securecookie host="^(?:\w*\.)?cdig\.me$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Center_for_Early_Childhood_Professional_Development.xml
+++ b/src/chrome/content/rules/Center_for_Early_Childhood_Professional_Development.xml
@@ -4,7 +4,7 @@
 	<target host="www.cecpdonline.org" />
 
 
-	<securecookie host="^(?:w*\.)?cecpdonline\.org$" name=".+" />
+	<securecookie host="^(?:\w*\.)?cecpdonline\.org$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Charity-Navigator.xml
+++ b/src/chrome/content/rules/Charity-Navigator.xml
@@ -15,7 +15,7 @@
 					-->
 	<!--securecookie host="^www\.charitynavigator\.org$" name="^(CFID|CFTOKEN|JSESSIONID)$" /-->
 
-	<securecookie host="^(?:w*\.)?charitynavigator\.org$" name=".+" />
+	<securecookie host="^(?:\w*\.)?charitynavigator\.org$" name=".+" />
 
 	<rule from="^http:" to="https:" />
 

--- a/src/chrome/content/rules/Cineble.com.xml
+++ b/src/chrome/content/rules/Cineble.com.xml
@@ -11,7 +11,7 @@
 	<target host="www.cineble.com" />
 
 
-	<securecookie host="^(?:w*\.)?cineble\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?cineble\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/ClickEquations.net.xml
+++ b/src/chrome/content/rules/ClickEquations.net.xml
@@ -22,7 +22,7 @@ Fetch error: http://clickequations.net/ => https://clickequations.net/: (7, 'Fai
 	<target host="*.clickequations.net" />
 
 
-	<securecookie host="^(?:w*\.)?clickequations\.net$" name=".+" />
+	<securecookie host="^(?:\w*\.)?clickequations\.net$" name=".+" />
 
 
 	<rule from="^http://((?:beacon|js|www)\.)?clickequations\.net/"

--- a/src/chrome/content/rules/Cloudscaling.com.xml
+++ b/src/chrome/content/rules/Cloudscaling.com.xml
@@ -19,7 +19,7 @@ Fetch error: http://cloudscaling.com/ => https://cloudscaling.com/: (60, 'SSL ce
 
 
 	<!--securecookie host="^\.cloudscaling\.com$" name="^(hsfirstvisit|__hssc|__hssrc|__hstc|hubspotutk|_mkto_trk|__utm\w)$" /-->
-	<securecookie host="^(?:w*\.)?cloudscaling\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?cloudscaling\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Cloudwear.com.xml
+++ b/src/chrome/content/rules/Cloudwear.com.xml
@@ -11,7 +11,7 @@ Fetch error: http://www.cloudwear.com/ => https://www.cloudwear.com/: (28, 'Conn
 	<target host="www.cloudwear.com" />
 
 
-	<securecookie host="^(?:w*\.)?cloudwear\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?cloudwear\.com$" name=".+" />
 
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/Colors-il.com.xml
+++ b/src/chrome/content/rules/Colors-il.com.xml
@@ -13,7 +13,7 @@ Fetch error: http://colors-il.com/ => https://colors-il.com/: (51, "SSL: no alte
 	<target host="www.colors-il.com" />
 
 
-	<securecookie host="^(?:w*\.)?colors-il.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?colors-il.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Credit_Suisse.xml
+++ b/src/chrome/content/rules/Credit_Suisse.xml
@@ -2,7 +2,7 @@
 	<target host="credit-suisse.com" />
 	<target host="www.credit-suisse.com" />
 
-	<securecookie host="^(?:w*\.)?credit-suisse\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?credit-suisse\.com$" name=".+" />
 
 	<rule from="^http:"
 		to="https:" />

--- a/src/chrome/content/rules/Custodian_Vaults.com.au.xml
+++ b/src/chrome/content/rules/Custodian_Vaults.com.au.xml
@@ -12,7 +12,7 @@
 	<target host="www.custodianvaults.com.au" />
 
 
-	<securecookie host="^(?:w*\.)?custodianvaults\.com\.au$" name=".+" />
+	<securecookie host="^(?:\w*\.)?custodianvaults\.com\.au$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/DDS2DDS.com.xml
+++ b/src/chrome/content/rules/DDS2DDS.com.xml
@@ -17,7 +17,7 @@ Fetch error: http://kaizencrossfit.com/ => https://kaizencrossfit.com/: (51, "SS
 
 	<!--	Server doesn't set Secure for:
 						-->
-	<securecookie host="^(?:w*\.)?(?:dds2dds|kaizencrossfit)\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?(?:dds2dds|kaizencrossfit)\.com$" name=".+" />
 
 
 	<rule from="^http://(www\.)?(dds2dds|kaizencrossfit)\.com/"

--- a/src/chrome/content/rules/DIYbanter.xml
+++ b/src/chrome/content/rules/DIYbanter.xml
@@ -4,7 +4,7 @@
 	<target host="www.diybanter.com" />
 
 
-	<securecookie host="^(?:w*\.)?diybanter\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?diybanter\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/DailyPix.xml
+++ b/src/chrome/content/rules/DailyPix.xml
@@ -6,7 +6,7 @@
 	<target host="www.lolzparade.com" />
 
 
-	<securecookie host="^(?:w*\.)?(?:dailypix\.me|lolzparade\.com)$" name=".+" />
+	<securecookie host="^(?:\w*\.)?(?:dailypix\.me|lolzparade\.com)$" name=".+" />
 
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/DataTables.net.xml
+++ b/src/chrome/content/rules/DataTables.net.xml
@@ -17,7 +17,7 @@
 					-->
 	<!--securecookie host="^\.datatables\.net$" name="^(?:__cfduid|cf_clearance)$" /-->
 
-	<securecookie host="^(?:w*\.)?datatables\.net$" name=".+" />
+	<securecookie host="^(?:\w*\.)?datatables\.net$" name=".+" />
 
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/DownloadVerse.com.xml
+++ b/src/chrome/content/rules/DownloadVerse.com.xml
@@ -4,7 +4,7 @@
 	<target host="www.downloadverse.com" />
 
 
-	<securecookie host="^(?:w*\.)?downloadverse\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?downloadverse\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Ecoff.org.xml
+++ b/src/chrome/content/rules/Ecoff.org.xml
@@ -14,7 +14,7 @@
 
 	<!--	Server doesn't set Secure for:
 						-->
-	<securecookie host="^(?:w*\.)?ecoff\.org$" name=".+" />
+	<securecookie host="^(?:\w*\.)?ecoff\.org$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/EducaCursos.xml
+++ b/src/chrome/content/rules/EducaCursos.xml
@@ -4,7 +4,7 @@
 	<target host="www.educacursos.com" />
 
 
-	<securecookie host="^(?:w*\.)?educacursos\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?educacursos\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/El_pueblo.xml
+++ b/src/chrome/content/rules/El_pueblo.xml
@@ -17,7 +17,7 @@ Fetch error: http://elpueblo.com/ => https://elpueblo.com/: (7, 'Failed to conne
 	<target host="www.elpueblo.com" />
 
 
-	<securecookie host="^(?:w*\.)?elpueblo\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?elpueblo\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Fashion_Dip.xml
+++ b/src/chrome/content/rules/Fashion_Dip.xml
@@ -4,7 +4,7 @@
 	<target host="www.fashiondip.com" />
 
 
-	<securecookie host="^(?:w*\.)?fashiondip\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?fashiondip\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Filmlash.com.xml
+++ b/src/chrome/content/rules/Filmlash.com.xml
@@ -15,7 +15,7 @@
 	<target host="www.filmlush.com" />
 
 
-	<securecookie host="^(?:w*\.)?filmlush\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?filmlush\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/FindRetros.com.xml
+++ b/src/chrome/content/rules/FindRetros.com.xml
@@ -18,7 +18,7 @@
 
 	<!--	Not secured by server:
 					-->
-	<securecookie host="^(?:w*\.)?findretros\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?findretros\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Flowtab.com.xml
+++ b/src/chrome/content/rules/Flowtab.com.xml
@@ -19,7 +19,7 @@ Fetch error: http://flowtab.com/ => https://flowtab.com/: (60, 'SSL certificate 
 	<target host="cdn.flowtab.mobi" />
 
 
-	<securecookie host="^(?:w*\.)?flowtab\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?flowtab\.com$" name=".+" />
 
 
 	<rule from="^http://(www\.)?flowtab\.com/"

--- a/src/chrome/content/rules/Foxydeal.de-falsemixed.xml
+++ b/src/chrome/content/rules/Foxydeal.de-falsemixed.xml
@@ -19,7 +19,7 @@ Fetch error: http://foxydeal.com/ => https://foxydeal.de/: (28, 'Connection time
 		<!--exclusion pattern="^http://(www\.)?foxydeal\.(com|de)/+(favicon\.ico|files/|wp-content/|wp-includes/)" /-->
 
 
-	<securecookie host="^(?:w*\.)?foxydeal\.de$" name=".+" />
+	<securecookie host="^(?:\w*\.)?foxydeal\.de$" name=".+" />
 
 
 	<rule from="^http://(www\.)?foxydeal\.(?:com|de)/(?!favicon\.ico|files/|wp-content/|wp-includes/)"

--- a/src/chrome/content/rules/Freenet.de.xml
+++ b/src/chrome/content/rules/Freenet.de.xml
@@ -114,7 +114,7 @@ Fetch error: http://www.mload.freenet.de/ => https://www.mload.freenet.de/: (35,
 					-->
 	<!--securecookie host="^\.freenet\.de$" name="^regfrnsecurity$" /-->
 
-	<securecookie host="^(?:w*\.)?mload\.webmail\.freenet\.de$" name=".+" />
+	<securecookie host="^(?:\w*\.)?mload\.webmail\.freenet\.de$" name=".+" />
 
 
 	<rule from="^http://abakus\.freenet\.de/"

--- a/src/chrome/content/rules/Fxphd.xml
+++ b/src/chrome/content/rules/Fxphd.xml
@@ -4,7 +4,7 @@
 	<target host="www.fxphd.com" />
 
 
-	<securecookie host="^(?:w*\.)?fxphd\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?fxphd\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/GFM_Trader.com.xml
+++ b/src/chrome/content/rules/GFM_Trader.com.xml
@@ -4,7 +4,7 @@
 	<target host="www.gfmtrader.com" />
 
 
-	<securecookie host="^(?:w*\.)?gfmtrader.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?gfmtrader.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Gavel_Buddy_Live.com.xml
+++ b/src/chrome/content/rules/Gavel_Buddy_Live.com.xml
@@ -8,7 +8,7 @@
 	<target host="www.gavelbuddylive.com" />
 
 
-	<securecookie host="^(?:w*\.)?gavelbuddylive\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?gavelbuddylive\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/GermanTV.xml
+++ b/src/chrome/content/rules/GermanTV.xml
@@ -4,7 +4,7 @@
 	<target host="www.germantv.net" />
 
 
-	<securecookie host="^(?:w*\.)?germantv\.net$" name=".+" />
+	<securecookie host="^(?:\w*\.)?germantv\.net$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Ghirardelligiftguides.com.xml
+++ b/src/chrome/content/rules/Ghirardelligiftguides.com.xml
@@ -13,7 +13,7 @@ Fetch error: http://ghirardelligiftguides.com/ => https://ghirardelligiftguides.
 	<target host="www.ghirardelligiftguides.com" />
 
 
-	<securecookie host="^(?:w*\.)?ghirardelligiftguides\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?ghirardelligiftguides\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Global_Bersih.xml
+++ b/src/chrome/content/rules/Global_Bersih.xml
@@ -4,7 +4,7 @@
 	<target host="www.globalbersih.org" />
 
 
-	<securecookie host="^(?:w*\.)?globalbersih.org$" name=".+" />
+	<securecookie host="^(?:\w*\.)?globalbersih.org$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/GoalWorthy.com.xml
+++ b/src/chrome/content/rules/GoalWorthy.com.xml
@@ -16,7 +16,7 @@
 					-->
 	<!--securecookie host="^\.goalworthy\.com$" name="^(?:__cfduid|cf_clearance)$" /-->
 
-	<securecookie host="^(?:w*\.)?goalworthy\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?goalworthy\.com$" name=".+" />
 
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/Goaldet.com.xml
+++ b/src/chrome/content/rules/Goaldet.com.xml
@@ -10,7 +10,7 @@
 	<target host="www.goaldet.com" />
 
 
-	<securecookie host="^(?:w*\.)?goaldet.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?goaldet.com$" name=".+" />
 
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/Green_Coffee_Bean_Extract.xml
+++ b/src/chrome/content/rules/Green_Coffee_Bean_Extract.xml
@@ -8,7 +8,7 @@
 	<target host="*.mygreenbeanextract.com" />
 
 
-	<securecookie host="^(?:w*\.)?mygreenbeanextract\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?mygreenbeanextract\.com$" name=".+" />
 
 
 	<!--	//$ redirects to http://$

--- a/src/chrome/content/rules/HabboLatino.xml
+++ b/src/chrome/content/rules/HabboLatino.xml
@@ -17,7 +17,7 @@ Fetch error: http://hlat.us/ => https://hlat.us/: Cycle detected - URL already e
 	<target host="www.hlat.us" />
 
 
-	<securecookie host="^(?:w*\.)?hlat\.us$" name=".+" />
+	<securecookie host="^(?:\w*\.)?hlat\.us$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Healthcare_Staff_Benefits.xml
+++ b/src/chrome/content/rules/Healthcare_Staff_Benefits.xml
@@ -4,7 +4,7 @@
 	<target host="www.healthcarestaffbenefits.org" />
 
 
-	<securecookie host="^(?:w*\.)?healthcarestaffbenefits\.org$" name=".+" />
+	<securecookie host="^(?:\w*\.)?healthcarestaffbenefits\.org$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Holoscripter.org.xml
+++ b/src/chrome/content/rules/Holoscripter.org.xml
@@ -4,7 +4,7 @@
 	<target host="www.holoscripter.org" />
 
 
-	<securecookie host="^(?:w*\.)?holoscripter\.org$" name=".+" />
+	<securecookie host="^(?:\w*\.)?holoscripter\.org$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/HoneyBeeLoans.com.xml
+++ b/src/chrome/content/rules/HoneyBeeLoans.com.xml
@@ -11,7 +11,7 @@ Fetch error: http://www.honeybeeloans.com/ => https://www.honeybeeloans.com/: (6
 	<target host="www.honeybeeloans.com" />
 
 
-	<securecookie host="^(?:w*\.)?honeybeeloans\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?honeybeeloans\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Hounddog_Central.xml
+++ b/src/chrome/content/rules/Hounddog_Central.xml
@@ -4,7 +4,7 @@
 	<target host="www.hounddogcentral.com" />
 
 
-	<securecookie host="^(?:w*\.)?hounddogcentral\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?hounddogcentral\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/IT_Works.xml
+++ b/src/chrome/content/rules/IT_Works.xml
@@ -22,7 +22,7 @@
 					-->
 	<!--securecookie host="^\.myitworks\.com$" name="^(?:__cfduid|SessionGuid|cf_clearance)$" /-->
 
-	<securecookie host="^(?:w*\.)?myitworks\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?myitworks\.com$" name=".+" />
 
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/Iberiabank.xml
+++ b/src/chrome/content/rules/Iberiabank.xml
@@ -4,7 +4,7 @@
 	<target host="www.iberiabank.com" />
 
 
-	<securecookie host="^(?:w*\.)?iberiabank\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?iberiabank\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Imfimg.com.xml
+++ b/src/chrome/content/rules/Imfimg.com.xml
@@ -4,7 +4,7 @@
 	<target host="www.imfimg.com" />
 
 
-	<securecookie host="^(?:w*\.)?imfimg\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?imfimg\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Inapub.co.uk.xml
+++ b/src/chrome/content/rules/Inapub.co.uk.xml
@@ -10,7 +10,7 @@
 	<target host="www.inapub.co.uk" />
 
 
-	<securecookie host="^(?:w*\.)?inapub\.co\.uk$" name=".+" />
+	<securecookie host="^(?:\w*\.)?inapub\.co\.uk$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Induction_Solutions.com-falsemixed.xml
+++ b/src/chrome/content/rules/Induction_Solutions.com-falsemixed.xml
@@ -12,7 +12,7 @@
 		<!--exclusion pattern="^http://(www\.)?inductionsolutions\.com/+(?!favicon\.ico|my-account($|[?/])|wp-content/|wp-includes/)" /-->
 
 
-	<securecookie host="^(?:w*\.)?inductionsolutions\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?inductionsolutions\.com$" name=".+" />
 
 
 	<rule from="^http://(www\.)?inductionsolutions\.com/(?!favicon\.ico|my-account(?:$|[?/])|wp-content/|wp-includes/)"

--- a/src/chrome/content/rules/Infamous.xml
+++ b/src/chrome/content/rules/Infamous.xml
@@ -8,7 +8,7 @@
 	<target host="www.foreverinfamous.com" />
 
 
-	<securecookie host="^(?:w*\.)?foreverinfamous\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?foreverinfamous\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Infinet.com.au-falsemixed.xml
+++ b/src/chrome/content/rules/Infinet.com.au-falsemixed.xml
@@ -12,7 +12,7 @@
 		<!--exclusion pattern="^http://(www\.)?infinet.com.au/(favicon\.ico|wp-content/|wp-includes/)" /-->
 
 
-	<securecookie host="^(?:w*\.)?infinet\.com\.au$" name=".+" />
+	<securecookie host="^(?:\w*\.)?infinet\.com\.au$" name=".+" />
 
 
 	<rule from="^http://(www\.)?infinet\.com\.au/(?!favicon\.ico|wp-content/|wp-includes/)"

--- a/src/chrome/content/rules/JotForm.xml
+++ b/src/chrome/content/rules/JotForm.xml
@@ -26,7 +26,7 @@
 	<target host="*.jotformpro.com" />
 
 
-	<securecookie host="^(?:w*\.)?jotform\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?jotform\.com$" name=".+" />
 
 
 	<rule from="^http://max\.jotfor\.ms/"
@@ -35,7 +35,7 @@
 	<!--	Although ^jotform.com works, ^ redirects
 		to www over http => clone that behavior:
 							-->
-	<rule from="^http://(?:www\.)?jotform\.com/"
+	<rule from="^http://(?:\www\.)?jotform\.com/"
 		to="https://www.jotform.com/" />
 
 	<rule from="^http://(secure\.|www\.)?jotformpro\.com/"

--- a/src/chrome/content/rules/L-auto-entrepreneur.org.xml
+++ b/src/chrome/content/rules/L-auto-entrepreneur.org.xml
@@ -6,7 +6,7 @@
 
 	<!--	Server doesn't set Secure for:
 						-->
-	<securecookie host="^(?:w*\.)?l-auto-entrepreneur\.org$" name=".+" />
+	<securecookie host="^(?:\w*\.)?l-auto-entrepreneur\.org$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Lazy_Kush.xml
+++ b/src/chrome/content/rules/Lazy_Kush.xml
@@ -4,7 +4,7 @@
 	<target host="www.lazykush.com" />
 
 
-	<securecookie host="^(?:w*\.)?lazykush\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?lazykush\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Leet_Media.com.xml
+++ b/src/chrome/content/rules/Leet_Media.com.xml
@@ -19,7 +19,7 @@ Fetch error: http://leetmedia.com/ => https://leetmedia.com/: (28, 'Operation ti
 
 	<!--	Not secured by server:
 					-->
-	<securecookie host="^(?:w*\.)?leetmedia\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?leetmedia\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Lettre-de-motivation-facile.com.xml
+++ b/src/chrome/content/rules/Lettre-de-motivation-facile.com.xml
@@ -6,7 +6,7 @@
 
 	<!--	Server doesn't set Secure:
 						-->
-	<securecookie host="^(?:w*\.)?lettre-de-motivation-facile\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?lettre-de-motivation-facile\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Linux_Forums.xml
+++ b/src/chrome/content/rules/Linux_Forums.xml
@@ -13,7 +13,7 @@
 	<target host="www.linuxforums.org" />
 
 
-	<securecookie host="^(?:w*\.)?linuxforums\.org$" name=".+" />
+	<securecookie host="^(?:\w*\.)?linuxforums\.org$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Louise_Harrison_Couture.com.xml
+++ b/src/chrome/content/rules/Louise_Harrison_Couture.com.xml
@@ -13,7 +13,7 @@ Non-2xx HTTP code: http://www.louiseharrisoncouture.com/ (200) => https://www.lo
 
 	<!--	Not secured by server:
 					-->
-	<securecookie host="^(?:w*\.)?louiseharrisoncouture\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?louiseharrisoncouture\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Lovett_Publishing_House.com.xml
+++ b/src/chrome/content/rules/Lovett_Publishing_House.com.xml
@@ -21,7 +21,7 @@ Fetch error: http://lovettpublishinghouse.com/ => https://lovettpublishinghouse.
 
 	<!--	Server doesn't set Secure for:
 						-->
-	<securecookie host="^(?:w*\.)?lovettpublishinghouse\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?lovettpublishinghouse\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Magic_Affiliate_plugin.com.xml
+++ b/src/chrome/content/rules/Magic_Affiliate_plugin.com.xml
@@ -14,7 +14,7 @@
 
 	<!--	Server doesn't set Secure for:
 						-->
-	<securecookie host="^(?:w*\.)?magicaffiliateplugin\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?magicaffiliateplugin\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Magic_Members.com.xml
+++ b/src/chrome/content/rules/Magic_Members.com.xml
@@ -14,7 +14,7 @@
 
 	<!--	Server doesn't set Secure:
 						-->
-	<securecookie host="^(?:w*\.)?magicmembers\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?magicmembers\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Man_in_the_Mirror.org.xml
+++ b/src/chrome/content/rules/Man_in_the_Mirror.org.xml
@@ -12,7 +12,7 @@
 	<target host="www.maninthemirror.org" />
 
 
-	<securecookie host="^(?:w*\.)?maninthemirror\.org$" name=".+" />
+	<securecookie host="^(?:\w*\.)?maninthemirror\.org$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/MarinellaRose.com.xml
+++ b/src/chrome/content/rules/MarinellaRose.com.xml
@@ -16,7 +16,7 @@ Fetch error: http://marinellarose.com/ => https://marinellarose.com/: (28, 'Oper
 	<target host="*.marinellarose.com" />
 
 
-	<securecookie host="^(?:w*\.)?(?:bellareed|marinellarose)\.com" name=".+" />
+	<securecookie host="^(?:\w*\.)?(?:bellareed|marinellarose)\.com" name=".+" />
 
 
 	<rule from="^http://(www\.)?(bellareed|marinellarose)\.com/"

--- a/src/chrome/content/rules/Mediant.xml
+++ b/src/chrome/content/rules/Mediant.xml
@@ -11,7 +11,7 @@ Fetch error: http://www.mandiant.net/ => https://www.mandiant.net/: (28, 'Operat
 	<target host="www.mandiant.net" />
 
 
-	<securecookie host="^(?:w*\.)?mandiant\.net$" name=".+" />
+	<securecookie host="^(?:\w*\.)?mandiant\.net$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Mer.io.xml
+++ b/src/chrome/content/rules/Mer.io.xml
@@ -6,7 +6,7 @@
 
 	<!--	Server doesn't set Secure for:
 						-->
-	<securecookie host="^(?:w*\.)?mer\.io$" name=".+" />
+	<securecookie host="^(?:\w*\.)?mer\.io$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Metallica.xml
+++ b/src/chrome/content/rules/Metallica.xml
@@ -15,7 +15,7 @@
 	<target host="www.metallica.com" />
 
 
-	<securecookie host="^(?:w*\.)?metallica\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?metallica\.com$" name=".+" />
 
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/Method_Acting_Strasberg.com.xml
+++ b/src/chrome/content/rules/Method_Acting_Strasberg.com.xml
@@ -17,7 +17,7 @@
 	<target host="www.methodactingstrasberg.com" />
 
 
-	<securecookie host="^(?:w*\.)?methodactingstrasberg.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?methodactingstrasberg.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Mobio_INsider.xml
+++ b/src/chrome/content/rules/Mobio_INsider.xml
@@ -15,7 +15,7 @@ Fetch error: http://www.stage-mobioinsider.com/ => https://www.stage-mobioinside
 	<target host="www.stage-mobioinsider.com" />
 
 
-	<securecookie host="^(?:w*\.)?(?:stage-)?mobioinsider\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?(?:stage-)?mobioinsider\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/MoodSmith.com.xml
+++ b/src/chrome/content/rules/MoodSmith.com.xml
@@ -4,7 +4,7 @@
 	<target host="www.moodsmith.com" />
 
 
-	<securecookie host="^(?:w*\.)?moodsmith\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?moodsmith\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Mouse_Blocker.com.xml
+++ b/src/chrome/content/rules/Mouse_Blocker.com.xml
@@ -14,7 +14,7 @@
 
 	<!--	Some, but not all, secured by server:
 							-->
-	<securecookie host="^(?:w*\.)?mouseblocker\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?mouseblocker\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Moviease.com.xml
+++ b/src/chrome/content/rules/Moviease.com.xml
@@ -10,7 +10,7 @@
 	<target host="www.moviease.com" />
 
 
-	<securecookie host="^(?:w*\.)?moviease\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?moviease\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/MyInteriorDecorator.com.xml
+++ b/src/chrome/content/rules/MyInteriorDecorator.com.xml
@@ -13,7 +13,7 @@ Fetch error: http://myinteriordecorator.com/ => https://myinteriordecorator.com/
 	<target host="www.myinteriordecorator.com" />
 
 
-	<securecookie host="^(?:w*\.)?myinteriordecorator\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?myinteriordecorator\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/My_IT_Works_Events.com.xml
+++ b/src/chrome/content/rules/My_IT_Works_Events.com.xml
@@ -10,7 +10,7 @@
 	<target host="www.myitworksevents.com" />
 
 
-	<securecookie host="^(?:w*\.)?myitworksevents\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?myitworksevents\.com$" name=".+" />
 
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/NYK_Europe.com-falsemixed.xml
+++ b/src/chrome/content/rules/NYK_Europe.com-falsemixed.xml
@@ -22,7 +22,7 @@ Fetch error: http://nykeurope.com/ => https://nykeurope.com/: Too many redirects
 		<!--exclusion pattern="^http://(www\.)?nykeurope\.com/+(favicon\.ico|images/|media/|modules/|templates/)" /-->
 
 
-	<securecookie host="^(?:w*\.)?nykeurope\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?nykeurope\.com$" name=".+" />
 
 
 	<rule from="^http://(www\.)?nykeurope\.com/(?!favicon\.ico|images/|media/|modules/|templates/)"

--- a/src/chrome/content/rules/National_Institute_for_Social_Media.xml
+++ b/src/chrome/content/rules/National_Institute_for_Social_Media.xml
@@ -4,7 +4,7 @@
 	<target host="www.nismonline.org" />
 
 
-	<securecookie host="^(?:w*\.)?nismonline\.org$" name=".+" />
+	<securecookie host="^(?:\w*\.)?nismonline\.org$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Netload.xml
+++ b/src/chrome/content/rules/Netload.xml
@@ -11,7 +11,7 @@ Fetch error: http://www.netload.in/ => https://www.netload.in/: (6, 'Could not r
 	<target host="www.netload.in" />
 
 
-	<securecookie host="^(?:w*\.)?netload\.in$" name=".+" />
+	<securecookie host="^(?:\w*\.)?netload\.in$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Network_Advertising_Initiative.xml
+++ b/src/chrome/content/rules/Network_Advertising_Initiative.xml
@@ -8,7 +8,7 @@
 	<target host="www.networkadvertising.org" />
 
 
-	<securecookie host="^(?:w*\.)?networkadvertising\.org$" name=".+" />
+	<securecookie host="^(?:\w*\.)?networkadvertising\.org$" name=".+" />
 
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/NeverDDoS.com.xml
+++ b/src/chrome/content/rules/NeverDDoS.com.xml
@@ -4,7 +4,7 @@
 	<target host="www.neverddos.com" />
 
 
-	<securecookie host="^(?:w*\.)?neverddos\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?neverddos\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/News9daily.org.xml
+++ b/src/chrome/content/rules/News9daily.org.xml
@@ -4,7 +4,7 @@
 	<target host="www.news9daily.org" />
 
 
-	<securecookie host="^(?:w*\.)?news9daily\.org$" name=".+" />
+	<securecookie host="^(?:\w*\.)?news9daily\.org$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Nicotine-Anonymous.xml
+++ b/src/chrome/content/rules/Nicotine-Anonymous.xml
@@ -3,7 +3,7 @@
 	<target host="www.nicotine-anonymous.org" />
 
 
-	<securecookie host="^(?:w*\.)?nicotine-anonymous\.org$" name=".+" />
+	<securecookie host="^(?:\w*\.)?nicotine-anonymous\.org$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Nisit69.com.xml
+++ b/src/chrome/content/rules/Nisit69.com.xml
@@ -47,7 +47,7 @@
 	<target host="www.nisit69.com" />
 
 
-	<securecookie host="^(?:w*\.)?nisit69\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?nisit69\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Nuwear.xml
+++ b/src/chrome/content/rules/Nuwear.xml
@@ -11,7 +11,7 @@ Fetch error: http://www.nuwear.com/ => https://www.nuwear.com/: (60, 'SSL certif
 	<target host="www.nuwear.com" />
 
 
-	<securecookie host="^(?:w*\.)?nuwear\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?nuwear\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/OneCloudSecurity.com.xml
+++ b/src/chrome/content/rules/OneCloudSecurity.com.xml
@@ -17,7 +17,7 @@ Fetch error: http://onecloudsecurity.com/ => https://onecloudsecurity.com/: Too 
 	<target host="www.onecloudsecurity.com" />
 
 
-	<securecookie host="^(?:w*\.)?onecloudsecurity\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?onecloudsecurity\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Online_Wellness_Association.xml
+++ b/src/chrome/content/rules/Online_Wellness_Association.xml
@@ -4,7 +4,7 @@
 	<target host="www.onlinewellnessassociation.com" />
 
 
-	<securecookie host="^(?:w*\.)?onlinewellnessassociation\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?onlinewellnessassociation\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Ontario_Minor_Hockey_Association.xml
+++ b/src/chrome/content/rules/Ontario_Minor_Hockey_Association.xml
@@ -13,7 +13,7 @@ Fetch error: http://omha.net/ => https://omha.net/: (51, "SSL: no alternative ce
 	<target host="www.omha.net" />
 
 
-	<securecookie host="^(?:w*\.)?omha\.net$" name=".+" />
+	<securecookie host="^(?:\w*\.)?omha\.net$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/OptionBit.xml
+++ b/src/chrome/content/rules/OptionBit.xml
@@ -4,7 +4,7 @@
 	<target host="www.optionbit.com" />
 
 
-	<securecookie host="^(?:w*\.)?optionbit\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?optionbit\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/PH_Cheats.xml
+++ b/src/chrome/content/rules/PH_Cheats.xml
@@ -15,7 +15,7 @@ Fetch error: http://phcheats.com/ => https://phcheats.com/: Cycle detected - URL
 	<target host="www.phcheats.com" />
 
 
-	<securecookie host="^(?:w*\.)?phcheats\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?phcheats\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Pagina_Zero.xml
+++ b/src/chrome/content/rules/Pagina_Zero.xml
@@ -13,7 +13,7 @@ Fetch error: http://paginazero.com.br/ => https://paginazero.com.br/: (51, "SSL:
 	<target host="www.paginazero.com.br" />
 
 
-	<securecookie host="^(?:w*\.)?paginazero\.com\.br$" name=".+" />
+	<securecookie host="^(?:\w*\.)?paginazero\.com\.br$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/PaoDelicia.com.xml
+++ b/src/chrome/content/rules/PaoDelicia.com.xml
@@ -11,7 +11,7 @@ Fetch error: http://www.paodelicia.com/ => https://www.paodelicia.com/: (51, "SS
 	<target host="www.paodelicia.com" />
 
 
-	<securecookie host="^(?:w*\.)?paodelicia\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?paodelicia\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Passed.cc.xml
+++ b/src/chrome/content/rules/Passed.cc.xml
@@ -11,7 +11,7 @@ Fetch error: http://www.passed.cc/ => https://www.passed.cc/: (35, 'Unknown SSL 
 	<target host="www.passed.cc" />
 
 
-	<securecookie host="^(?:w*\.)?passed\.cc$" name=".+" />
+	<securecookie host="^(?:\w*\.)?passed\.cc$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/PewDiePie.net.xml
+++ b/src/chrome/content/rules/PewDiePie.net.xml
@@ -4,7 +4,7 @@
 	<target host="www.pewdiepie.net" />
 
 
-	<securecookie host="^(?:w*\.)?pewdiepie\.net$" name=".+" />
+	<securecookie host="^(?:\w*\.)?pewdiepie\.net$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Pizza.fr.xml
+++ b/src/chrome/content/rules/Pizza.fr.xml
@@ -8,7 +8,7 @@
 	<target host="www.pizza.fr" />
 
 
-	<securecookie host="^(?:w*\.)?pizza\.fr$" name=".+" />
+	<securecookie host="^(?:\w*\.)?pizza\.fr$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/PointsHound.xml
+++ b/src/chrome/content/rules/PointsHound.xml
@@ -4,7 +4,7 @@
 	<target host="www.pointshound.com" />
 
 
-	<securecookie host="^(?:w*\.)?pointshound\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?pointshound\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/PopVote.hk.xml
+++ b/src/chrome/content/rules/PopVote.hk.xml
@@ -4,7 +4,7 @@
 	<target host="www.popvote.hk" />
 
 
-	<securecookie host="^(?:w*\.)?popvote\.hk$" name=".+" />
+	<securecookie host="^(?:\w*\.)?popvote\.hk$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Power_to_the_Pooch.xml
+++ b/src/chrome/content/rules/Power_to_the_Pooch.xml
@@ -13,7 +13,7 @@ Fetch error: http://powertothepooch.com/ => https://powertothepooch.com/: (28, '
 	<target host="www.powertothepooch.com" />
 
 
-	<securecookie host="^(?:w*\.)?powertothepooch\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?powertothepooch\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Powerlineman.com.xml
+++ b/src/chrome/content/rules/Powerlineman.com.xml
@@ -4,7 +4,7 @@
 	<target host="www.powerlineman.com" />
 
 
-    <securecookie host="^(?:w*\.)?powerlineman\.com" name=".+" />
+    <securecookie host="^(?:\w*\.)?powerlineman\.com" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Primes_Eco_Energie.com.xml
+++ b/src/chrome/content/rules/Primes_Eco_Energie.com.xml
@@ -4,7 +4,7 @@
 	<target host="www.primesecoenergie.com" />
 
 
-	<securecookie host="^(?:w*\.)?primesecoenergie\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?primesecoenergie\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/RCKing.xml
+++ b/src/chrome/content/rules/RCKing.xml
@@ -32,7 +32,7 @@
 	<!--securecookie host="^\.rcking\.eu$" name="^(?:__cfduid|[\da-f]{32}|cf_clearance)$" /-->
 	<!--securecookie host="^www\.rcking\.eu$" name="^lgc$" /-->
 
-	<securecookie host="^(?:w*\.)?rcking\.eu$" name=".+" />
+	<securecookie host="^(?:\w*\.)?rcking\.eu$" name=".+" />
 
 
 	<rule from="^http://rcking\.eu/"

--- a/src/chrome/content/rules/ROMDashboard.xml
+++ b/src/chrome/content/rules/ROMDashboard.xml
@@ -4,7 +4,7 @@
 	<target host="www.romdashboard.com" />
 
 
-	<securecookie host="^(?:w*\.)?romdashboard\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?romdashboard\.com$" name=".+" />
 
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/ReelHD.com.xml
+++ b/src/chrome/content/rules/ReelHD.com.xml
@@ -19,7 +19,7 @@
 	<target host="reelhd.com" />
 
 
-	<securecookie host="^(?:w*\.)?reelhd\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?reelhd\.com$" name=".+" />
 
 
 	<rule from="^http://reelhd\.com/"

--- a/src/chrome/content/rules/Responsive.io.xml
+++ b/src/chrome/content/rules/Responsive.io.xml
@@ -24,7 +24,7 @@
 
 	<!--	Not secured by server:
 					-->
-	<securecookie host="^(?:w*\.)?responsive\.io$" name=".+" />
+	<securecookie host="^(?:\w*\.)?responsive\.io$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Richmond_Tea_Party.xml
+++ b/src/chrome/content/rules/Richmond_Tea_Party.xml
@@ -4,7 +4,7 @@
 	<target host="www.richmondteaparty.com" />
 
 
-	<securecookie host="^(?:w*\.)?richmondteaparty\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?richmondteaparty\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/RolePlayChat.org.xml
+++ b/src/chrome/content/rules/RolePlayChat.org.xml
@@ -19,7 +19,7 @@ Fetch error: http://www.roleplaychat.org/ => https://www.roleplaychat.org/: (7, 
 	<target host="www.roleplaychat.org" />
 
 
-	<securecookie host="^(?:w*\.)?roleplaychat\.org$" name=".+" />
+	<securecookie host="^(?:\w*\.)?roleplaychat\.org$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/SQL_Converter.xml
+++ b/src/chrome/content/rules/SQL_Converter.xml
@@ -4,7 +4,7 @@
 	<target host="www.sqlconverter.com" />
 
 
-	<securecookie host="^(?:w*\.)?sqlconverter\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?sqlconverter\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Sanoma.com.xml
+++ b/src/chrome/content/rules/Sanoma.com.xml
@@ -23,7 +23,7 @@
 	<target host="www.sanoma.com" />
 
 
-	<securecookie host="^(?:w*\.)?sanoma\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?sanoma\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Scanmarker.xml
+++ b/src/chrome/content/rules/Scanmarker.xml
@@ -4,7 +4,7 @@
 	<target host="www.scanmarker.com" />
 
 
-	<securecookie host="^(?:w*\.)?scanmarker\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?scanmarker\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Score_Restore.com.xml
+++ b/src/chrome/content/rules/Score_Restore.com.xml
@@ -4,7 +4,7 @@
 	<target host="www.scorerestore.com" />
 
 
-	<securecookie host="^(?:w*\.)?scorerestore\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?scorerestore\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Seedboxes.cc.xml
+++ b/src/chrome/content/rules/Seedboxes.cc.xml
@@ -4,7 +4,7 @@
 	<target host="www.seedboxes.cc" />
 
 
-	<securecookie host="^(?:w*\.)?seedboxes\.cc$" name=".+" />
+	<securecookie host="^(?:\w*\.)?seedboxes\.cc$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Servercraft.xml
+++ b/src/chrome/content/rules/Servercraft.xml
@@ -4,7 +4,7 @@
 	<target host="www.servercraft.co" />
 
 
-	<securecookie host="^(?:w*\.)?servercraft\.co$" name=".+" />
+	<securecookie host="^(?:\w*\.)?servercraft\.co$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Shamans_Garden.xml
+++ b/src/chrome/content/rules/Shamans_Garden.xml
@@ -4,7 +4,7 @@
 	<target host="www.shamansgarden.com" />
 
 
-	<securecookie host="^(?:w*\.)?shamansgarden\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?shamansgarden\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Shotgun_Club.xml
+++ b/src/chrome/content/rules/Shotgun_Club.xml
@@ -4,7 +4,7 @@
 	<target host="www.shotgunclub.com" />
 
 
-	<securecookie host="^(?:w*\.)?shotgunclub\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?shotgunclub\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Simple_Pickup.xml
+++ b/src/chrome/content/rules/Simple_Pickup.xml
@@ -10,7 +10,7 @@
 	<target host="www.simplepickup.com" />
 
 
-	<securecookie host="^(?:w*\.)?simplepickup\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?simplepickup\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Spartafx.com.xml
+++ b/src/chrome/content/rules/Spartafx.com.xml
@@ -13,7 +13,7 @@ Fetch error: http://spartafx.com/ => https://spartafx.com/: (6, 'Could not resol
 	<target host="www.spartafx.com" />
 
 
-	<securecookie host="^(?:w*\.)?spartafx\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?spartafx\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Spartan_Institute.xml
+++ b/src/chrome/content/rules/Spartan_Institute.xml
@@ -17,7 +17,7 @@ Fetch error: http://thespartaninstitute.com/ => https://thespartaninstitute.com/
 	<target host="www.thespartaninstitute.com" />
 
 
-	<securecookie host="^(?:w*\.)?thespartaninstitute\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?thespartaninstitute\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Speaker_Exchange.xml
+++ b/src/chrome/content/rules/Speaker_Exchange.xml
@@ -4,7 +4,7 @@
 	<target host="www.reconingspeakers.com" />
 
 
-	<securecookie host="^(?:w*\.)?reconingspeakers\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?reconingspeakers\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/SpeakyChat.com.xml
+++ b/src/chrome/content/rules/SpeakyChat.com.xml
@@ -6,7 +6,7 @@
 	<target host="*.speakyweb.com" />
 
 
-	<securecookie host="^(?:w*\.)?speaky(?:chat|web)\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?speaky(?:chat|web)\.com$" name=".+" />
 
 
 	<rule from="^http://((?:download|install|www)\.)?speakychat\.com/"

--- a/src/chrome/content/rules/SpeedPPC.xml
+++ b/src/chrome/content/rules/SpeedPPC.xml
@@ -10,7 +10,7 @@
 	<target host="www.speedppc.com" />
 
 
-	<securecookie host="^(?:w*\.)?speedppc\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?speedppc\.com$" name=".+" />
 
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/Spendbitcoins.xml
+++ b/src/chrome/content/rules/Spendbitcoins.xml
@@ -17,7 +17,7 @@ Fetch error: http://spendbitcoins.com/ => https://spendbitcoins.com/: Too many r
 	<target host="www.spendbitcoins.com" />
 
 
-	<securecookie host="^(?:w*\.)?spendbitcoins\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?spendbitcoins\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Symplicity.xml
+++ b/src/chrome/content/rules/Symplicity.xml
@@ -5,7 +5,7 @@
 	<target host="www.symplicity.com" />
 
 
-	<securecookie host="^(?:w*\.)?symplicity\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?symplicity\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Synergist_SCADA.xml
+++ b/src/chrome/content/rules/Synergist_SCADA.xml
@@ -17,7 +17,7 @@ Fetch error: http://synergistscada.com/ => https://synergistscada.com/: Too many
 	<target host="www.synergistscada.com" />
 
 
-	<securecookie host="^(?:w*\.)?synergistscada\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?synergistscada\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/TF_Sprays.com.xml
+++ b/src/chrome/content/rules/TF_Sprays.com.xml
@@ -4,7 +4,7 @@
 	<target host="www.tfsprays.com" />
 
 
-	<securecookie host="^(?:w*\.)?tfsprays\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?tfsprays\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/TSB_Mag.com.xml
+++ b/src/chrome/content/rules/TSB_Mag.com.xml
@@ -22,7 +22,7 @@
 	<target host="www.tsbmag.com" />
 
 
-	<securecookie host="^(?:w*\.)?tsbmag\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?tsbmag\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Tailgaters_Parking.com.xml
+++ b/src/chrome/content/rules/Tailgaters_Parking.com.xml
@@ -4,7 +4,7 @@
 	<target host="www.tailgatersparking.com" />
 
 
-	<securecookie host="^(?:w*\.)?tailgatersparking\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?tailgatersparking\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/TankaFetast.com.xml
+++ b/src/chrome/content/rules/TankaFetast.com.xml
@@ -21,7 +21,7 @@ Fetch error: http://www.tankafetast.com/ => https://www.tankafetast.com/: (35, '
 					-->
 	<!--securecookie host="^\.tankafetast\.com$" name="^(?:__cfduid|cf_clearance)$" /-->
 
-	<securecookie host="^(?:w*\.)?tankafetast\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?tankafetast\.com$" name=".+" />
 
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/Technocrat.net.xml
+++ b/src/chrome/content/rules/Technocrat.net.xml
@@ -6,7 +6,7 @@
 
 	<!--	Not secured by server:
 					-->
-	<securecookie host="^(?:w*\.)?technocrat\.net$" name=".+" />
+	<securecookie host="^(?:\w*\.)?technocrat\.net$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Terres_Oubliees.com.xml
+++ b/src/chrome/content/rules/Terres_Oubliees.com.xml
@@ -4,13 +4,13 @@
 	<target host="*.terresoubliees.com" />
 
 
-	<securecookie host="^(?:w*\.)?terresoubliees\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?terresoubliees\.com$" name=".+" />
 
 
 	<!--	^ redirects to www over http,
 		so copy that behavior:
 					-->
-	<rule from="^http://(?:www\.)?terresoubliees\.com/"
+	<rule from="^http://(?:\www\.)?terresoubliees\.com/"
 		to="https://www.terresoubliees.com/" />
 
 	<rule from="^http://erp\.terresoubliees\.com/"

--- a/src/chrome/content/rules/Thuisbezorgd.nl.xml
+++ b/src/chrome/content/rules/Thuisbezorgd.nl.xml
@@ -8,7 +8,7 @@
 	<target host="www.thuisbezorgd.nl" />
 
 
-	<securecookie host="^(?:w*\.)?thuisbezorgd\.nl$" name=".+" />
+	<securecookie host="^(?:\w*\.)?thuisbezorgd\.nl$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Ticket_Driver.xml
+++ b/src/chrome/content/rules/Ticket_Driver.xml
@@ -4,7 +4,7 @@
 	<target host="www.ticketdriver.com" />
 
 
-	<securecookie host="^(?:w*\.)?ticketdriver\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?ticketdriver\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Time_Clock_Deals.com.xml
+++ b/src/chrome/content/rules/Time_Clock_Deals.com.xml
@@ -10,7 +10,7 @@
 	<target host="www.timeclockdeals.com" />
 
 
-	<securecookie host="^(?:w*\.)?timeclockdeals\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?timeclockdeals\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/TorLock.com.xml
+++ b/src/chrome/content/rules/TorLock.com.xml
@@ -42,7 +42,7 @@ Fetch error: http://cdn.torlock.com/ => https://tlock-16e3.kxcdn.com/: (51, "SSL
 					-->
 	<!--securecookie host="^\.torlock\.com$" name="^(?:__cfduid|cf_clearance)$" /-->
 
-	<securecookie host="^(?:w*\.)?torlock\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?torlock\.com$" name=".+" />
 
 
 	<!--	!www redirects to www over http,

--- a/src/chrome/content/rules/TorrentFreak.com.xml
+++ b/src/chrome/content/rules/TorrentFreak.com.xml
@@ -19,7 +19,7 @@
 	<target host="www.torrentfreak.com" />
 
 
-	<securecookie host="^(?:w*\.)?torrentfreak\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?torrentfreak\.com$" name=".+" />
 
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/Total_Boox.xml
+++ b/src/chrome/content/rules/Total_Boox.xml
@@ -10,7 +10,7 @@ Fetch error: http://totalboox.com/ => https://totalboox.com/: (6, 'Could not res
 	<target host="www.totalboox.com" />
 
 
-	<securecookie host="^(?:w*\.)?totalboox\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?totalboox\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Total_Eyecare.xml
+++ b/src/chrome/content/rules/Total_Eyecare.xml
@@ -4,7 +4,7 @@
 	<target host="www.totalicare.com" />
 
 
-	<securecookie host="^(?:w*\.)?totalicare\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?totalicare\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/TrendWeight.xml
+++ b/src/chrome/content/rules/TrendWeight.xml
@@ -4,7 +4,7 @@
 	<target host="www.trendweight.com" />
 
 
-	<securecookie host="^(?:w*\.)?trendweight\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?trendweight\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/TutsPlus.com.xml
+++ b/src/chrome/content/rules/TutsPlus.com.xml
@@ -48,7 +48,7 @@
 	<!--securecookie host="^support\.tutsplus\.com$" name="^(_help_center_session|_zendesk_session|_zendesk_shared_session)$" /-->
 
 	<securecookie host="^\.tutsplus\.com$" name="^__cfduid$" />
-	<!--securecookie host="^(?:w*\.)?tutsplus\.com$" name=".+" /-->
+	<!--securecookie host="^(?:\w*\.)?tutsplus\.com$" name=".+" /-->
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Upx69.com.xml
+++ b/src/chrome/content/rules/Upx69.com.xml
@@ -53,7 +53,7 @@
 					-->
 	<!--securecookie host="^\.upx69\.com$" name="^(?:__cfduid|cf_clearance)$" /-->
 
-	<securecookie host="^(?:w*\.)?upx69\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?upx69\.com$" name=".+" />
 
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/VDQ_Bulbs.com.au.xml
+++ b/src/chrome/content/rules/VDQ_Bulbs.com.au.xml
@@ -4,7 +4,7 @@
 	<target host="www.vdqbulbs.com.au" />
 
 
-	<securecookie host="^(?:w*\.)?vdqbulbs\.com\.au$" name=".+" />
+	<securecookie host="^(?:\w*\.)?vdqbulbs\.com\.au$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Vdoth.com.xml
+++ b/src/chrome/content/rules/Vdoth.com.xml
@@ -38,7 +38,7 @@ Fetch error: http://www.clipth.net/ => https://www.vdoth.com/: (28, 'Connection 
 	<target host="www.clipth.net" />
 
 
-	<securecookie host="^(?:w*\.)?vdoth\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?vdoth\.com$" name=".+" />
 
 
 	<rule from="^http://www\.clipth\.net/"

--- a/src/chrome/content/rules/Visa_to_Vietnam.xml
+++ b/src/chrome/content/rules/Visa_to_Vietnam.xml
@@ -4,7 +4,7 @@
 	<target host="www.visatovietnam.org" />
 
 
-	<securecookie host="^(?:w*\.)?visatovietnam\.org$" name=".+" />
+	<securecookie host="^(?:\w*\.)?visatovietnam\.org$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Voodoo_Ping.com.xml
+++ b/src/chrome/content/rules/Voodoo_Ping.com.xml
@@ -12,7 +12,7 @@
 	<target host="www.voodooping.com" />
 
 
-	<securecookie host="^(?:w*\.)?voodooping\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?voodooping\.com$" name=".+" />
 
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/VosCast.com.xml
+++ b/src/chrome/content/rules/VosCast.com.xml
@@ -14,7 +14,7 @@
 
 	<!--	Not secured by server:
 					-->
-	<securecookie host="^(?:w*\.)?voscast\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?voscast\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/WebCitz.xml
+++ b/src/chrome/content/rules/WebCitz.xml
@@ -4,7 +4,7 @@
 	<target host="www.webcitz.com" />
 
 
-	<securecookie host="^(?:w*\.)?webcitz\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?webcitz\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Weboolu.xml
+++ b/src/chrome/content/rules/Weboolu.xml
@@ -27,7 +27,7 @@ Fetch error: http://weboolu.com/ => https://weboolu.com/: (7, 'Failed to connect
 	<target host="www.webooluinc.com" />
 
 
-	<securecookie host="^(?:w*\.)?weboolu(?:inc)?\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?weboolu(?:inc)?\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Webtimeclock.com.xml
+++ b/src/chrome/content/rules/Webtimeclock.com.xml
@@ -6,7 +6,7 @@
 	<target host="www.webtimeclock.com" />
 
 
-	<securecookie host="^(?:w*\.)?webtimeclock\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?webtimeclock\.com$" name=".+" />
 
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/Wellbid.com.xml
+++ b/src/chrome/content/rules/Wellbid.com.xml
@@ -5,7 +5,7 @@
 	<target host="www.wellbid.com" />
 
 
-	<securecookie host="^(?:w*\.)?wellbid\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?wellbid\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Woopra.xml
+++ b/src/chrome/content/rules/Woopra.xml
@@ -12,7 +12,7 @@
 	<target host="www.woopra.com" />
 
 
-	<securecookie host="^(?:w*\.)?woopra\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?woopra\.com$" name=".+" />
 
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/Xbetsport.com.xml
+++ b/src/chrome/content/rules/Xbetsport.com.xml
@@ -10,7 +10,7 @@
 	<target host="www.xbetsport.com" />
 
 
-	<securecookie host="^(?:w*\.)?xbetsport\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?xbetsport\.com$" name=".+" />
 
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/Yed24hr.com.xml
+++ b/src/chrome/content/rules/Yed24hr.com.xml
@@ -76,10 +76,10 @@
 	<target host="www.movzeed.com" />
 
 
-	<securecookie host="^(?:w*\.)?yed24hr\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?yed24hr\.com$" name=".+" />
 
 
-	<rule from="^http://(?:www\.)?mov(?:24hr|zeed)\.com/"
+	<rule from="^http://(?:\www\.)?mov(?:24hr|zeed)\.com/"
 		to="https://www.yed24hr.com/" />
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/Your_Date_Link.xml
+++ b/src/chrome/content/rules/Your_Date_Link.xml
@@ -13,7 +13,7 @@ Fetch error: http://yourdatelink.com/ => https://yourdatelink.com/: (51, "SSL: n
 	<target host="www.yourdatelink.com" />
 
 
-	<securecookie host="^(?:w*\.)?yourdatelink\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?yourdatelink\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/Zeedpic69.com.xml
+++ b/src/chrome/content/rules/Zeedpic69.com.xml
@@ -9,7 +9,7 @@
 	<target host="www.zeedpic69.com" />
 
 
-	<securecookie host="^(?:w*\.)?zeedpic69\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?zeedpic69\.com$" name=".+" />
 
 
 	<rule from="^http:"

--- a/src/chrome/content/rules/Zendy_Labs.xml
+++ b/src/chrome/content/rules/Zendy_Labs.xml
@@ -4,7 +4,7 @@
 	<target host="www.zendylabs.com" />
 
 
-	<securecookie host="^(?:w*\.)?zendylabs\.com$" name=".+" />
+	<securecookie host="^(?:\w*\.)?zendylabs\.com$" name=".+" />
 
 
 	<rule from="^http:" to="https:" />


### PR DESCRIPTION
It seems to me that a wrong pattern was used... cc @Hainish 

```bash
$ grep -lF '(?:w*\.)' *.xml  | xargs sed -i 's/?:w/?:\\w/g'
```