### PR TITLE
Make it possible to open debugging ruleset editor on Firefox

### DIFF
--- a/chromium/pages/options/index.html
+++ b/chromium/pages/options/index.html
@@ -53,6 +53,10 @@
       </div>
     </div>
 
+    <div class="section-wrapper">
+      <a href="/pages/debugging-rulesets/index.html" target="_blank" data-i18n="options_debuggingRulesets"></a>
+    </div>
+
     <script src="ux.js"></script>
     <script src="../translation.js"></script>
     <script src="../util.js"></script>

--- a/chromium/pages/options/index.html
+++ b/chromium/pages/options/index.html
@@ -53,9 +53,7 @@
       </div>
     </div>
 
-    <div class="section-wrapper">
-      <a href="/pages/debugging-rulesets/index.html" target="_blank" data-i18n="options_debuggingRulesets"></a>
-    </div>
+    <a href="/pages/debugging-rulesets/index.html" target="_blank" data-i18n="options_debuggingRulesets"></a>
 
     <script src="ux.js"></script>
     <script src="../translation.js"></script>

--- a/chromium/pages/options/ux.js
+++ b/chromium/pages/options/ux.js
@@ -343,11 +343,4 @@ document.addEventListener("DOMContentLoaded", () => {
     }
     update_channels_last_checked.innerText = chrome.i18n.getMessage("options_updatesLastChecked") + last_checked_string;
   });
-
-  document.onkeydown = function(evt) {
-    evt = evt || window.event;
-    if (evt.ctrlKey && evt.keyCode == 90) {
-      window.open("/pages/debugging-rulesets/index.html");
-    }
-  };
 });

--- a/src/chrome/locale/en/https-everywhere.dtd
+++ b/src/chrome/locale/en/https-everywhere.dtd
@@ -28,6 +28,7 @@
 <!ENTITY https-everywhere.options.storedRulesetsVersion "Stored rulesets version: ">
 <!ENTITY https-everywhere.options.updatesLastChecked "Updates last checked: ">
 <!ENTITY https-everywhere.options.updatesLastCheckedNever "never">
+<!ENTITY https-everywhere.options.debuggingRulesets "Debugging Rulesets (advanced)">
 
 <!ENTITY https-everywhere.prefs.export_settings "Export Settings">
 <!ENTITY https-everywhere.prefs.reset_defaults "Reset to Defaults">


### PR DESCRIPTION
On latest Firefox Nightly, pressing Ctrl-Z on options page does nothing if you are viewing it from Firefox UI, and if you are viewing it directly it just shows a "popup blocked" message.