### PR TITLE
Adjust CSS for long http links

### DIFF
--- a/chromium/pages/cancel/style.css
+++ b/chromium/pages/cancel/style.css
@@ -34,6 +34,13 @@ form button{
   cursor: pointer;
 }
 
+#url-value{
+  display: block;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
 #open-url-button{
   display: inline-block;
   float: left;


### PR DESCRIPTION
- Email tracking links get long and break layout, so cap overflow with an ellipsis