### PR TITLE
Add distro fallback on install-dev-dependencies.sh

### DIFF
--- a/install-dev-dependencies.sh
+++ b/install-dev-dependencies.sh
@@ -22,6 +22,7 @@ if [ $UID != 0 ]; then
   SUDO_SHIM=sudo
 fi
 
+# debian based installation
 if type apt-get >/dev/null ; then
   $SUDO_SHIM apt-get update
   $SUDO_SHIM apt-get install -y lsb-release
@@ -48,12 +49,16 @@ if type apt-get >/dev/null ; then
   if [ ! -f /usr/lib/chromium/chromedriver ] && [ -f `which chromedriver` ]; then
     $SUDO_SHIM ln -s `which chromedriver` /usr/lib/chromium/chromedriver
   fi
+
+# macOS installation
 elif type brew >/dev/null ; then
   brew list python &>/dev/null || brew install python
   brew install libxml2 gnu-sed chromedriver
   if ! echo $PATH | grep -ql /usr/local/bin ; then
     echo '/usr/local/bin not found in $PATH, please add it.'
   fi
+
+# distros that use rpm (Fedora, Suse, CentOS) installation
 elif type dnf >/dev/null ; then
   $SUDO_SHIM dnf install -y firefox gcc git libcurl-devel libxml2-devel \
     libxslt-devel python-devel redhat-rpm-config xorg-x11-server-Xvfb which \

--- a/install-dev-dependencies.sh
+++ b/install-dev-dependencies.sh
@@ -23,7 +23,7 @@ if [ $UID != 0 ]; then
 fi
 
 # debian based installation
-if type apt-get >/dev/null ; then
+if type apt-get>/dev/null 2>&1;  then
   $SUDO_SHIM apt-get update
   $SUDO_SHIM apt-get install -y lsb-release
   BROWSERS="firefox chromium-browser"
@@ -38,7 +38,7 @@ if type apt-get >/dev/null ; then
   $SUDO_SHIM apt-get install -y libxml2-dev libxml2-utils libxslt1-dev \
     python3.6-dev $BROWSERS zip sqlite3 python3-pip libcurl4-openssl-dev xvfb \
     libssl-dev git curl $CHROMEDRIVER
-  if ! type geckodriver >/dev/null; then
+  if ! type geckodriver >/dev/null 2>&1;  then
     curl -LO "https://github.com/mozilla/geckodriver/releases/download/v0.17.0/geckodriver-v0.17.0-linux64.tar.gz"
     tar -zxvf "geckodriver-v0.17.0-linux64.tar.gz"
     rm -f "geckodriver-v0.17.0-linux64.tar.gz"
@@ -51,7 +51,7 @@ if type apt-get >/dev/null ; then
   fi
 
 # macOS installation
-elif type brew >/dev/null ; then
+elif type brew >/dev/null 2>&1; then
   brew list python &>/dev/null || brew install python
   brew install libxml2 gnu-sed chromedriver
   if ! echo $PATH | grep -ql /usr/local/bin ; then
@@ -59,7 +59,7 @@ elif type brew >/dev/null ; then
   fi
 
 # distros that use rpm (Fedora, Suse, CentOS) installation
-elif type dnf >/dev/null ; then
+elif type dnf >/dev/null 2>&1; then
   $SUDO_SHIM dnf install -y firefox gcc git libcurl-devel libxml2-devel \
     libxslt-devel python-devel redhat-rpm-config xorg-x11-server-Xvfb which \
     findutils procps openssl openssl-devel chromium GConf2
@@ -76,7 +76,7 @@ elif type dnf >/dev/null ; then
     $SUDO_SHIM chown root /usr/bin/chromedriver
     $SUDO_SHIM chmod 755 /usr/bin/chromedriver
   fi
-  if ! type geckodriver >/dev/null; then
+  if ! type geckodriver >/dev/null 2>&1;  then
     curl -LO "https://github.com/mozilla/geckodriver/releases/download/v0.17.0/geckodriver-v0.17.0-macos.tar.gz"
     tar -zxvf "geckodriver-v0.17.0-macos.tar.gz"
     rm -f "geckodriver-v0.17.0-macos.tar.gz"
@@ -90,6 +90,11 @@ elif type dnf >/dev/null ; then
     $SUDO_SHIM sh -c 'dbus-uuidgen > /var/lib/dbus/machine-id'
   fi
   export PYCURL_SSL_LIBRARY=openssl
+else
+    echo \
+    "Your distribuiton isn't supported by this script yet!"\
+    "Please install them manually."
+    exit
 fi
 
 # Get the addon SDK submodule and rule checker

--- a/install-dev-dependencies.sh
+++ b/install-dev-dependencies.sh
@@ -22,6 +22,12 @@ if [ $UID != 0 ]; then
   SUDO_SHIM=sudo
 fi
 
