### PR TITLE
Update PlayStation.xml

### DIFF
--- a/src/chrome/content/rules/PlayStation.xml
+++ b/src/chrome/content/rules/PlayStation.xml
@@ -27,9 +27,7 @@
 
 		- ^ (mismatched)
 		- metrics.aem ᵐ
-		- static.blog ᴬ
 		- uk ᵐ
-		- us ᴬ
 		- cdn.us ³
 		- service1.us ᵉ
 		- www.us ᵐ
@@ -78,6 +76,8 @@
 				-->
 	<target host="playstation.com" />
 	<target host="smetrics.aem.playstation.com" />
+	<target host="asia.playstation.com" />
+	<target host="static.blog.playstation.com" />
 	<target host="docs.playstation.com" />
 
 	<target host="secure.eu.playstation.com" />
@@ -85,11 +85,13 @@
 	<target host="hardware.support.eu.playstation.com" />
 
 	<target host="io.playstation.com" />
+	<target host="www.jp.playstation.com" />
 	<target host="media.playstation.com" />
 	<target host="psmedia.playstation.com" />
 	<target host="status.playstation.com" />
 	<target host="store.playstation.com" />
 
+	<target host="us.playstation.com" />
 	<target host="blog.us.playstation.com" />
 	<target host="secure.cdn.us.playstation.com" />
 	<target host="secure.us.playstation.com" />
@@ -101,73 +103,15 @@
 	<!--	Complications:
 				-->
 	<target host="metrics.aem.playstation.com" />
-	<target host="static.blog.playstation.com" />
-	<target host="us.playstation.com" />
 	<target host="cdn.us.playstation.com" />
-	<target host="www.us.playstation.com" />
 
-		<!--	Redirects to http:
-						-->
-		<!--exclusion pattern="^http://blog\.us\.playstation\.com/$" /-->
-		<!--
-			Exceptions:
-					-->
-		<exclusion pattern="^http://blog\.us\.playstation\.com/(?!/*wp-content/)" />
-
-			<!--	+ve:
-					-->
-			<test url="http://blog.us.playstation.com/comment_policy/" />
-			<test url="http://blog.us.playstation.com/tag/call-of-duty/feed/" />
-
-			<!--	-ve:
-					-->
-			<test url="http://blog.us.playstation.com/wp-content/plugins/wp-postratings/images/custom/rating_off.png" />
-
-
-	<!--	Not secured by server:
-					-->
-	<!--securecookie host="^(?:www\.)?playstation\.com$" name="^AWSELB$" /-->
-	<!--securecookie host="^\.playstation\.com$" name="^(?:APPLICATION_SITE_URL|ps_auth|ps_profile_US|s_vi)$" /-->
-	<!--securecookie host="^\.aem\.playstation\.com$" name="^s_vi$" /-->
-	<!--securecookie host="^io\.playstation\.com$" name="^(?:JSESSIONID|SONYCOOKIE)$" /-->
-	<!--securecookie host="^support\.us\.playstation\.com$" name="^Lithium(?:UserInfo|UserSecure|Visitor)$" /-->
-	<!--securecookie host="^(www\.)support\.playstation\.com$" name="^(JSESSIONID|TS[0-9a-f]{8})$" /-->
-
-	<!--securecookie host="." name="." /-->
-	<securecookie host="^\." name="^s_v" />
-	<securecookie host="^(?!blog\.us\.)\w" name=".+" />
+	<securecookie host=".+" name=".+" />
 
 	<rule from="^http://playstation\.com/"
 		to="https://www.playstation.com/" />
 
 	<rule from="^http://metrics\.aem\.playstation\.com/"
 		to="https://smetrics.aem.playstation.com/" />
-
-	<rule from="^http://static\.blog\.playstation\.com/"
-		to="https://blog.us.playstation.com/" />
-
-	<rule from="^http://(?:www\.)?us\.playstation\.com/$"
-		to="https://www.playstation.com/en-us/home/" />
-
-	<rule from="^http://(?:www\.)?us\.playstation\.com/support/?"
-		to="https://support.us.playstation.com/" />
-
-		<exclusion pattern="^http://(?:www\.)?us\.playstation\.com/(?!$|support/?(\?.*)?$)" />
-
-			<!--	+ve:
-					-->
-			<test url="http://us.playstation.com/PS3/Network/Status" />
-			<test url="http://us.playstation.com/chat" />
-			<test url="http://us.playstation.com/community/myfriends/" />
-			<test url="http://us.playstation.com/digitalupgrade/" />
-			<test url="http://us.playstation.com/registration/" />
-			<test url="http://us.playstation.com/search/" />
-			<test url="http://us.playstation.com/tunein-radio/" />
-			<test url="http://us.playstation.com/vidzone/" />
-
-			<!--	-ve:
-					-->
-			<test url="http://us.playstation.com/support/" />
 
 	<rule from="^http://cdn\.us\.playstation\.com/"
 		to="https://secure.cdn.us.playstation.com/" />


### PR DESCRIPTION
`us` works while `www.us` does not (note that `www.us` behave differently on different path, I simply removed the complicated rules) 

```bash
$ curl www.us.playstation.com/
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>301 Moved Permanently</title>
</head><body>
<h1>Moved Permanently</h1>
<p>The document has moved <a href="http://www.playstation.com/en-us/home/">here</a>.</p>
</body></html>

$ curl www.us.playstation.com/test-path/
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>301 Moved Permanently</title>
</head><body>
<h1>Moved Permanently</h1>
<p>The document has moved <a href="http://us.playstation.com/test-path/">here</a>.</p>
</body></html>

```

Also added more subdomains. 