### PR TITLE
[Python.org.xml] Update rulesets

### DIFF
--- a/src/chrome/content/rules/Python.org.xml
+++ b/src/chrome/content/rules/Python.org.xml
@@ -59,7 +59,6 @@
 	<target host="status.python.org" />
 	<target host="svn.python.org" />
 	<target host="testpypi.python.org" />
-	<target host="vote.python.org" />
 	<target host="warehouse.python.org" />
 	<target host="warehouse-staging.python.org" />
 	<target host="wiki.python.org" />

--- a/src/chrome/content/rules/Python.org.xml
+++ b/src/chrome/content/rules/Python.org.xml
@@ -1,12 +1,10 @@
 <!--
 	HSTS preloaded:
+		- ^
 		- docs
 		- doc
 		- hg
-
-	Incomplete certificate chain:
-		- hg.es
-		- lists.es
+		- www
 
 	Mismatched:
 		- calendario.es
@@ -15,14 +13,9 @@
 		- www.pl
 		- forum.pl
 		- ns1.pl
-		- redesign
 		- uk
 
-	Refused:
-		- buildbot
-
 	TLS protocol errors:
-		- blog
 		- blog-cn
 		- blog-de
 		- blog-es
@@ -34,24 +27,26 @@
 		- blog-ru
 		- blog-tw
 		- dinsdale
-		- legacy
 -->
 
 <ruleset name="Python.org">
-	<target host="python.org" />
-	<target host="www.python.org" />
 	<target host="africa.python.org" />
+	<target host="blog.python.org" />
 	<target host="bugs.python.org" />
+	<target host="buildbot.python.org" />
 	<target host="cheeseshop.python.org" />
 	<target host="devguide.python.org" />
 	<target host="console.python.org" />
 	<target host="discuss.python.org" />
 	<target host="es.python.org" />
+	<target host="hg.es.python.org" />
+	<target host="lists.es.python.org" />
 	<target host="www.es.python.org" />
 	<target host="openbadges.es.python.org" />
 	<target host="socios.es.python.org" />
 	<target host="front.python.org" />
 	<target host="jobs.python.org" />
+	<target host="legacy.python.org" />
 	<target host="mail.python.org" />
 	<target host="packaging.python.org" />
 	<target host="packages.python.org" />


### PR DESCRIPTION
* https://python.org and https://www.python.org are preloaded.
* redesign, vote domains are NX
* blog, legacy, buildbot, hg.es, lists.es all have good HTTPS support.