### PR TITLE
add *.jamfcloud.com rule to JAMF software ruleset

### DIFF
--- a/src/chrome/content/rules/JAMF_Software.com.xml
+++ b/src/chrome/content/rules/JAMF_Software.com.xml
@@ -4,6 +4,7 @@
 	<target host="my.jamfsoftware.com" />
 	<target host="store.jamfsoftware.com" />
 	<target host="support.jamfsoftware.com" />
+	<target host="*.jamfcloud.com" />
 		<!--
 			Dropped:
 					-->

--- a/src/chrome/content/rules/JAMF_Software.com.xml
+++ b/src/chrome/content/rules/JAMF_Software.com.xml
@@ -10,7 +10,7 @@
 		<test url="http://hosted.jamfcloud.com/" />
 
 	<!--	Mismatched:	-->
-	<exclusion pattern="^http://content\.jamfsoftware\.com/" />
+	<exclusion pattern="^http://content\.jamfcloud\.com/" />
 		<test url="http://content.jamfcloud.com/" />
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/JAMF_Software.com.xml
+++ b/src/chrome/content/rules/JAMF_Software.com.xml
@@ -1,25 +1,17 @@
-<ruleset name="JAMF Software.com (partial)">
-
+<ruleset name="JAMF_Software.com (partial)">
 	<target host="jamfnation.jamfsoftware.com" />
 	<target host="my.jamfsoftware.com" />
 	<target host="store.jamfsoftware.com" />
 	<target host="support.jamfsoftware.com" />
+
 	<target host="*.jamfcloud.com" />
+		<test url="http://signup.jamfcloud.com/" />
+		<test url="http://jamf.jamfcloud.com/" />
+		<test url="http://hosted.jamfcloud.com/" />
 
-	<test url="http://signup.jamfcloud.com/" />
-	<test url="http://jamf.jamfcloud.com/" />
-	<test url="http://hosted.jamfcloud.com/" />
-		<!--
-			Dropped:
-					-->
-		<!--exclusion pattern="^http://www\.jamfsoftware\.com/" /-->
-
-
-	<!--	Not secured by server, could we secure this safely?
-									-->
-	<!--securecookie host="^\.jamfsoftware\.com$" name="^JSESSIONID$" /-->
-
+	<!--	Mismatched:	-->
+	<exclusion pattern="^http://content\.jamfsoftware\.com/" />
+		<test url="http://content.jamfcloud.com/" />
 
 	<rule from="^http:" to="https:" />
-
 </ruleset>

--- a/src/chrome/content/rules/JAMF_Software.com.xml
+++ b/src/chrome/content/rules/JAMF_Software.com.xml
@@ -5,6 +5,10 @@
 	<target host="store.jamfsoftware.com" />
 	<target host="support.jamfsoftware.com" />
 	<target host="*.jamfcloud.com" />
+
+	<test url="http://signup.jamfcloud.com" />
+	<test url="http://jamf.jamfcloud.com" />
+	<test url="http://hosted.jamfcloud.com" />
 		<!--
 			Dropped:
 					-->

--- a/src/chrome/content/rules/JAMF_Software.com.xml
+++ b/src/chrome/content/rules/JAMF_Software.com.xml
@@ -6,9 +6,9 @@
 	<target host="support.jamfsoftware.com" />
 	<target host="*.jamfcloud.com" />
 
-	<test url="http://signup.jamfcloud.com" />
-	<test url="http://jamf.jamfcloud.com" />
-	<test url="http://hosted.jamfcloud.com" />
+	<test url="http://signup.jamfcloud.com/" />
+	<test url="http://jamf.jamfcloud.com/" />
+	<test url="http://hosted.jamfcloud.com/" />
 		<!--
 			Dropped:
 					-->


### PR DESCRIPTION
jamfcloud.com is SaaS hosted by JAMF Software at _subdomain_.jamfcloud.com - all subdomains do listen on HTTPS, so the wildcard is desirable to rewrite everything here.