### PR TITLE
Fix DeprecationWarning in HTTPS Everywhere Checker

### DIFF
--- a/test/rules/src/https_everywhere_checker/check_rules.py
+++ b/test/rules/src/https_everywhere_checker/check_rules.py
@@ -14,7 +14,7 @@ import sys
 import threading
 import time
 
-from configparser import SafeConfigParser
+from configparser import ConfigParser
 
 from lxml import etree
 

--- a/test/rules/src/https_everywhere_checker/check_rules.py
+++ b/test/rules/src/https_everywhere_checker/check_rules.py
@@ -308,7 +308,7 @@ def cli():
                         help='write results in json file')
     args = parser.parse_args()
 
-    config = SafeConfigParser()
+    config = ConfigParser()
     config.read(args.checker_config)
 
     logfile = config.get("log", "logfile")


### PR DESCRIPTION
Example of warning:
```
test/rules/src/https_everywhere_checker/check_rules.py:311: DeprecationWarning: The SafeConfigParser class has been renamed to ConfigParser in Python 3.2. This alias will be removed in future versions. Use ConfigParser directly instead.
  config = SafeConfigParser()
```