### PR TITLE
BBCI.co.uk

### DIFF
--- a/src/chrome/content/rules/bbci.co.uk.xml
+++ b/src/chrome/content/rules/bbci.co.uk.xml
@@ -5,35 +5,345 @@
 	Note: platform is for not increasing
 	non-Tor distinguishability.
 
+	Cert expired:
+		- public.broker.newsbeat.news.api.bbci.co.uk
+		- ws-downloads.test.files.bbci.co.uk
+		- emp.live.bbci.co.uk
+		- smp.live.bbci.co.uk
+		- smp.bbci.co.uk
+		- smp.stage.bbci.co.uk
+		- ptk-planning.int.08f5f640f8bc7f58.xhst.bbci.co.uk
+		- ptk-ideas.int.08f5f640f8bc7f58.xhst.bbci.co.uk
+		- ptk-talent.int.08f5f640f8bc7f58.xhst.bbci.co.uk
+		- smp-stage.1a91796ffe900239.xhst.bbci.co.uk
+		- dmkarcade.stage.88f7f3063155d2b9.xhst.bbci.co.uk
+		- smp-live.e9645da448e0c4fd.xhst.bbci.co.uk
 
-	Mixed content:
+	Chain issues:
+		- int.api.bbci.co.uk
+		- eddie.api.bbci.co.uk
+		- navigation.api.bbci.co.uk
+		- newsrig.api.bbci.co.uk
+		- sawmill.api.bbci.co.uk
+		- test.api.bbci.co.uk
+		- termsmatcher.test.api.bbci.co.uk
+		- navigation.test.12cb080e2ed825d1.xhst.bbci.co.uk
+		- www.toolshed.20a521c60ef63921.xhst.bbci.co.uk
+		- fbd-status.test.3e13ed67c7a4a2a7.xhst.bbci.co.uk
+		- music-clip-dashboard.4f1c27d5446dd563.xhst.bbci.co.uk
+		- bbcthree-web-server.4fcbc952736b6869.xhst.bbci.co.uk
+		- res-bbcsfx.live.66ca84950f5177d0.xhst.bbci.co.uk
+		- marooned.test.68e997ad0bd896f7.xhst.bbci.co.uk
+		- mt-imagechef.test.68e997ad0bd896f7.xhst.bbci.co.uk
+		- venue-explorer-live.8555a8c0fdec99c9.xhst.bbci.co.uk
+		- venue-explorer-r2-live.8555a8c0fdec99c9.xhst.bbci.co.uk
+		- navigation.90fe2324ce3eb149.xhst.bbci.co.uk
+		- music-clip-dashboard.test.a4fe5a1b8af97dd3.xhst.bbci.co.uk
+		- dashboards.bb31241ec649ec88.xhst.bbci.co.uk
+		- ugc-curation.test.c7dff5ab13c48206.xhst.bbci.co.uk
+		- ugc-curation.int.c7dff5ab13c48206.xhst.bbci.co.uk
+		- www-eu-west-1.mozart-routing.da1817b281b16742.xhst.bbci.co.uk
+		- ws-messenger-bot.int.ee74d3541ebec4a3.xhst.bbci.co.uk
+		- ws-messenger-bot.test.ee74d3541ebec4a3.xhst.bbci.co.uk
+		- ws-messenger-bot.ee74d3541ebec4a3.xhst.bbci.co.uk
+		- fbd-status.f232431b92c1c6e9.xhst.bbci.co.uk
+		- introducing-service.int.f28ec3debf109f28.xhst.bbci.co.uk
+		- introducing-service-internal.test.f28ec3debf109f28.xhst.bbci.co.uk
 
