### PR TITLE
Add patch for Chrome run time issue

### DIFF
--- a/chromium/pages/options/ux.js
+++ b/chromium/pages/options/ux.js
@@ -20,6 +20,10 @@ document.addEventListener("DOMContentLoaded", () => {
   };
 
   sendMessage("get_option", defaultOptions, item => {
+    // Sometimes item does not define on runtime in Chrome
+    if( !item ){
+      item = defaultOptions;
+    }
     showCounter.checked = item.showCounter;
     autoUpdateRulesets.checked = item.autoUpdateRulesets;
     enableMixedRulesets.checked = item.enableMixedRulesets;

--- a/chromium/pages/options/ux.js
+++ b/chromium/pages/options/ux.js
@@ -21,7 +21,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   sendMessage("get_option", defaultOptions, item => {
     // Sometimes item does not define on runtime in Chrome
-    if( !item ){
+    if(!item) {
       item = defaultOptions;
     }
     showCounter.checked = item.showCounter;

--- a/test/selenium/test_options.py
+++ b/test/selenium/test_options.py
@@ -11,8 +11,8 @@ class OptionsTest(ExtensionTestCase):
         self.assertEqual(self.driver.current_url, self.shim.options_url)
 
     def test_show_counter(self):
-        if self.shim.browser_type == 'chrome':
-            raise unittest.SkipTest('broken on chrome')
+        # if self.shim.browser_type == 'chrome':
+        #     raise unittest.SkipTest('broken on chrome')
         selector = '#showCounter'
         self.load_options()
         sleep(3)
@@ -22,7 +22,6 @@ class OptionsTest(ExtensionTestCase):
         el.click()
 
         self.driver.refresh()
-        sleep(3)
         el = self.query_selector(selector)
         self.assertFalse(el.is_selected())
         el.click()


### PR DESCRIPTION
Caught that at times "item" is not defined during "show counter" test. Causing Chrome and Chrome Beta test to fail. Adding this in as a stop gap so this test can continue for future PRs.

Related: #17274 