### PR TITLE
Update W3C.xml

### DIFF
--- a/src/chrome/content/rules/W3C.xml
+++ b/src/chrome/content/rules/W3C.xml
@@ -6,6 +6,7 @@
 		- flanders (mismatch)
 		- herman (timeout)
 		- irc (401)
+		- people (mixed content)
 		- services (mixed content)
 		- test (no longer exists on server)
 -->
@@ -27,8 +28,6 @@
                 <test url="http://lists.w3.org/Archives/Public/" />
 <!-- No tests for media.w3.org as no subfolders or other pages seem to be present -->
 	<target host="media.w3.org" />
-	<target host="people.w3.org" />
-                <test url="http://people.w3.org/webmail/" />
 	<target host="validator.w3.org" />
                 <test url="http://validator.w3.org/docs/help.html" />
 <!-- No tests for validator-suite.w3.org as it is a redirect -->

--- a/src/chrome/content/rules/W3C.xml
+++ b/src/chrome/content/rules/W3C.xml
@@ -6,7 +6,6 @@
 		- flanders (mismatch)
 		- herman (timeout)
 		- irc (401)
-		- people (mismatch)
 		- services (mixed content)
 		- test (no longer exists on server)
 -->
@@ -28,6 +27,8 @@
                 <test url="http://lists.w3.org/Archives/Public/" />
 <!-- No tests for media.w3.org as no subfolders or other pages seem to be present -->
 	<target host="media.w3.org" />
+	<target host="people.w3.org" />
+                <test url="http://people.w3.org/webmail/" />
 	<target host="validator.w3.org" />
                 <test url="http://validator.w3.org/docs/help.html" />
 <!-- No tests for validator-suite.w3.org as it is a redirect -->


### PR DESCRIPTION
https://people.w3.org/ is no longer mismatched.