### PR TITLE
redirect uwaterloo csclub mirrors

### DIFF
--- a/src/chrome/content/rules/University-of-Waterloo.xml
+++ b/src/chrome/content/rules/University-of-Waterloo.xml
@@ -7,7 +7,9 @@
 	Invalid certificate:
 		cacr.uwaterloo.ca
 		cecs.uwaterloo.ca
+		mirror.cs.uwaterloo.ca
 		hr.uwaterloo.ca
+		mirror.uwaterloo.ca
 
 -->
 <ruleset name="University of Waterloo (partial)">
@@ -18,6 +20,7 @@
 	<target host="crysp.uwaterloo.ca" />
 	<target host="cs.uwaterloo.ca" />
 	<target host="www.cs.uwaterloo.ca" />
+	<target host="mirror.cs.uwaterloo.ca" />
 	<target host="csclub.uwaterloo.ca" />
 	<target host="mirror.csclub.uwaterloo.ca" />
 	<target host="bookings.lib.uwaterloo.ca" />
@@ -30,6 +33,7 @@
 		<!-- 404 with HTTPS -->
 		<exclusion pattern="^http://www.math.uwaterloo.ca/tsp/" />
 		<test url="http://www.math.uwaterloo.ca/tsp/" />
+	<target host="mirror.uwaterloo.ca" />
 	<target host="nexusmail.uwaterloo.ca" />
 	<target host="www.nexusmail.uwaterloo.ca" />
 	<target host="www.reserves.uwaterloo.ca" />
@@ -37,6 +41,7 @@
 	<target host="uwspace.uwaterloo.ca" />
 	<target host="wise.uwaterloo.ca" />
 
-	<rule from="^http:"
-		to="https:" />
+	<rule from="^http://mirror\.uwaterloo\.ca/" to="https://mirror.csclub.uwaterloo.ca/" />
+	<rule from="^http://mirror\.cs\.uwaterloo\.ca/" to="https://mirror.csclub.uwaterloo.ca/" />
+	<rule from="^http:" to="https:" />
 </ruleset>


### PR DESCRIPTION
The certificate is only valid for *.csclub.uwaterloo.ca, but these other subdomains rank higher in searches.

(For context, this is one of the most popular official Canadian mirrors for a bunch of linux distros and open source projects.)