### PR TITLE
Create ruleset: Translate House

### DIFF
--- a/src/chrome/content/rules/TranslateHouse.org.xml
+++ b/src/chrome/content/rules/TranslateHouse.org.xml
@@ -1,0 +1,15 @@
+<!--
+	Mismatch:
+		translatehouse.org
+		docs.translatehouse.org
+-->
+<ruleset name="TranslateHouse.org">
+	<target host="amagama.translatehouse.org" />
+	<target host="pootle.translatehouse.org" />
+	<target host="toolkit.translatehouse.org" />
+	<target host="virtaal.translatehouse.org" />
+
+	<securecookie host=".+" name=".+" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>


### PR DESCRIPTION
The domain `translatehouse.org` is actually GitHub Pages. The domain `docs.translatehouse.org` is actually Read the Docs.