+if [ "`uname -m`" == "x86_64" ]; then
+  ARCH=64
+else
+  ARCH=32
+fi
+
 # debian based installation
 if type apt-get>/dev/null 2>&1;  then
   $SUDO_SHIM apt-get update
@@ -39,9 +45,9 @@ if type apt-get>/dev/null 2>&1;  then
     python3.6-dev $BROWSERS zip sqlite3 python3-pip libcurl4-openssl-dev xvfb \
     libssl-dev git curl $CHROMEDRIVER
   if ! type geckodriver >/dev/null 2>&1;  then
-    curl -LO "https://github.com/mozilla/geckodriver/releases/download/v0.17.0/geckodriver-v0.17.0-linux64.tar.gz"
-    tar -zxvf "geckodriver-v0.17.0-linux64.tar.gz"
-    rm -f "geckodriver-v0.17.0-linux64.tar.gz"
+    curl -LO "https://github.com/mozilla/geckodriver/releases/download/v0.17.0/geckodriver-v0.17.0-linux$ARCH.tar.gz"
+    tar -zxvf "geckodriver-v0.17.0-linux$ARCH.tar.gz"
+    rm -f "geckodriver-v0.17.0-linux$ARCH.tar.gz"
     $SUDO_SHIM mv geckodriver /usr/bin/geckodriver
     $SUDO_SHIM chown root /usr/bin/geckodriver
     $SUDO_SHIM chmod 755 /usr/bin/geckodriver
@@ -64,11 +70,6 @@ elif type dnf >/dev/null 2>&1; then
     libxslt-devel python-devel redhat-rpm-config xorg-x11-server-Xvfb which \
     findutils procps openssl openssl-devel chromium GConf2
   if ! type chromedriver >/dev/null; then
-    if [ "`uname -m`" == "x86_64" ]; then
-      ARCH=64
-    else
-      ARCH=32
-    fi
     curl -O "https://chromedriver.storage.googleapis.com/2.23/chromedriver_linux$ARCH.zip"
     unzip "chromedriver_linux$ARCH.zip"
     rm -f "chromedriver_linux$ARCH.zip"

