### PR TITLE
[PHP.xml] two subdomains now support HSTS

### DIFF
--- a/src/chrome/content/rules/PHP.xml
+++ b/src/chrome/content/rules/PHP.xml
@@ -6,11 +6,9 @@
 		- gcov ²
 		- gtk ³
 		- lxr ¹
-		- museum ¹
 		- news ¹
 		- snaps ¹
 		- talks ³
-		- windows ¹
 		- www ⁴
 
 	¹ Refused
@@ -46,6 +44,7 @@
 	<target host="edit.php.net" />
 	<target host="git.php.net" />
 	<target host="master.php.net" />
+	<target host="museum.php.net" />
 	<target host="pear.php.net" />
 	<target host="pear2.php.net" />
 	<target host="pecl.php.net" />
@@ -56,6 +55,7 @@
 	<target host="static.php.net" />
 	<target host="svn.php.net" />
 	<target host="wiki.php.net" />
+	<target host="windows.php.net" />
 
 	<securecookie host=".+" name=".+" />
 


### PR DESCRIPTION
https://museum.php.net and https://windows.php.net now send HSTS headers.
```
C:\Windows\System32>curl --head https://museum.php.net
HTTP/1.1 200 OK
Server: nginx
Date: Sat, 13 Oct 2018 08:34:43 GMT
Content-Type: text/html
Connection: keep-alive
Strict-Transport-Security: max-age=63072000; includeSubdomains


C:\Windows\System32>curl --head https://windows.php.net
HTTP/1.1 200 OK
Content-Length: 0
Content-Type: text/html; charset=UTF-8
Server: Microsoft-IIS/8.5
X-Powered-By: PHP/7.2.5
Strict-Transport-Security: max-age=15768000
Date: Sat, 13 Oct 2018 08:34:48 GMT
```