### PR TITLE
Add SSL internal error code to SSL misconfiguration list

### DIFF
--- a/chromium/background-scripts/background.js
+++ b/chromium/background-scripts/background.js
@@ -643,7 +643,6 @@ function onCompleted(details) {
  * @param details details for the chrome.webRequest (see chrome doc)
  */
 function onErrorOccurred(details) {
-  console.log(details.error);
   if (httpNowhereOn &&
     details.type == "main_frame" &&
     simpleHTTPNowhereRedirect.get(details.requestId) &&

--- a/chromium/background-scripts/background.js
+++ b/chromium/background-scripts/background.js
@@ -643,6 +643,7 @@ function onCompleted(details) {
  * @param details details for the chrome.webRequest (see chrome doc)
  */
 function onErrorOccurred(details) {
+  console.log(details.error);
   if (httpNowhereOn &&
     details.type == "main_frame" &&
     simpleHTTPNowhereRedirect.get(details.requestId) &&
@@ -651,6 +652,7 @@ function onErrorOccurred(details) {
       details.error.indexOf("net::ERR_CERT_") == 0 ||
       details.error.indexOf("net::ERR_CONNECTION_") == 0 ||
       details.error.indexOf("net::ERR_ABORTED") == 0 ||
+      details.error.indexOf("net::ERR_SSL_PROTOCOL_ERROR") == 0 ||
       details.error.indexOf("NS_ERROR_CONNECTION_REFUSED") == 0 ||
       details.error.indexOf("NS_ERROR_NET_TIMEOUT") == 0 ||
       details.error.indexOf("NS_ERROR_NET_ON_TLS_HANDSHAKE_ENDED") == 0 ||
@@ -660,6 +662,7 @@ function onErrorOccurred(details) {
       details.error.indexOf("Unable to communicate securely with peer: requested domain name does not match the server’s certificate.") == 0 ||
       details.error.indexOf("Peer’s Certificate issuer is not recognized.") == 0 ||
       details.error.indexOf("Peer’s Certificate has been revoked.") == 0 ||
+      details.error.indexOf("Peer reports it experienced an internal error.") == 0 ||
       details.error.indexOf("The server uses key pinning (HPKP) but no trusted certificate chain could be constructed that matches the pinset. Key pinning violations cannot be overridden.") == 0 ||
       details.error.indexOf("SSL received a weak ephemeral Diffie-Hellman key in Server Key Exchange handshake message.") == 0 ||
       details.error.indexOf("The certificate was signed using a signature algorithm that is disabled because it is not secure.") == 0 ||


### PR DESCRIPTION
Added in a SSL code that occurs when HTTP Everywhere attempts to upgrade a HTTP request from a domain with this error.

Closes #17529