### PR TITLE
Do not modify headers if EASE is disabled. fix #17253

### DIFF
--- a/chromium/background-scripts/background.js
+++ b/chromium/background-scripts/background.js
@@ -690,10 +690,16 @@ function onErrorOccurred(details) {
  */
 function onHeadersReceived(details) {
   if (isExtensionEnabled && httpNowhereOn) {
-    // Do not upgrade the .onion requests in HTTP Nowhere Mode,
+    // Do not upgrade the .onion requests in EASE mode,
     // See https://github.com/EFForg/https-everywhere/pull/14600#discussion_r168072480
     const uri = new URL(details.url);
     if (uri.hostname.slice(-6) == '.onion') {
+      return {};
+    }
+
+    // Do not upgrade resources if the first-party domain disbled EASE mode
+    // This is needed for HTTPS sites serve mixed content and is broken
+    if (disabledList.has(uri.hostname)) {
       return {};
     }
 

--- a/chromium/background-scripts/background.js
+++ b/chromium/background-scripts/background.js
@@ -699,7 +699,22 @@ function onHeadersReceived(details) {
 
     // Do not upgrade resources if the first-party domain disbled EASE mode
     // This is needed for HTTPS sites serve mixed content and is broken
-    if (disabledList.has(uri.hostname)) {
+    let firstPartyHost;
+    if (details.type == "main_frame") {
+      firstPartyHost = uri.host;
+    } else {
+      // In Firefox, documentUrl is preferable here, since it will always be the
+      // URL in the URL bar, but it was only introduced in FF 54.  We should get
+      // rid of `originUrl` at some point.
+      if ('documentUrl' in details) { // Firefox 54+
+        firstPartyHost = new URL(details.documentUrl).host;
+      } else if ('originUrl' in details) { // Firefox < 54
+        firstPartyHost = new URL(details.originUrl).host;
+      } else if('initiator' in details) { // Chrome
+        firstPartyHost = new URL(details.initiator).host;
+      }
+    }
+    if (disabledList.has(firstPartyHost)) {
       return {};
     }
 


### PR DESCRIPTION
I have only tested this on Chrome. Mixed content requests might still be blocked by Firefox's own MCB mechanism... 

close #17253 cc @Hainish @zoracon 