-		- Image on feeds from news.bbcimg.co.uk
+	Connection refused:
+		- a11yadmin.fdf75a6b0caaeba5.xhst.bbci.co.uk
+
+	Timeout:
+		- bbci.co.uk
+		- www.bbci.co.uk
+		- amanita.api.bbci.co.uk
+		- push-handshaker.api.bbci.co.uk
+		- a-ssl.files.bbci.co.uk
+		- bam.files.bbci.co.uk
+		- c.files.bbci.co.uk
+		- mybbc.test.files.bbci.co.uk
+		- r.stage.bbci.co.uk
+		- irfs-atomized-news-web-server-int.b07db82418431317.xhst.bbci.co.uk
+		- irfs-atomized-news-web-server-live.b07db82418431317.xhst.bbci.co.uk
+		- push-handshaker.5f5007da7cab9df2.xhst.bbci.co.uk
+
+	TLS handshake failure:
+
+		- connected-tv-service-matterhorn.test.api.bbci.co.uk
+		- connected-tv-service-matterhorn.api.bbci.co.uk
+		- radio-nav-service.api.bbci.co.uk
+		- wormhole.api.bbci.co.uk
+		- ptk-continuity.int.08f5f640f8bc7f58.xhst.bbci.co.uk
+		- ptk-ideas.test.08f5f640f8bc7f58.xhst.bbci.co.uk
+		- eavis-admin.2a239b108769940a.xhst.bbci.co.uk
+		- music-tupac-production.4f1c27d5446dd563.xhst.bbci.co.uk
+		- fbd-playout-view-gnl.6d0fbb0b8c1310b0.xhst.bbci.co.uk
+		- eavis-admin.int.b893206ae42b8e81.xhst.bbci.co.uk
+		- eavis-admin.test.b893206ae42b8e81.xhst.bbci.co.uk
+		- music-tupac-production.int.a4fe5a1b8af97dd3.xhst.bbci.co.uk
+		- music-tupac-production.test.a4fe5a1b8af97dd3.xhst.bbci.co.uk
+		- irfs-google-home-vivo-web-server-int.b07db82418431317.xhst.bbci.co.uk
+		- registrar.notifications.int.d33b6bf046809c92.xhst.bbci.co.uk
+		- registrar.notifications.test.d33b6bf046809c92.xhst.bbci.co.uk
+		- ptk-ideas.e42945d874b7f660.xhst.bbci.co.uk
+		- ptk-continuity.e42945d874b7f660.xhst.bbci.co.uk
+		- ptk-planning.e42945d874b7f660.xhst.bbci.co.uk
+		- ptk-talent.e42945d874b7f660.xhst.bbci.co.uk
+		- fbd-playout-view.f232431b92c1c6e9.xhst.bbci.co.uk
+
+
+
+	Cert mismatch:
+		- radio-service-information.api.bbci.co.uk
+		- push2.api.bbci.co.uk
+		- radio-service-information.test.api.bbci.co.uk
+		- touchcast.files.bbci.co.uk
+		- ess.live.0757de8f8fce7a23.xhst.bbci.co.uk
+		- simorgh.live.034dc2ac1e64e95d.xhst.bbci.co.uk
+		- ptk-acquisition.test.08f5f640f8bc7f58.xhst.bbci.co.uk
+		- ptk-compliance.test.08f5f640f8bc7f58.xhst.bbci.co.uk
+		- int-ejbca.0c6408661b29db05.xhst.bbci.co.uk
+		- test-ejbca.0c6408661b29db05.xhst.bbci.co.uk
+		- cd-megavolt.int.12cb080e2ed825d1.xhst.bbci.co.uk
+		- cd-megavolt.test.12cb080e2ed825d1.xhst.bbci.co.uk
+		- navpromo.test.12cb080e2ed825d1.xhst.bbci.co.uk
+		- uas-a127-apiman.live.24ca1eb415514906.xhst.bbci.co.uk
+		- ssc.live.3925c5b702a8aaca.xhst.bbci.co.uk
+		- bouncer.int.279bdcc0037b028a.xhst.bbci.co.uk
+		- bouncer.test.279bdcc0037b028a.xhst.bbci.co.uk
+		- ejbca.295fa644f47ffb52.xhst.bbci.co.uk
+		- telescope.520da5f02a3996ab.xhst.bbci.co.uk
+		- scv-tableau.int.3665e16f12cd9093.xhst.bbci.co.uk
+		- redbutton.40860ee4b46a057d.xhst.bbci.co.uk
+		- director.520da5f02a3996ab.xhst.bbci.co.uk
+		- telescope-beta.520da5f02a3996ab.xhst.bbci.co.uk
+		- weather-warnings-publish.54837d50f4ec2005.xhst.bbci.co.uk
+		- ocsp-test.5ec420ad531f7a99.xhst.bbci.co.uk
+		- taster-analytics-dashboard.6713fd36e31e9cf3.xhst.bbci.co.uk
+		- taster-analytics-dashboard.test.6713fd36e31e9cf3.xhst.bbci.co.uk
+		- navpromo.90fe2324ce3eb149.xhst.bbci.co.uk
+		- component.iplayer.82849e5993825384.xhst.bbci.co.uk
+		- dmkarcade.88f7f3063155d2b9.xhst.bbci.co.uk
+		- cd-megavolt.90fe2324ce3eb149.xhst.bbci.co.uk
+		- newton.test.a86f587b6ef86000.xhst.bbci.co.uk
+		- einstein.a9193e8608fd0153.xhst.bbci.co.uk
+		- newton.a9193e8608fd0153.xhst.bbci.co.uk
+		- introducing.live.abccc994c251444d.xhst.bbci.co.uk
+		- introducing-service.live.abccc994c251444d.xhst.bbci.co.uk
+		- upload.rd.live.abf2f65fcdb6839e.xhst.bbci.co.uk
+		- kitchen.rd.abf2f65fcdb6839e.xhst.bbci.co.uk
+		- idcta-origin.int.id.b77ff526efa260da.xhst.bbci.co.uk
+		- idcta-origin.stage.id.b77ff526efa260da.xhst.bbci.co.uk
+		- idcta.test.id.b77ff526efa260da.xhst.bbci.co.uk
+		- account.id.int.b77ff526efa260da.xhst.bbci.co.uk
+		- profile.id.int.b77ff526efa260da.xhst.bbci.co.uk
+		- session.id.int.b77ff526efa260da.xhst.bbci.co.uk
+		- account.id.stage.b77ff526efa260da.xhst.bbci.co.uk
+		- profile.id.stage.b77ff526efa260da.xhst.bbci.co.uk
+		- session.id.stage.b77ff526efa260da.xhst.bbci.co.uk
+		- account.id.test.b77ff526efa260da.xhst.bbci.co.uk
+		- profile.id.test.b77ff526efa260da.xhst.bbci.co.uk
+		- session.id.test.b77ff526efa260da.xhst.bbci.co.uk
+		- bouncer.b9e101f453e4b64e.xhst.bbci.co.uk
+		- account.id.c121be2a55e13acd.xhst.bbci.co.uk
+		- idcta.id.c121be2a55e13acd.xhst.bbci.co.uk
+		- profile.id.c121be2a55e13acd.xhst.bbci.co.uk
+		- session.id.c121be2a55e13acd.xhst.bbci.co.uk
+		- scv-tableau.live.d56942cc57261a3e.xhst.bbci.co.uk
+		- redbutton.int.da32a38ddb2ddaf5.xhst.bbci.co.uk
+		- redbutton.test.da32a38ddb2ddaf5.xhst.bbci.co.uk
+		- ptk-acquisition.e42945d874b7f660.xhst.bbci.co.uk
+		- www.bbc.com.europe-central-1.live-live.gtm-edge.e9fb45cfcc47b85b.xhst.bbci.co.uk
+		- ptk-compliance.e42945d874b7f660.xhst.bbci.co.uk
+		- search-a127.alb.ea3a988d37b461e8.xhst.bbci.co.uk
+		- ws-messenger-bot-webhook.int.ee74d3541ebec4a3.xhst.bbci.co.uk
+		- ws-messenger-bot-webhook.test.ee74d3541ebec4a3.xhst.bbci.co.uk
+		- ws-messenger-bot-webhook.ee74d3541ebec4a3.xhst.bbci.co.uk
+		- edibl.f7f1036195026b0a.xhst.bbci.co.uk
+		- introducing.int.f28ec3debf109f28.xhst.bbci.co.uk
+		- introducing.test.f28ec3debf109f28.xhst.bbci.co.uk
+		- branding.f7a721cd26cdddcd.xhst.bbci.co.uk
 
 -->
 <ruleset name="BBCi.co.uk (partial)" platform="mixedcontent">
 
