### PR TITLE
Add 179.ru

### DIFF
--- a/src/chrome/content/rules/179.ru.xml
+++ b/src/chrome/content/rules/179.ru.xml
@@ -35,7 +35,7 @@
 	<exclusion
 		pattern="^http://(bak|monitor|sbory|support|t3|wiki)\.179\.ru/.+$" />
 	<rule from="^http://(bak|monitor|sbory|support|t3|wiki)\.179\.ru/$"
-		to="https://server.179.ru/wiki" />
+		to="https://server.179.ru/wiki/" />
 
 	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/179.ru.xml
+++ b/src/chrome/content/rules/179.ru.xml
@@ -1,0 +1,33 @@
+<!--
+	HTTPS broken:
+		2011.179.ru
+		bak.179.ru
+		biobase.179.ru
+		monitor.179.ru
+		sbory.179.ru
+		support.179.ru
+		t3.179.ru
+		v2017-b2.179.ru
+		vezdehod.179.ru
+		wiki.179.ru
+
+	Mixed content:
+		2013.179.ru
+-->
+<ruleset name="179.ru">
+	<target host="179.ru" />
+	<target host="www.179.ru" />
+	<target host="2012.179.ru" />
+	<target host="2015.179.ru" />
+	<target host="dop.179.ru" />
+	<target host="moodle.179.ru" />
+	<target host="open.179.ru" />
+	<target host="server.179.ru" />
+
+	<securecookie host=".+" name=".+" />
+
+	<rule from="^http://(bak|monitor|sbory|support|t3|wiki)\.179\.ru/.*$"
+		to="https://server.179.ru/wiki" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/179.ru.xml
+++ b/src/chrome/content/rules/179.ru.xml
@@ -19,10 +19,16 @@
 	<target host="www.179.ru" />
 	<target host="2012.179.ru" />
 	<target host="2015.179.ru" />
+	<target host="bak.179.ru" />
 	<target host="dop.179.ru" />
+	<target host="monitor.179.ru" />
 	<target host="moodle.179.ru" />
 	<target host="open.179.ru" />
+	<target host="sbory.179.ru" />
 	<target host="server.179.ru" />
+	<target host="support.179.ru" />
+	<target host="t3.179.ru" />
+	<target host="wiki.179.ru" />
 
 	<securecookie host=".+" name=".+" />
 

--- a/src/chrome/content/rules/179.ru.xml
+++ b/src/chrome/content/rules/179.ru.xml
@@ -1,41 +1,35 @@
 <!--
 	HTTPS broken:
 		2011.179.ru
-		bak.179.ru
 		biobase.179.ru
+		v2017-b2.179.ru
+		vezdehod.179.ru
+
+	Mixed content:
+		2013.179.ru
+
+	There are a few domain names whose only purpose appears to be a redirect.
+	For example, http://wiki.179.ru/ redirects to https://server.179.ru/wiki/.
+	For those domain names, HTTPS does not work;
+	but non-root URLs like http://wiki.179.ru/foo simply give an error.
+		bak.179.ru
 		monitor.179.ru
 		sbory.179.ru
 		support.179.ru
 		t3.179.ru
-		v2017-b2.179.ru
-		vezdehod.179.ru
 		wiki.179.ru
-
-	Mixed content:
-		2013.179.ru
 -->
 <ruleset name="179.ru">
 	<target host="179.ru" />
 	<target host="www.179.ru" />
 	<target host="2012.179.ru" />
 	<target host="2015.179.ru" />
-	<target host="bak.179.ru" />
 	<target host="dop.179.ru" />
-	<target host="monitor.179.ru" />
 	<target host="moodle.179.ru" />
 	<target host="open.179.ru" />
-	<target host="sbory.179.ru" />
 	<target host="server.179.ru" />
-	<target host="support.179.ru" />
-	<target host="t3.179.ru" />
-	<target host="wiki.179.ru" />
 
 	<securecookie host=".+" name=".+" />
-
-	<exclusion
-		pattern="^http://(bak|monitor|sbory|support|t3|wiki)\.179\.ru/.+$" />
-	<rule from="^http://(bak|monitor|sbory|support|t3|wiki)\.179\.ru/$"
-		to="https://server.179.ru/wiki/" />
 
 	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/179.ru.xml
+++ b/src/chrome/content/rules/179.ru.xml
@@ -26,7 +26,9 @@
 
 	<securecookie host=".+" name=".+" />
 
-	<rule from="^http://(bak|monitor|sbory|support|t3|wiki)\.179\.ru/.*$"
+	<exclusion
+		pattern="^http://(bak|monitor|sbory|support|t3|wiki)\.179\.ru/.+$" />
+	<rule from="^http://(bak|monitor|sbory|support|t3|wiki)\.179\.ru/$"
 		to="https://server.179.ru/wiki" />
 
 	<rule from="^http:" to="https:" />


### PR DESCRIPTION
There are a few domain names whose only purpose appears to be a redirect. For example, <http://wiki.179.ru/> redirects to <https://server.179.ru/wiki/>. For those domain names, HTTPS does not work; but non-root URLs like <http://wiki.179.ru/foo> simply give an error. I tried to express that using the exclusion.