### PR TITLE
Update Perl.org.xml

### DIFF
--- a/src/chrome/content/rules/Perl.org.xml
+++ b/src/chrome/content/rules/Perl.org.xml
@@ -22,7 +22,7 @@
 	Mixed image from www on rt
 
 -->
-<ruleset name="Perl.org (partial)">
+<ruleset name="Perl.org">
 
 	<target host="perl.org" />
 	<target host="www.perl.org" />

--- a/src/chrome/content/rules/Perl.org.xml
+++ b/src/chrome/content/rules/Perl.org.xml
@@ -6,36 +6,15 @@
 			- st.pimg.net
 
 
-	Problematic domains:
-
-		- ^ ¹
-		- perldoc		(works; mismatched, CN: *.a.ssl.fastly.net)
-		- svn.perl.org		(works, self-signed)
-
-	¹ Refused
-
-
 	Nonfunctional perl.org subdomains:
 
-		- blob *
 		- blogs *
-		- books *
-		- cpan *
-		- cpanratings *
 		- cpansearch	(times out)
-		- dbi *
-		- dev *
-		- perl5.git *
 		- history *
 		- irc		(http reply)
-		- www.irc *
-		- jobs *
-		- learn *
-		- lists *
-		- log		(blogspot)
-		- noc *
 		- pdl *
 		- use *
+		- svn		(times out)
 
 	* Refused
 
@@ -46,19 +25,26 @@
 <ruleset name="Perl.org (partial)">
 
 	<target host="perl.org" />
-	<target host="*.perl.org" />
-
+	<target host="www.perl.org" />
+	<target host="blob.perl.org" />
+	<target host="books.perl.org" />
+	<target host="cpan.perl.org" />
+	<target host="cpanratings.perl.org" />
+	<target host="dbi.perl.org" />
+	<target host="dev.perl.org" />
+	<target host="perl5.git.perl.org" />
+	<target host="www.irc.perl.org" />
+	<target host="jobs.perl.org" />
+	<target host="learn.perl.org" />
+	<target host="lists.perl.org" />
+	<target host="log.perl.org" />
+	<target host="noc.perl.org" />
+	<target host="pause.perl.org" />
+	<target host="perldoc.perl.org" />
+	<target host="rt.perl.org" />
 
 	<securecookie host="^rt\.perl\.org$" name=".+" />
 
-
-	<rule from="^http://(?:www\.)?perl\.org/"
-		to="https://www.perl.org/" />
-
-	<rule from="^http://log\.perl\.org/favicon\.ico"
-		to="https://www.blogger.com/favicon.ico" />
-
-	<rule from="^http://(pause|rt)\.perl\.org/"
-		to="https://$1.perl.org/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>


### PR DESCRIPTION
Most of perl.org subdomains now support HTTPS. Comment and rulesets are updated.