-	<target host="emp.bbci.co.uk" />
-	<target host="feeds.bbci.co.uk" />
+	<target host="acme-bridge.api.bbci.co.uk"/>
+	<target host="homepage-mobile-app-config.api.bbci.co.uk"/>
+	<target host="catal-support.api.bbci.co.uk"/>
+	<target host="buzz-app.api.bbci.co.uk"/>
+	<target host="childrens-data.api.bbci.co.uk"/>
+	<target host="camino-broker-cdn.api.bbci.co.uk"/>
+	<target host="ess.api.bbci.co.uk"/>
+	<target host="ibl.api.bbci.co.uk"/>
+	<target host="camino-broker.api.bbci.co.uk"/>
+	<target host="buzz-app.int.api.bbci.co.uk"/>
+	<target host="catal-support.int.api.bbci.co.uk"/>
+	<target host="einstein.api.bbci.co.uk"/>
+	<target host="blue-peter-card-retrieval.int.api.bbci.co.uk"/>
+	<target host="blue-peter-card-submission.int.api.bbci.co.uk"/>
+	<target host="ess.int.api.bbci.co.uk"/>
+	<target host="locator-service.int.api.bbci.co.uk"/>
+	<target host="push.int.api.bbci.co.uk"/>
+	<target host="locator-service.api.bbci.co.uk"/>
+	<target host="media-availability.int.api.bbci.co.uk"/>
+	<target host="search-suggest.int.api.bbci.co.uk"/>
+	<target host="sport-store.int.api.bbci.co.uk"/>
+	<target host="search.int.api.bbci.co.uk"/>
+	<target host="nitro-a127-gateway-mutual-ssl.int.api.bbci.co.uk"/>
+	<target host="toggles.int.api.bbci.co.uk"/>
+	<target host="media-syndication.int.api.bbci.co.uk"/>
+	<target host="sport-store-ingest.int.api.bbci.co.uk"/>
+	<target host="navpromo.api.bbci.co.uk"/>
+	<target host="media-availability.api.bbci.co.uk"/>
+	<target host="media-syndication.api.bbci.co.uk"/>
+	<target host="nitro.api.bbci.co.uk"/>
+	<target host="nitro-e2e.api.bbci.co.uk"/>
+	<target host="philippa-producer.api.bbci.co.uk"/>
+	<target host="philippa-producer-cdn.api.bbci.co.uk"/>
+	<target host="nitro-a127-gateway-mutual-ssl.api.bbci.co.uk"/>
+	<target host="philippa-resolver.api.bbci.co.uk"/>
+	<target host="push.api.bbci.co.uk"/>
+	<target host="newton.api.bbci.co.uk"/>
+	<target host="philippa-resolver-cdn.api.bbci.co.uk"/>
+	<target host="search-query.api.bbci.co.uk"/>
+	<target host="search.api.bbci.co.uk"/>
+	<target host="search-suggest.api.bbci.co.uk"/>
+	<target host="partner.sawmill.api.bbci.co.uk"/>
+	<target host="simorgh.api.bbci.co.uk"/>
+	<target host="sla.api.bbci.co.uk"/>
+	<target host="buzz-app.stage.api.bbci.co.uk"/>
+	<target host="acme-bridge.test.api.bbci.co.uk"/>
+	<target host="sport-store.api.bbci.co.uk"/>
+	<target host="sport-store-ingest.api.bbci.co.uk"/>
+	<target host="catal-support.test.api.bbci.co.uk"/>
+	<target host="taster-pilots.api.bbci.co.uk"/>
+	<target host="blue-peter-card-submission.test.api.bbci.co.uk"/>
+	<target host="blue-peter-card-retrieval.test.api.bbci.co.uk"/>
+	<target host="fetch.test.api.bbci.co.uk"/>
+	<target host="ess.test.api.bbci.co.uk"/>
+	<target host="ibl.test.api.bbci.co.uk"/>
+	<target host="camino-broker.test.api.bbci.co.uk"/>
+	<target host="locator-service.test.api.bbci.co.uk"/>
+	<target host="media-availability.test.api.bbci.co.uk"/>
+	<target host="navpromo.test.api.bbci.co.uk"/>
+	<target host="media-syndication.test.api.bbci.co.uk"/>
+	<target host="search.test.api.bbci.co.uk"/>
+	<target host="philippa-producer.test.api.bbci.co.uk"/>
+	<target host="newton.test.api.bbci.co.uk"/>
+	<target host="push.test.api.bbci.co.uk"/>
+	<target host="philippa-resolver.test.api.bbci.co.uk"/>
+	<target host="search-query.test.api.bbci.co.uk"/>
+	<target host="nitro-a127-gateway-mutual-ssl.test.api.bbci.co.uk"/>
+	<target host="toggles.test.api.bbci.co.uk"/>
+	<target host="sport-store.test.api.bbci.co.uk"/>
+	<target host="trevor-resolver.test.api.bbci.co.uk"/>
+	<target host="trevor-producer.test.api.bbci.co.uk"/>
+	<target host="walter-producer.test.api.bbci.co.uk"/>
+	<target host="sport-store-ingest.test.api.bbci.co.uk"/>
+	<target host="simorgh.test.api.bbci.co.uk"/>
+	<target host="walter-resolver.test.api.bbci.co.uk"/>
+	<target host="weather-broker.test.api.bbci.co.uk"/>
+	<target host="weather-broker-cdn.test.api.bbci.co.uk"/>
+	<target host="trevor-producer-cdn.api.bbci.co.uk"/>
+	<target host="trevor-resolver.api.bbci.co.uk"/>
+	<target host="trevor-producer.api.bbci.co.uk"/>
+	<target host="walter-resolver.api.bbci.co.uk"/>
+	<target host="walter-producer-cdn.api.bbci.co.uk"/>
+	<target host="weather-warnings-publish.api.bbci.co.uk"/>
+	<target host="walter-producer.api.bbci.co.uk"/>
+	<target host="weather-broker-cdn.api.bbci.co.uk"/>
+	<target host="weather-broker.api.bbci.co.uk"/>
+	<target host="emp.bbci.co.uk"/>
+	<target host="a.files.bbci.co.uk"/>
+	<target host="downloads.bbci.co.uk"/>
+	<target host="feeds.bbci.co.uk"/>
+	<target host="trevor-resolver-cdn.api.bbci.co.uk"/>
+	<target host="academy.files.bbci.co.uk"/>
+	<target host="account-wrapper.files.bbci.co.uk"/>
+	<target host="applinks.files.bbci.co.uk"/>
+	<target host="bbcthree-web-cdn.files.bbci.co.uk"/>
+	<target host="bitesize.files.bbci.co.uk"/>
+	<target host="branding.files.bbci.co.uk"/>
+	<target host="buzz-config.files.bbci.co.uk"/>
+	<target host="childrens-web.files.bbci.co.uk"/>
+	<target host="childrens-binary.files.bbci.co.uk"/>
+	<target host="buzz-editorial.files.bbci.co.uk"/>
+	<target host="connected-tv.files.bbci.co.uk"/>
+	<target host="equation-chef.files.bbci.co.uk"/>
+	<target host="food.files.bbci.co.uk"/>
+	<target host="fxt.files.bbci.co.uk"/>
+	<target host="food-images.files.bbci.co.uk"/>
+	<target host="guides.files.bbci.co.uk"/>
+	<target host="gel.files.bbci.co.uk"/>
+	<target host="homepage.files.bbci.co.uk"/>
+	<target host="ownit-assets.int.files.bbci.co.uk"/>
+	<target host="introducing.files.bbci.co.uk"/>
+	<target host="iplayer-mobile-appconfig.files.bbci.co.uk"/>
+	<target host="iplayer-radio-mobile-appconfig.files.bbci.co.uk"/>
+	<target host="iplayer-web.files.bbci.co.uk"/>
+	<target host="kandl-timelines.files.bbci.co.uk"/>
+	<target host="kandl-genres.files.bbci.co.uk"/>
+	<target host="m.files.bbci.co.uk"/>
+	<target host="map-remote-config.files.bbci.co.uk"/>
+	<target host="monitoring.files.bbci.co.uk"/>
+	<target host="music-audio.files.bbci.co.uk"/>
+	<target host="music.files.bbci.co.uk"/>
+	<target host="nav.files.bbci.co.uk"/>
+	<target host="mybbc-analytics.files.bbci.co.uk"/>
+	<target host="news.files.bbci.co.uk"/>
+	<target host="music-events.files.bbci.co.uk"/>
+	<target host="mybbc.files.bbci.co.uk"/>
+	<target host="ranked-list-images.files.bbci.co.uk"/>
+	<target host="notifications.files.bbci.co.uk"/>
+	<target host="podcasts.files.bbci.co.uk"/>
+	<target host="programmes.files.bbci.co.uk"/>
+	<target host="rdux.files.bbci.co.uk"/>
+	<target host="rmp.files.bbci.co.uk"/>
+	<target host="search.files.bbci.co.uk"/>
+	<target host="buzz-config.stage.files.bbci.co.uk"/>
+	<target host="ychef.stage.files.bbci.co.uk"/>
+	<target host="downloads.taster.files.bbci.co.uk"/>
+	<target host="team-picker.files.bbci.co.uk"/>
+	<target host="news.test.files.bbci.co.uk"/>
+	<target host="ranked-list-images.test.files.bbci.co.uk"/>
+	<target host="team-picker.test.files.bbci.co.uk"/>
+	<target host="ychef.test.files.bbci.co.uk"/>
+	<target host="toybox-assets.files.bbci.co.uk"/>
+	<target host="travel.files.bbci.co.uk"/>
+	<target host="weather-tiles.files.bbci.co.uk"/>
+	<target host="weather.files.bbci.co.uk"/>
+	<target host="weather-tiles-basemap.files.bbci.co.uk"/>
+	<target host="weatherwatchers.files.bbci.co.uk"/>
+	<target host="ws-downloads.files.bbci.co.uk"/>
+	<target host="ychef.files.bbci.co.uk"/>
+	<target host="ichef.bbci.co.uk"/>
+	<target host="ichef-1.bbci.co.uk"/>
+	<target host="ichef-notifications.bbci.co.uk"/>
+	<target host="open.int.bbci.co.uk"/>
+	<target host="ichef.int.bbci.co.uk"/>
+	<target host="static.int.bbci.co.uk"/>
+	<target host="ichef.live.bbci.co.uk"/>
+	<target host="open.bbci.co.uk"/>
+	<target host="r.bbci.co.uk"/>
+	<target host="emp.stage.bbci.co.uk"/>
+	<target host="feeds.stage.bbci.co.uk"/>
+	<target host="ichef-1.stage.bbci.co.uk"/>
+	<target host="ichef.stage.bbci.co.uk"/>
+	<target host="open.stage.bbci.co.uk"/>
+	<target host="static.stage.bbci.co.uk"/>
+	<target host="static.bbci.co.uk"/>
+	<target host="emp.test.bbci.co.uk"/>
+	<target host="r.test.bbci.co.uk"/>
+	<target host="open.test.bbci.co.uk"/>
+	<target host="ichef.test.bbci.co.uk"/>
+	<target host="static.test.bbci.co.uk"/>
 
