### PR TITLE
Add question mark for disable prompt

### DIFF
--- a/chromium/pages/cancel/ux.js
+++ b/chromium/pages/cancel/ux.js
@@ -30,7 +30,7 @@ function displayURL() {
   originURLLink.innerText = originURL;
 
   originURLLink.addEventListener("click", function() {
-    if (confirm(chrome.i18n.getMessage("chrome_disable_on_this_site"))) {
+    if (confirm(chrome.i18n.getMessage("chrome_disable_on_this_site") + '?')) {
       const url = new URL(originURL);
       sendMessage("disable_on_site", url.host, () => {
         window.location = originURL;


### PR DESCRIPTION
When user clicks URL on interstitial, they get a statement
that seems more like a command, than an option.

Note: This is not the ideal solution, but provides a better user
indicator until we revisit the UI for un-encrypted requests.