### PR TITLE
Create ruleset: W3C Test

### DIFF
--- a/src/chrome/content/rules/W3C-Test.org.xml
+++ b/src/chrome/content/rules/W3C-Test.org.xml
@@ -1,0 +1,25 @@
+<!--
+	Mismatch:
+		www2.w3c-test.org
+	Punycode:
+		lve-6lad => élève
+		n8j6ds53lwwkrqhv28a => 天気の良い日
+	Non-Standard HTTP Port:
+		n8j6ds53lwwkrqhv28a.www2.w3c-test.org:82
+	Note:
+		Double dash not allowed in XML comment; punycode prefix removed.
+-->
+<ruleset name="W3C-test.org">
+	<target host="w3c-test.org" />
+	<target host="www.w3c-test.org" />
+	<target host="www1.w3c-test.org" />
+	<target host="www2.w3c-test.org" />
+	<target host="xn--lve-6lad.w3c-test.org" />
+	<target host="xn--n8j6ds53lwwkrqhv28a.w3c-test.org" />
+
+	<securecookie host=".+" name=".+" />
+
+	<rule from="^http://www2\.w3c-test\.org/" to="https://www.w3c-test.org/" />
+	<rule from="^http://xn--n8j6ds53lwwkrqhv28a\.w3c-test\.org:82/" to="https://xn--n8j6ds53lwwkrqhv28a.w3c-test.org/" />
+	<rule from="^http:" to="https:" />
+</ruleset>


### PR DESCRIPTION
I skipped the punycode prefix `xn--` in XML comment because it is illegal there. Punycode is not very common in the atlas; I found following examples:

https://github.com/EFForg/https-everywhere/blob/a5c787ba3422d3be9c4b9aaa3ef76ee26897da78/src/chrome/content/rules/Josefsson.org.xml#L12

https://github.com/EFForg/https-everywhere/blob/a5c787ba3422d3be9c4b9aaa3ef76ee26897da78/src/chrome/content/rules/JS.org.xml#L1784

https://github.com/EFForg/https-everywhere/blob/a5c787ba3422d3be9c4b9aaa3ef76ee26897da78/src/chrome/content/rules/xn--90aijkdmaud0d.xn--p1ai.xml#L1-L10

None of them added comment about the code.