### PR TITLE
Remove Network message for unknown hosts

### DIFF
--- a/chromium/background-scripts/background.js
+++ b/chromium/background-scripts/background.js
@@ -650,7 +650,6 @@ function onErrorOccurred(details) {
       details.error.indexOf("net::ERR_CONNECTION_") == 0 ||
       details.error.indexOf("net::ERR_ABORTED") == 0 ||
       details.error.indexOf("NS_ERROR_CONNECTION_REFUSED") == 0 ||
-      details.error.indexOf("NS_ERROR_UNKNOWN_HOST") == 0 ||
       details.error.indexOf("NS_ERROR_NET_TIMEOUT") == 0 ||
       details.error.indexOf("NS_ERROR_NET_ON_TLS_HANDSHAKE_ENDED") == 0 ||
       details.error.indexOf("NS_BINDING_ABORTED") == 0 ||


### PR DESCRIPTION
This refers to #17192, where sites that don't exist get blocked by our EASE mode page.

The conclusive sentiment here on my part is that with or without EASE (BAUR) a site that doesn't exist (http or https), will pose little threat to our users. Since all major browsers provide a page explaining that the site does not exist.