### PR TITLE
add archive.ph

### DIFF
--- a/src/chrome/content/rules/Archive.is.xml
+++ b/src/chrome/content/rules/Archive.is.xml
@@ -18,6 +18,8 @@
 	<target host="blog.archive.is" />
 	<target host="archive.li" />
 	<target host="www.archive.li" />
+	<target host="archive.ph" />
+	<target host="www.archive.ph" />
 
 	<rule from="^http://(www\.)?archive\.is/"
 		to="https://$1archive.fo/" />


### PR DESCRIPTION
I was redirected here from another archive.is site a few days ago, and its metadata (on the website and at WHOIS) indicates that it's the same site as archive.is. (The SSL certificate became valid on `29 December 2018, 8:05:27 AM GMT`; presumably this is the first one.)