### PR TITLE
Ensure that when the extension is updated, older rulesets are cleared…

### DIFF
--- a/chromium/background-scripts/update_channels.js
+++ b/chromium/background-scripts/update_channels.js
@@ -18,7 +18,8 @@ exports.update_channels = [{
        '-sbyMKGJ5j1BWTnibCklDXtWzXtuiz18EgE'
   },
   update_path_prefix: 'https://www.https-rulesets.org/v1/',
-  scope: ''
+  scope: '',
+  replaces_default_rulesets: true
 }];
 
 })(typeof exports === 'undefined' ? require.scopes.update_channels = {} : exports);


### PR DESCRIPTION
In https://trac.torproject.org/projects/tor/ticket/29454 there's a discussion about how Tor Browser users are often getting older versions of rulesets.

Currently, if any rulesets have been successfully downloaded and verified from the update channels (https://www.https-rulesets.org/ for instance) , this will overwrite the extension built-in rulesets.

Polling of the update channels occurs every 24 hours, or on browser startup if it's been longer than 24 hours since the last poll.

In Tor Browser this is a problem, since the tor circuit hasn't been established at browser startup, when the poll request is made.  It fails, and the rulesets aren't updated.

For some Tor Browser users, they've successfully downloaded rulesets once, but subsequently they've gotten fails for the above reason.  This means they're stuck on an old version of the rulesets, even after the extension itself is updated and they have newer rules available within the extension.

This PR does a few things:

- When an update to the extension is made, we clear the https://www.https-rulesets.org/ rulesets from the browser. We'll then be using the extension-bundled rulesets.
- We only update the extension to the latest rulesets from https://www.https-rulesets.org/ if the timestamp for those rulesets is newer than the extension itself. This will prevent the case where HTTPS Everywhere downloads the newest ruleset, then an update to the extension is made which clears the https-rulesets.org rulesets, and then you need to download the rulesets from https-rulesets.org again.