### PR TITLE
Do not run on https requests

### DIFF
--- a/chromium/manifest.json
+++ b/chromium/manifest.json
@@ -48,7 +48,7 @@
         "tabs",
         "cookies",
         "storage",
-        "*://*/*",
+        "http://*/*",
         "ftp://*/*"
     ],
     "version": "2019.1.7",


### PR DESCRIPTION
Now when https->https rewrites are completely removed, we can skip all https requests.