### PR TITLE
Updated URL to new Atlas URL

### DIFF
--- a/chromium/pages/popup/index.html
+++ b/chromium/pages/popup/index.html
@@ -71,7 +71,7 @@
     </div>
 
     <footer>
-      <a id="viewAllRules" href="https://www.eff.org/https-everywhere/atlas" target="_blank" data-i18n="menu_viewAllRules"></a><br>
+      <a id="viewAllRules" href="https://atlas.eff.org/index.html" target="_blank" data-i18n="menu_viewAllRules"></a><br>
       <br>
       <a id="aboutTitle" href="https://www.eff.org/https-everywhere" target="_blank" data-i18n="about_title"></a><br>
       <br>


### PR DESCRIPTION
Chose to use https://atlas.eff.org/index.html instead of https://atlas.eff.org/ because links to go back to "HTTPS Everywhere Atlas" main page from the Atlas itself go to the index.html file.  This is also a little safer in the event of a server misconfiguration or hack.