### PR TITLE
archive.org fallback for 'block http'

### DIFF
--- a/chromium/pages/cancel/index.html
+++ b/chromium/pages/cancel/index.html
@@ -11,6 +11,8 @@
     <h1 id="https-everywhere"><img src="../../images/banner-red.png" alt="HTTPS Everywhere" /></h1>
     <p data-i18n="cancel_he_blocking_explainer"></p>
     <p id="url-paragraph"><span id="url-label">URL: </span><a href="#" id="originURL"></a></p>
+    <p data-i18n="cancel_he_blocking_internet_archive_explainer"></p>
+    <p id="url-paragraph"><a href="#" id="waybackMachineURL" data-i18n="cancel_he_blocking_internet_archive_link"></a></p>
     <script src="../translation.js"></script>
     <script src="../util.js"></script>
     <script src="ux.js"></script>

--- a/src/chrome/locale/en/https-everywhere.dtd
+++ b/src/chrome/locale/en/https-everywhere.dtd
@@ -34,6 +34,8 @@
 
 <!ENTITY https-everywhere.cancel.he_blocking_explainer "HTTPS Everywhere noticed you were navigating to a non-HTTPS page, and tried to send you to the HTTPS version instead. The HTTPS version is unavailable. Most likely this site does not support HTTPS, but it is also possible that an attacker is blocking the HTTPS version. If you wish to view the unencrypted version of this page, you can still do so by disabling the 'Block all unencrypted requests' option in your HTTPS Everywhere extension. Be aware that disabling this option could make your browser vulnerable to network-based downgrade attacks on websites you visit.">
 <!ENTITY https-everywhere.cancel.he_blocking_network "network-based downgrade attacks">
+<!ENTITY https-everywhere.cancel.he_blocking_internet_archive_explainer "You can also try viewing the latest snapshot of this page from the Internet Archive's Wayback Machine via an HTTPS connection:">
+<!ENTITY https-everywhere.cancel.he_blocking_internet_archive_link "View page on the Internet Archive">
 
 <!ENTITY https-everywhere.chrome.stable_rules "Stable rules">
 <!ENTITY https-everywhere.chrome.stable_rules_description "Force encrypted connections to these websites:">


### PR DESCRIPTION
Hi! Here's my attempt at a patch to let users who have decided to "Block all unencrypted requests" to view a non-HTTPS page via an encrypted connection to archive.org.

I'm happy to revise as needed. :)