### PR TITLE
Use latest stable node in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ matrix:
         - "node"
     - env: TEST="unittests"
       language: node_js
-      node_js: 9
+      node_js:
+        - "node"
     - env: TEST="validations"
     - env: TEST="fetch"
     - env: TEST="preloaded"

--- a/chromium/package.json
+++ b/chromium/package.json
@@ -12,7 +12,7 @@
     "fetch-mock": "^6.3.0",
     "mocha": "^4.1.0",
     "nan": "^2.10.0",
-    "node-webcrypto-ossl": "^1.0.36",
+    "node-webcrypto-ossl": "^1.0.37",
     "nyc": "^11.6.0",
     "sinon": "^4.4.8",
     "sinon-chrome": "^2.3.1",


### PR DESCRIPTION
node-webcrypto-ossl [v1.0.37+](https://github.com/PeculiarVentures/node-webcrypto-ossl/releases/tag/v1.0.37) support OpenSSL version used in NodeJS v10/v11


ref: https://github.com/EFForg/https-everywhere/pull/15254 https://github.com/EFForg/https-everywhere/issues/15253