### PR TITLE
Enable Rettighedsalliancen.dk and simplify rule

### DIFF
--- a/src/chrome/content/rules/Rettighedsalliancen.dk.xml
+++ b/src/chrome/content/rules/Rettighedsalliancen.dk.xml
@@ -1,20 +1,9 @@
-
-<!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://rettighedsalliancen.dk/ => https://www.rettighedsalliancen.dk/: (60, 'SSL certificate problem: self signed certificate')
-Fetch error: http://www.rettighedsalliancen.dk/ => https://www.rettighedsalliancen.dk/: (60, 'SSL certificate problem: self signed certificate')
-
-	Some style sheet and script references are 
-	hard coded to be fetched over http, which
-	causes 	design breaking in mixed content
-	blocking browsers.
--->
-<ruleset name="Rettighedsalliancen.dk (mixed content)" platform="mixedcontent" default_off='failed ruleset test'>
+<ruleset name="Rettighedsalliancen.dk">
 
 	<target host="rettighedsalliancen.dk" />
 	<target host="www.rettighedsalliancen.dk" />
 
-	<rule from="^http://(www\.)?rettighedsalliancen\.dk/"
-		to="https://www.rettighedsalliancen.dk/" />
+	<rule from="^http:"
+		to="https:" />
 
 </ruleset>


### PR DESCRIPTION
Rettighedsalliancen.dk is now available over HTTPS with no errors or mixed content