-	<target host="a-ssl.files.bbci.co.uk" />
-	<target host="c.files.bbci.co.uk" />
-	<target host="homepage.files.bbci.co.uk" />
-	<target host="m.files.bbci.co.uk" />
-	<target host="mybbc.files.bbci.co.uk" />
-	<target host="nav.files.bbci.co.uk" />
-	<target host="travel.files.bbci.co.uk" />
+	<securecookie host=".+" name=".+" />
 
-	<target host="ichef.bbci.co.uk" />
-	<target host="ichef-1.bbci.co.uk" />
-	<target host="open.bbci.co.uk" />
-	<target host="static.bbci.co.uk" />
+	<rule from="^http:"
+		to="https:" />
 
-		<!--    Avoid potential XHR or flash policy problems:
-									-->
-		<exclusion pattern="^http:/(?!.+\.(?:bmp|css|gifv?|ico|jpe?g|pdf|png|svg|tiff?|ttf|woff)(?:$|\?))" />
-
-			<!--	+ve:
+				<!--	+ve:
 					-->
 			<test url="http://emp.bbci.co.uk/emp/SMPf/1.16.3/StandardMediaPlayerChromelessFlash.swf" />
 			<test url="http://feeds.bbci.co.uk/news/rss.xml" />
@@ -48,8 +358,6 @@
 			<test url="http://static.bbci.co.uk/frameworks/requirejs/0.13.1/sharedmodules/require.js" />
 			<test url="http://static.bbci.co.uk/ws/js/vendor/site_catalyst/s_code_bbcws.js" />
 
-		<test url="http://c.files.bbci.co.uk/F681/production/_89650136_0505villarricavolcano-chile-reuters.jpg" />
-		<test url="http://c.files.bbci.co.uk/F681/production/_89650136_0505villarricavolcano-chile-reuters.jpg" />
 		<test url="http://homepage.files.bbci.co.uk/s/homepage-v5/2164/images/right-arrow--grey.svg" />
 		<test url="http://m.files.bbci.co.uk/releases/1141/libs/bbc-grandstand/dist/core.css" />
 		<test url="http://mybbc.files.bbci.co.uk/s/notification-ui/1.4.2/css/main.min.css" />
@@ -60,12 +368,4 @@
 		<test url="http://travel.files.bbci.co.uk/travel-ui/335/img/search/sprites/locservices_ui_x1.png" />
 
 		<test url="http://static.bbci.co.uk/modules/twitter/0.2.4/img/trans.gif" />
-
-
-	<securecookie host="^\w" name=".+" />
-
-
-	<rule from="^http:"
-		to="https:" />
-
 </ruleset>


### PR DESCRIPTION
This will rewrite all subdomains to TLS that do not redirect to plain.
We need to check for fallout since the TLS migration on the BBC isn't 100% completed yet