--- a/src/chrome/content/rules/Karlsruhe.de.xml
+++ b/src/chrome/content/rules/Karlsruhe.de.xml
@@ -1,0 +1,142 @@
+<!--
+	Invalid certificate:
+		- www.cbs.karlsruhe.de
+		- www.vibe.ces.karlsruhe.de
+		- www.web.ces.karlsruhe.de
+		- ess.karlsruhe.de
+		- cas.ess.karlsruhe.de
+		- moodle.ess.karlsruhe.de
+		- fls.karlsruhe.de
+		- huebsch.karlsruhe.de
+		- www.huebsch.karlsruhe.de
+		- owigow.karlsruhe.de
+		- www.sicheres.karlsruhe.de
+		- staatstheater.karlsruhe.de
+		- www.staatstheater.karlsruhe.de
+		- sanierung.staatstheater.karlsruhe.de
+		- spielzeit1[2-8]-1[3-9].staatstheater.karlsruhe.de
+		- stadtlexikon.karlsruhe.de
+		- www.stoerfall.karlsruhe.de
+		- web2.karlsruhe.de
+		- akorgbw.wiki.karlsruhe.de
+
+	Non-2xx HTTP code:
+		- karl.karlsruhe.de
+
+	Refused:
+		- qualle.hhs.karlsruhe.de
+		- kontentor99.karlsruhe.de
+		- rhin2.karlsruhe.de
+
+	Timeout:
+		- afsta.karlsruhe.de
+		- avg.karlsruhe.de
+		- chs.karlsruhe.de
+		- daten.karlsruhe.de
+		- db1.karlsruhe.de
+		- dienste2.karlsruhe.de
+		- endeavour.karlsruhe.de
+		- kultur.karlsruhe.de
+		- la.karlsruhe.de
+		- mail2.karlsruhe.de
+		- mail3.karlsruhe.de
+		- matrix-mdm.karlsruhe.de
+		- cloud.mgg.karlsruhe.de
+		- mdm.mgg.karlsruhe.de
+		- ns1.karlsruhe.de
+		- oa.karlsruhe.de
+		- rhin1.karlsruhe.de
+		- sjb.karlsruhe.de
+		- as.staatstheater.karlsruhe.de
+		- cloud.staatstheater.karlsruhe.de
+		- mon.staatstheater.karlsruhe.de
+		- webmail.staatstheater.karlsruhe.de
+		- ua.karlsruhe.de
+		- wettbewerbe.karlsruhe.de
+		- zjd.karlsruhe.de
+		- zoo.karlsruhe.de
+
+	Unable to get local issuer certificate:
+		- hms.karlsruhe.de
+		- files.hms.karlsruhe.de
+		- suche.karlsruhe.de
+		- suche.karlsruhe2.de
+-->
+<ruleset name="Karlsruhe.de">
+
+	<target host="karlsruhe.de" />
+	<target host="www.karlsruhe.de" />
+	<target host="artenschutz.karlsruhe.de" />
+	<target host="autodiscover.avg.karlsruhe.de" />
+	<target host="bem.karlsruhe.de" />
+	<target host="beteiligung.karlsruhe.de" />
+	<target host="bsb.karlsruhe.de" />
+	<target host="cbs.karlsruhe.de" />
+	<target host="files.cbs.karlsruhe.de" />
+	<target host="moodle.cbs.karlsruhe.de" />
+	<target host="vibe.cbs.karlsruhe.de" />
+	<target host="ces.karlsruhe.de" />
+	<target host="www.ces.karlsruhe.de" />
+	<target host="filr.ces.karlsruhe.de" />
+	<target host="kalender.ces.karlsruhe.de" />
+	<target host="mobile.ces.karlsruhe.de" />
+	<target host="piwik.ces.karlsruhe.de" />
+	<target host="vibe.ces.karlsruhe.de" />
+	<target host="web.ces.karlsruhe.de" />
+	<target host="fw.chs.karlsruhe.de" />
+	<target host="dienste.karlsruhe.de" />
+	<target host="edit.karlsruhe.de" />
+	<target host="edit99.karlsruhe.de" />
+	<target host="faecher.karlsruhe.de" />
+	<target host="feedback.karlsruhe.de" />
+	<target host="formulare.karlsruhe.de" />
+	<target host="geodaten.karlsruhe.de" />
+	<target host="geoportal.karlsruhe.de" />
+	<target host="grabsuche.karlsruhe.de" />
+	<target host="gruenestadt.karlsruhe.de" />
+	<target host="guide.karlsruhe.de" />
+	<target host="heimstiftung.karlsruhe.de" />
+	<target host="hhs.karlsruhe.de" />
+	<target host="www.hhs.karlsruhe.de" />
+	<target host="beta.hhs.karlsruhe.de" />
+	<target host="filr.hhs.karlsruhe.de" />
+	<target host="gazoo.hhs.karlsruhe.de" />
+	<target host="groupwise.hhs.karlsruhe.de" />
+	<target host="moodle.hhs.karlsruhe.de" />
+	<target host="moodlex.hhs.karlsruhe.de" />
+	<target host="moodle.hms.karlsruhe.de" />
+	<target host="mail1.huebsch.karlsruhe.de" />
+	<target host="kalender.karlsruhe.de" />
+	<target host="kammermusikwettbewerb.karlsruhe.de" />
+	<target host="kita.karlsruhe.de" />
+	<target host="autodiscover.kvv.karlsruhe.de" />
+	<target host="lernfabrik.karlsruhe.de" />
+	<target host="www.lernfabrik.karlsruhe.de" />
+	<target host="m.karlsruhe.de" />
+	<target host="matrix-seg.karlsruhe.de" />
+	<target host="www.mgg.karlsruhe.de" />
+	<target host="owncloud.mgg.karlsruhe.de" />
+	<target host="mobil.karlsruhe.de" />
+	<target host="nubnetzwerk.karlsruhe.de" />
+	<target host="opac.karlsruhe.de" />
+	<target host="otv.karlsruhe.de" />
+	<target host="partnerschaftsboerse-eine-welt.karlsruhe.de" />
+	<target host="presse.karlsruhe.de" />
+	<target host="rhin.karlsruhe.de" />
+	<target host="staatstheatertickets.karlsruhe.de" />
+	<target host="transparenz.karlsruhe.de" />
+	<target host="autodiscover.vbk.karlsruhe.de" />
+	<target host="vmz.karlsruhe.de" />
+	<target host="vps.karlsruhe.de" />
+	<target host="web1.karlsruhe.de" />
+	<target host="web3.karlsruhe.de" />
+	<target host="wes.karlsruhe.de" />
+	<target host="wolke.karlsruhe.de" />
+	<target host="www1.karlsruhe.de" />
+	<target host="www99.karlsruhe.de" />
+
+	<securecookie host=".+" name=".+" />
+
+	<rule from="^http:" to="https:" />
+
+</ruleset>


### PR DESCRIPTION
This PR is inspired by the moment when the script failed to work on Arch Linux.

Little enhancements were made:

- Comments specify which distro is the command related
- Output of `type` command doesn't appears  for user (either in success or fail)
- If any of install commands doesn't work (`apt`, `dnf`, ...), it displays an warning message

Thanks!