### PR TITLE
Add "How to Fix Site" to Documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,7 @@
 * [Welcome!](#welcome)
     * [HTTPS Everywhere Source Code Layout](#https-everywhere-source-code-layout)
     * [Submitting Changes](#submitting-changes)
+    * [I want to fix my site](#i-want-to-fix-my-site)
 * [Contributing Rulesets](#contributing-rulesets)
     * [General Info](#general-info)
     * [New Rulesets](#new-rulesets)
@@ -67,6 +68,18 @@ Tests are performed in headless browsers and located in the [`test`](test) top-l
 To submit changes, open a pull request from our [GitHub repository](https://github.com/efforg/https-everywhere).
 
 HTTPS Everywhere is maintained by a limited set of staff and volunteers.  Please be mindful that we may take a while before we're able to review your contributions.
+
+## I Want To Fix My Site
+
+To get an SSL certificate, go to: [Let's Encrypt](https://letsencrypt.org/)
+
+"I have an SSL certificate, but it's not configured properly"
+
+Scan your site at the [Mozilla Observatory](https://observatory.mozilla.org/) and get not only what is wrong/insecure about your site, but also tips and directions on how to fix the issues.
+
+"How do I get on the HSTS preload list?"
+
+In order to do this, not only must you have a SSL certicate correctly installed and your site redirecting to HTTPS, but also meet a few extra requirements that satisfy a proper HSTS header. To view "how close" your site is to being on the HSTS preload list, scan your site [here](https://hstspreload.org/).
 
 * * *
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,9 +77,9 @@ To get an SSL certificate, go to: [Let's Encrypt](https://letsencrypt.org/)
 
 Scan your site at the [Mozilla Observatory](https://observatory.mozilla.org/) and get results on what is wrong/insecure about your site, as well as also tips and directions on how to fix those issues.
 
-**"How do I get on the HSTS preload list?"**
+**"How do I get on the HSTS Preload list?"**
 
-In order to do this, not only must you have a SSL certicate correctly installed and your site redirecting to HTTPS, but also meet a few extra requirements that satisfy a proper HSTS header. To view "how close" your site is to being on the HSTS preload list, scan your site [here](https://hstspreload.org/).
+In order to do this, not only must you have a SSL certicate correctly installed and your site redirecting to HTTPS, but also meet a few extra requirements for a [`Strict-Transport-Security`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security) header. To view "how close" your site is to being on the HSTS Preload list, scan your site [here](https://hstspreload.org/).
 
 * * *
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 * [Welcome!](#welcome)
     * [HTTPS Everywhere Source Code Layout](#https-everywhere-source-code-layout)
     * [Submitting Changes](#submitting-changes)
-    * [I want to fix my site](#i-want-to-fix-my-site)
+    * [I Want To Fix My Site](#i-want-to-fix-my-site)
 * [Contributing Rulesets](#contributing-rulesets)
     * [General Info](#general-info)
     * [New Rulesets](#new-rulesets)
@@ -73,11 +73,11 @@ HTTPS Everywhere is maintained by a limited set of staff and volunteers.  Please
 
 To get an SSL certificate, go to: [Let's Encrypt](https://letsencrypt.org/)
 
-"I have an SSL certificate, but it's not configured properly"
+**"I have an SSL certificate, but it's not configured properly"**
 
-Scan your site at the [Mozilla Observatory](https://observatory.mozilla.org/) and get not only what is wrong/insecure about your site, but also tips and directions on how to fix the issues.
+Scan your site at the [Mozilla Observatory](https://observatory.mozilla.org/) and get results on what is wrong/insecure about your site, as well as also tips and directions on how to fix those issues.
 
-"How do I get on the HSTS preload list?"
+**"How do I get on the HSTS preload list?"**
 
 In order to do this, not only must you have a SSL certicate correctly installed and your site redirecting to HTTPS, but also meet a few extra requirements that satisfy a proper HSTS header. To view "how close" your site is to being on the HSTS preload list, scan your site [here](https://hstspreload.org/).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,9 @@ HTTPS Everywhere is maintained by a limited set of staff and volunteers.  Please
 
 ## I Want To Fix My Site
 
-To get an SSL certificate, go to: [Let's Encrypt](https://letsencrypt.org/)
+**"I want to get an SSL certificate"
+
+To get an SSL certificate, as an option, you can go to [Let's Encrypt](https://letsencrypt.org/) and get a free certificate.
 
 **"I have an SSL certificate, but it's not configured properly"**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ Scan your site at the [Mozilla Observatory](https://observatory.mozilla.org/) an
 
 **"How do I get on the HSTS Preload list?"**
 
-In order to do this, not only must you have a SSL certicate correctly installed and your site redirecting to HTTPS, but also meet a few extra requirements for a [`Strict-Transport-Security`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security) header. To view "how close" your site is to being on the HSTS Preload list, scan your site [here](https://hstspreload.org/).
+In order to do this, not only must you have a SSL certicate correctly installed and your site redirecting to HTTPS, but also meet a few extra requirements for the[`HTTP Strict-Transport-Security`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security) header. To view "how close" your site is for HSTS preloading, scan your site [here](https://hstspreload.org/).
 
 * * *
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,7 @@ HTTPS Everywhere is maintained by a limited set of staff and volunteers.  Please
 
 ## I Want To Fix My Site
 
-**"I want to get an SSL certificate"
+**"I want to get an SSL certificate"**
 
 To get an SSL certificate, as an option, you can go to [Let's Encrypt](https://letsencrypt.org/) and get a free certificate.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ To get an SSL certificate, go to: [Let's Encrypt](https://letsencrypt.org/)
 
 **"I have an SSL certificate, but it's not configured properly"**
 
-Scan your site at the [Mozilla Observatory](https://observatory.mozilla.org/) and get results on what is wrong/insecure about your site, as well as also tips and directions on how to fix those issues.
+Scan your site at the [Mozilla Observatory](https://observatory.mozilla.org/) and get results on what is wrong/insecure about your site, as well as tips and directions on how to fix those issues.
 
 **"How do I get on the HSTS Preload list?"**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ Scan your site at the [Mozilla Observatory](https://observatory.mozilla.org/) an
 
 **"How do I get on the HSTS Preload list?"**
 
-In order to do this, not only must you have a SSL certicate correctly installed and your site redirecting to HTTPS, but also meet a few extra requirements for the[`HTTP Strict-Transport-Security`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security) header. To view "how close" your site is for HSTS preloading, scan your site [here](https://hstspreload.org/).
+In order to do this, you must have an SSL certicate correctly installed and your site redirecting to HTTPS. As well as meet a few extra requirements for the [`HTTP Strict-Transport-Security`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security) header. To view "how close" your site is for HSTS preloading, scan your site [here](https://hstspreload.org/).
 
 * * *
 


### PR DESCRIPTION
Provide information and a path for site admins and web developers who may want to figure out how to fix their malformed SSL configurations.