### PR TITLE
Show only rulesets which performed an upgrade

### DIFF
--- a/chromium/background-scripts/background.js
+++ b/chromium/background-scripts/background.js
@@ -406,10 +406,11 @@ function onBeforeRequest(details) {
   let newuristr = null;
 
   for (let ruleset of potentiallyApplicable) {
-    if (details.url.match(ruleset.scope)) {
-      appliedRulesets.addRulesetToTab(details.tabId, details.type, ruleset);
-      if (ruleset.active && !newuristr) {
-        newuristr = ruleset.apply(uri.href);
+    if (ruleset.active && details.url.match(ruleset.scope)) {
+      newuristr = ruleset.apply(uri.href);
+      if (newuristr !== null) {
+        appliedRulesets.addRulesetToTab(details.tabId, details.type, ruleset);
+        break;
       }
     }
   }


### PR DESCRIPTION
As a side effect of #17010, the popup no longer shows rulesets which do not perform any upgrade on HTTPS pages, this PR makes it the default behavior on HTTP pages as well. It also introduce room for performance improvement like #16951.

There was concerns that users might need granular control of all the ruleset states to avoid site breakages, but #16546 is merged so I guess this is less likely an issue. 

A controversial side effect could be the fact that `default_off` rulesets will not be visible anymore. That's why I have closed #16951 before #17010 emerged. 

cc @Hainish @jsha @zoracon @Bisaloo @J0WI @jeremyn for opinions