### PR TITLE
[PyData.org] Update ruleset

### DIFF
--- a/src/chrome/content/rules/PyData.org.xml
+++ b/src/chrome/content/rules/PyData.org.xml
@@ -1,13 +1,7 @@
 <!--
 	Invalid certificate:
-		blaze.pydata.org
-		blz.pydata.org
-		chicago.pydata.org
-		compilers.pydata.org
-		datashape.pydata.org
 		llvmlite.pydata.org
 		odo.pydata.org
-		xarray.pydata.org
 
 	No working URL known:
 		cdn.pydata.org
@@ -21,14 +15,20 @@
 	<target host="pydata.org" />
 	<target host="www.pydata.org" />
 	<target host="berlin.pydata.org" />
+	<target host="blaze.pydata.org" />
+	<target host="blz.pydata.org" />
 	<target host="bokeh.pydata.org" />
+	<target host="chicago.pydata.org" />
+	<target host="compilers.pydata.org" />
 	<target host="conda.pydata.org" />
 	<target host="dask.pydata.org" />
+	<target host="datashape.pydata.org" />
 	<target host="london.pydata.org" />
 	<target host="numba.pydata.org" />
 	<target host="pandas.pydata.org" />
 	<target host="seaborn.pydata.org" />
-
+	<target host="xarray.pydata.org" />
+	
 	<securecookie host=".+" name=".+" />
 
 	<rule from="^http:" to="https:" />


### PR DESCRIPTION
Several previously problematic subdomains now work. Some font-related mixed content issues warnings will show up on `blaze` and `xarray` but nothing problematic.