### PR TITLE
Update Rust-Lang.org.xml

### DIFF
--- a/src/chrome/content/rules/Rust-Lang.org.xml
+++ b/src/chrome/content/rules/Rust-Lang.org.xml
@@ -1,6 +1,5 @@
 <!--
-	Unable to Connect:
-		rust-lang.org
+	
 -->
 <ruleset name="Rust-Lang.org">
 	<target host="rust-lang.org" />
@@ -13,8 +12,6 @@
 	<target host="users.rust-lang.org" />
 
 	<securecookie host=".+" name=".+" />
-
-	<rule from="^http://rust-lang\.org/" to="https://www.rust-lang.org/" />
 
 	<rule from="^http:" to="https:" />
 </ruleset>


### PR DESCRIPTION
https://rust-lang.org can redirect to https://www.rust-lang.org itself.