### PR TITLE
Add UI in option page to view and remove user rules

### DIFF
--- a/chromium/background-scripts/background.js
+++ b/chromium/background-scripts/background.js
@@ -898,14 +898,16 @@ chrome.runtime.onMessage.addListener(function(message, sender, sendResponse){
       return true;
     },
     remove_rule: () => {
-      all_rules.removeRuleAndStore(message.object)
+      all_rules.removeRuleAndStore(message.object.ruleset, message.object.src)
         .then(() => {
           /**
            * FIXME: initializeAllRules is needed for calls from the option pages.
            * Since message.object is not of type Ruleset, rules.removeUserRule
            * is not usable...
            */
-          return initializeAllRules();
+          if (message.object.src === 'options') {
+            return initializeAllRules();
+          }
         })
         .then(() => {
           if (sendResponse !== null) {

--- a/chromium/background-scripts/background.js
+++ b/chromium/background-scripts/background.js
@@ -894,7 +894,10 @@ chrome.runtime.onMessage.addListener(function(message, sender, sendResponse){
       return true;
     },
     remove_rule: () => {
-      all_rules.removeRuleAndStore(message.object);
+      all_rules.removeRuleAndStore(message.object). then(() => {
+        sendResponse(true);
+      });
+      return true;
     },
     get_ruleset_timestamps: () => {
       update.getRulesetTimestamps().then(timestamps => sendResponse(timestamps));

--- a/chromium/background-scripts/background.js
+++ b/chromium/background-scripts/background.js
@@ -887,6 +887,10 @@ chrome.runtime.onMessage.addListener(function(message, sender, sendResponse){
         chrome.tabs.reload();
       });
     },
+    get_user_rules: () => {
+      store.get_promise(all_rules.USER_RULE_KEY, []).then(userRules => sendResponse(userRules));
+      return true;
+    },
     add_new_rule: () => {
       all_rules.addNewRuleAndStore(message.object).then(() => {
         sendResponse(true);
@@ -894,7 +898,7 @@ chrome.runtime.onMessage.addListener(function(message, sender, sendResponse){
       return true;
     },
     remove_rule: () => {
-      all_rules.removeRuleAndStore(message.object). then(() => {
+      all_rules.removeRuleAndStore(message.object).then(() => {
         sendResponse(true);
       });
       return true;

--- a/chromium/background-scripts/background.js
+++ b/chromium/background-scripts/background.js
@@ -898,9 +898,18 @@ chrome.runtime.onMessage.addListener(function(message, sender, sendResponse){
       return true;
     },
     remove_rule: () => {
-      all_rules.removeRuleAndStore(message.object).then(() => {
-        sendResponse(true);
-      });
+      all_rules.removeRuleAndStore(message.object)
+        .then(() => {
+          /**
+           * FIXME: initializeAllRules is needed for calls from the option pages.
+           * Since message.object is not of type Ruleset, rules.removeUserRule
+           * is not usable...
+           */
+          return initializeAllRules();
+        })
+        .then(() => {
+          sendResponse(true);
+        })
       return true;
     },
     get_ruleset_timestamps: () => {

--- a/chromium/background-scripts/background.js
+++ b/chromium/background-scripts/background.js
@@ -908,7 +908,9 @@ chrome.runtime.onMessage.addListener(function(message, sender, sendResponse){
           return initializeAllRules();
         })
         .then(() => {
-          sendResponse(true);
+          if (sendResponse !== null) {
+            sendResponse(true);
+          }
         })
       return true;
     },

--- a/chromium/background-scripts/rules.js
+++ b/chromium/background-scripts/rules.js
@@ -372,7 +372,7 @@ RuleSets.prototype = {
   /**
   * Load all stored user rules into this RuleSet object
   */
-  loadStoredUserRules: async function() {
+  loadStoredUserRules: function() {
     return this.getStoredUserRules()
       .then(userRules => {
         this.addFromJson(userRules, getScope());

--- a/chromium/background-scripts/rules.js
+++ b/chromium/background-scripts/rules.js
@@ -409,7 +409,7 @@ RuleSets.prototype = {
       let userRules = await this.getStoredUserRules();
       userRules = userRules.filter(r =>
         !(r.name == ruleset.name &&
-          r.rule[0].to == ruleset.rules[0].to)
+          r.rule[0].to == ruleset.rule[0].to)
       );
       await this.store.set_promise(this.USER_RULE_KEY, userRules);
     }

--- a/chromium/background-scripts/rules.js
+++ b/chromium/background-scripts/rules.js
@@ -221,7 +221,7 @@ RuleSets.prototype = {
     this.store = store;
     this.ruleActiveStates = await this.store.get_promise('ruleActiveStates', {});
     await applyStoredFunc(this);
-    this.loadStoredUserRules();
+    await this.loadStoredUserRules();
     await this.addStoredCustomRulesets();
   },
 

--- a/chromium/background-scripts/store.js
+++ b/chromium/background-scripts/store.js
@@ -72,28 +72,29 @@ async function performMigrations() {
       await set_promise('ruleActiveStates', ruleActiveStates);
     }
 
-    if (migration_version === 1) {
-      await get_promise(rules.RuleSets().USER_RULE_KEY, [])
-        .then(userRules => {
-          userRules = userRules.map(userRule => {
-            return {
-              name: userRule.host,
-              target: [userRule.host],
-              rule: [{ from: userRule.urlMatcher, to: userRule.redirectTo }],
-              default_off: "user rule"
-            }
-          })
-          return userRules;
-        })
-        .then(userRules => {
-          return set_promise(rules.RuleSets().USER_RULE_KEY, userRules);
-        })
-
-      migration_version = 2;
-      await set_promise('migration_version', migration_version);
-    }
   } catch (e) {
     // do nothing
+  }
+
+  if (migration_version === 1) {
+    await get_promise(rules.RuleSets().USER_RULE_KEY, [])
+      .then(userRules => {
+        userRules = userRules.map(userRule => {
+          return {
+            name: userRule.host,
+            target: [userRule.host],
+            rule: [{ from: userRule.urlMatcher, to: userRule.redirectTo }],
+            default_off: "user rule"
+          }
+        })
+        return userRules;
+      })
+      .then(userRules => {
+        return set_promise(rules.RuleSets().USER_RULE_KEY, userRules);
+      })
+
+    migration_version = 2;
+    await set_promise('migration_version', migration_version);
   }
 }
 

--- a/chromium/background-scripts/store.js
+++ b/chromium/background-scripts/store.js
@@ -76,7 +76,7 @@ async function performMigrations() {
     // do nothing
   }
 
-  if (migration_version < 1) {
+  if (migration_version <= 1) {
     await get_promise(rules.RuleSets().USER_RULE_KEY, [])
       .then(userRules => {
         userRules = userRules.map(userRule => {

--- a/chromium/background-scripts/store.js
+++ b/chromium/background-scripts/store.js
@@ -51,29 +51,50 @@ function local_set_promise(key, value) {
 
 
 async function performMigrations() {
-  const migration_version = await get_promise('migration_version', 0);
+  let migration_version = await get_promise('migration_version', 0);
 
-  if (migration_version < 1) {
+  try {
+    if (migration_version === 0) {
+      let ls = localStorage;
+      let ruleActiveStates = {};
 
-    let ls;
-    try {
-      ls = localStorage;
-    } catch(e) {}
-
-    let ruleActiveStates = {};
-    for (const key in ls) {
-      if (ls.hasOwnProperty(key)) {
-        if (key == rules.RuleSets().USER_RULE_KEY){
-          await set_promise(rules.RuleSets().USER_RULE_KEY, JSON.parse(ls[key]));
-        } else {
-          ruleActiveStates[key] = (ls[key] == "true");
+      for (let key in ls) {
+        if (ls.hasOwnProperty(key)) {
+          if (rules.RuleSets().USER_RULE_KEY === key) {
+            await set_promise(rules.RuleSets().USER_RULE_KEY, JSON.parse(ls[key]));
+          } else {
+            ruleActiveStates[key] = (ls[key] === "true");
+          }
         }
       }
+      migration_version = 1;
+      await set_promise('migration_version', migration_version);
+      await set_promise('ruleActiveStates', ruleActiveStates);
     }
-    await set_promise('ruleActiveStates', ruleActiveStates);
-  }
 
-  await set_promise('migration_version', 1);
+    if (migration_version === 1) {
+      await get_promise(rules.RuleSets().USER_RULE_KEY, [])
+        .then(userRules => {
+          userRules = userRules.map(userRule => {
+            return {
+              name: userRule.host,
+              target: [userRule.host],
+              rule: [{ from: userRule.urlMatcher, to: userRule.redirectTo }],
+              default_off: "user rule"
+            }
+          })
+          return userRules;
+        })
+        .then(userRules => {
+          return set_promise(rules.RuleSets().USER_RULE_KEY, userRules);
+        })
+
+      migration_version = 2;
+      await set_promise('migration_version', migration_version);
+    }
+  } catch (e) {
+    // do nothing
+  }
 }
 
 const local = {

--- a/chromium/background-scripts/store.js
+++ b/chromium/background-scripts/store.js
@@ -76,7 +76,7 @@ async function performMigrations() {
     // do nothing
   }
 
-  if (migration_version === 1) {
+  if (migration_version < 1) {
     await get_promise(rules.RuleSets().USER_RULE_KEY, [])
       .then(userRules => {
         userRules = userRules.map(userRule => {

--- a/chromium/pages/options/index.html
+++ b/chromium/pages/options/index.html
@@ -19,6 +19,9 @@
         <input type="checkbox" id="autoUpdateRulesets">
         <label for="autoUpdateRulesets" data-i18n="options_autoUpdateRulesets"></label>
       </div>
+      <div id="user-rules-wrapper">
+        <p class="user-rules-wrapper-header" data-i18n="options_userRulesListed"></p>
+      </div>
       <div id="disabled-rules-wrapper">
         <p class="disabled-rules-wrapper-header" data-i18n="options_disabledUrlsListed"></p>
       </div>

--- a/chromium/pages/options/style.css
+++ b/chromium/pages/options/style.css
@@ -15,6 +15,24 @@ body{
   margin-bottom: 20px;
 }
 
+/** User rules Option**/
+.user-rules-wrapper-header {
+  font-weight: bold;
+  padding-left: 5px;
+}
+.user-rules-list-item:last-of-type {
+  border-bottom: none;
+}
+.user-rules-list-item {
+  border-bottom: 1px solid #ccc;
+  display: inline-flex;
+  margin-left: 5%;
+  width: 80%;
+}
+.user-rules-list-item p {
+  width: 100%;
+}
+
 /** Disabled Sites Option**/
 .disabled-rules-wrapper-header {
   font-weight: bold;

--- a/chromium/pages/options/ux.js
+++ b/chromium/pages/options/ux.js
@@ -233,6 +233,40 @@ document.addEventListener("DOMContentLoaded", () => {
     window.scrollTo(0,0);
   }
 
+  // Get a list of user Rules
+  sendMessage("get_user_rules", null, userRules => {
+    let user_rules_parent = e("user-rules-wrapper");
+
+    if ( 0 === userRules.length) {
+      hide(user_rules_parent);
+      return ;
+    }
+
+    // img element "remove button"
+    let templateRemove = document.createElement("img");
+    templateRemove.src = chrome.extension.getURL("images/remove.png");
+    templateRemove.className = "remove";
+
+    for (const userRule of userRules) {
+      let user_rule_host = document.createElement("div");
+      let user_rule_name = document.createElement("p");
+      let remove = templateRemove.cloneNode(true);
+
+      user_rule_host.className = "user-rules-list-item";
+      user_rule_name.className = "user-rules-list-item_single"
+      user_rule_name.innerText = userRule.name;
+      user_rule_host.appendChild(user_rule_name);
+      user_rules_parent.appendChild(user_rule_host);
+      user_rule_host.appendChild(remove);
+
+      remove.addEventListener("click", () => {
+        sendMessage("remove_rule", userRule, () => {
+          hide( user_rule_host );
+        });
+      });
+    }
+  })
+
   // HTTPS Everywhere Sites Disabled section in General Settings module
   getOption_("disabledList", [], function(item) {
     let rule_host_parent = e("disabled-rules-wrapper");

--- a/chromium/pages/options/ux.js
+++ b/chromium/pages/options/ux.js
@@ -263,7 +263,7 @@ document.addEventListener("DOMContentLoaded", () => {
         // assume the removal is successful and hide ui element
         hide( user_rule_host );
         // remove the user rule
-        sendMessage("remove_rule", userRule);
+        sendMessage("remove_rule", { ruleset: userRule, src: 'options' });
       });
     }
   })

--- a/chromium/pages/options/ux.js
+++ b/chromium/pages/options/ux.js
@@ -253,7 +253,7 @@ document.addEventListener("DOMContentLoaded", () => {
       let remove = templateRemove.cloneNode(true);
 
       user_rule_host.className = "user-rules-list-item";
-      user_rule_name.className = "user-rules-list-item_single"
+      user_rule_name.className = "user-rules-list-item-single"
       user_rule_name.innerText = userRule.name;
       user_rule_host.appendChild(user_rule_name);
       user_rules_parent.appendChild(user_rule_host);

--- a/chromium/pages/options/ux.js
+++ b/chromium/pages/options/ux.js
@@ -260,9 +260,10 @@ document.addEventListener("DOMContentLoaded", () => {
       user_rule_host.appendChild(remove);
 
       remove.addEventListener("click", () => {
-        sendMessage("remove_rule", userRule, () => {
-          hide( user_rule_host );
-        });
+        // assume the removal is successful and hide ui element
+        hide( user_rule_host );
+        // remove the user rule
+        sendMessage("remove_rule", userRule);
       });
     }
   })

--- a/chromium/pages/popup/ux.js
+++ b/chromium/pages/popup/ux.js
@@ -78,7 +78,7 @@ function appendRulesToListDiv(rulesets, list_div) {
           line.appendChild(remove);
 
           remove.addEventListener("click", () => {
-            sendMessage("remove_rule", ruleset, () => {
+            sendMessage("remove_rule", { ruleset, src: 'popup' }, () => {
               list_div.removeChild(line);
             });
           });

--- a/chromium/pages/popup/ux.js
+++ b/chromium/pages/popup/ux.js
@@ -251,9 +251,14 @@ function addManualRule() {
 
     e("add-new-rule-button").addEventListener("click", function() {
       const params = {
-        host : e("new-rule-host").value,
-        redirectTo : e("new-rule-redirect").value,
-        urlMatcher : e("new-rule-regex").value
+        /**
+         * FIXME: the current implementation forbide users setting custom
+         * ruleset names...
+         */
+        name: e("new-rule-host").value,
+        target : [e("new-rule-host").value],
+        rule: [{ to: e("new-rule-redirect").value, from: e("new-rule-regex").value }],
+        default_off: "user rule"
       };
       sendMessage("add_new_rule", params, function() {
         location.reload();

--- a/src/chrome/locale/en/https-everywhere.dtd
+++ b/src/chrome/locale/en/https-everywhere.dtd
@@ -18,6 +18,7 @@
 <!ENTITY https-everywhere.options.enableMixedRulesets "Enable mixed content rulesets">
 <!ENTITY https-everywhere.options.showDevtoolsTab "Show Devtools tab">
 <!ENTITY https-everywhere.options.autoUpdateRulesets "Auto-update rulesets">
+<!ENTITY https-everywhere.options.userRulesListed "HTTPS Everywhere User rules">
 <!ENTITY https-everywhere.options.disabledUrlsListed "HTTPS Everywhere Sites Disabled">
 <!ENTITY https-everywhere.options.updateChannelsWarning "Warning: Adding update channels can cause attackers to hijack your browser. Only edit this section if you know what you're doing!">
 <!ENTITY https-everywhere.options.addUpdateChannel "Add Update Channel">

--- a/src/chrome/locale/en/https-everywhere.dtd
+++ b/src/chrome/locale/en/https-everywhere.dtd
@@ -18,7 +18,7 @@
 <!ENTITY https-everywhere.options.enableMixedRulesets "Enable mixed content rulesets">
 <!ENTITY https-everywhere.options.showDevtoolsTab "Show Devtools tab">
 <!ENTITY https-everywhere.options.autoUpdateRulesets "Auto-update rulesets">
-<!ENTITY https-everywhere.options.userRulesListed "HTTPS Everywhere User rules">
+<!ENTITY https-everywhere.options.userRulesListed "HTTPS Everywhere User Rules">
 <!ENTITY https-everywhere.options.disabledUrlsListed "HTTPS Everywhere Sites Disabled">
 <!ENTITY https-everywhere.options.updateChannelsWarning "Warning: Adding update channels can cause attackers to hijack your browser. Only edit this section if you know what you're doing!">
 <!ENTITY https-everywhere.options.addUpdateChannel "Add Update Channel">


### PR DESCRIPTION
@Hainish This will introduce a simple UI in the option page for users to view and remove the user rules.

P.S. to my surprise, there is some constraint in the current implementation (in lookups & caching) which rendered this more complicated than I have expected... And it is not possible to allow custom user rules names, meaning there is only 1 custom rule for each domain... 

supersedes #16616 relates #14969