### PR TITLE
Disable modifying headers on disabled pages

### DIFF
--- a/chromium/background-scripts/background.js
+++ b/chromium/background-scripts/background.js
@@ -690,6 +690,11 @@ function onHeadersReceived(details) {
     if (uri.hostname.slice(-6) == '.onion') {
       return {};
     }
+   
+    const documentUrl = new URL(details.documentUrl); 
+    if (disabledList.has(documentUrl.hostname)) {
+      return {};
+    }
 
     let responseHeadersChanged = false;
     let cspHeaderFound = false;


### PR DESCRIPTION
HTTPS Everywhere modifies access-control-allow-origin on HTTP nowhere mode. Even if you disabled HTTPS Everywhere with the "Disable HTTPS Everywhere on this site" feature, this was rewritten and the problem occurred. This PR disables modifying on the sites.