### PR TITLE
Fix Chromium local store exception

### DIFF
--- a/chromium/background-scripts/store.js
+++ b/chromium/background-scripts/store.js
@@ -99,9 +99,9 @@ async function performMigrations() {
 }
 
 const local = {
-  get: chrome.storage.local.get,
-  set: chrome.storage.local.set,
-  remove: chrome.storage.local.remove,
+  get: (...args) => chrome.storage.local.get(...args),
+  set: (...args) => chrome.storage.local.set(...args),
+  remove: (...args) => chrome.storage.local.remove(...args),
   get_promise: local_get_promise,
   set_promise: local_set_promise
 };


### PR DESCRIPTION
At least on Chromium 73 when opening the extension options window an exception
"TypeError: Illegal invocation: Function must be called on an object of type StorageArea"
is thrown, which results in empty update channels page.

It looks like chrome.storage.local methods need to be called while bound to
the chrome.storage.local object.

According to
https://github.com/KeithHenry/chromeExtensionAsync/issues/10
https://github.com/wtetsu/mouse-dictionary/issues/16 this Chromium change
has been introduced probably around version 70 or 72.

Automatic ruleset updates might have been affected by this, too.
