### PR TITLE
Trove.com updates

### DIFF
--- a/src/chrome/content/rules/Trove.com.xml
+++ b/src/chrome/content/rules/Trove.com.xml
@@ -1,48 +1,12 @@
-
-<!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://id.trove.com/ => https://id.trove.com/: (6, 'Could not resolve host: id.trove.com')
-Fetch error: http://moneta.trove.com/ => https://moneta.trove.com/: (6, 'Could not resolve host: moneta.trove.com')
-Fetch error: http://id.trove-stg.com/ => https://id.trove-stg.com/: (6, 'Could not resolve host: id.trove-stg.com')
-
-	Other Trove rulesets:
-
-		- Social_Reader.com.xml
-
-
-	Nonfunctional domains:
-
-		- blog.trove.com *
-		- info.trove.com *
-
-	* tumblr
-
-
-	Insecure cookies are set for these domains:
-
-		- .trove.com
-
--->
-<ruleset name="Trove.com (partial)" default_off='failed ruleset test'>
-
-	<!--	Direct rewrites:
-				-->
+<ruleset name="Trove.com">
 	<target host="trove.com" />
-	<target host="id.trove.com" />
-	<target host="moneta.trove.com" />
 	<target host="www.trove.com" />
-
-	<target host="id.trove-stg.com" />
-
-
-	<!--	Not secured by server:
-					-->
-	<!--securecookie host="^\.trove\.com$" name="^(treatment|wapo_sess_id)$" /-->
-
-	<securecookie host="^(?:id)?\.trove\.com$" name=".+" />
-
+	<target host="api.trove.com" />
+	<target host="app.trove.com" />
+	<target host="blog.trove.com" />
+	<target host="help.trove.com" />
+	<target host="status.trove.com" />
 
 	<rule from="^http:"
-		to="https:" />
-
+		    to="https:" />
 </ruleset>


### PR DESCRIPTION
Updating config due to new domain ownership

I have no control over the `socialreader.com` site, but the trove.com redirects in `src/chrome/content/rules//Social_Reader.com.xml` should go away.