### PR TITLE
Fix securecookie rule in Radare.org.xml

### DIFF
--- a/src/chrome/content/rules/Radare.org.xml
+++ b/src/chrome/content/rules/Radare.org.xml
@@ -1,16 +1,13 @@
 <!--
-	Connection refused:
+	Connection timeout:
 		- cloud.radare.org
-
-	Wrong server:
-		- cydia.radare.org
 -->
-
 <ruleset name="Radare.org">
 	<target host="radare.org" />
 	<target host="www.radare.org" />
+	<target host="cydia.radare.org" />
 
-	<securecookie host="^(www)\.radare\.org$" name=".+" />
+	<securecookie host=".+" name=".+" />
 
 	<rule from="^http:" to="https:" />
 </ruleset>


### PR DESCRIPTION
apparently it was missing a `?`