### PR TITLE
Remove middle wildcard support in rules.js

### DIFF
--- a/chromium/background-scripts/rules.js
+++ b/chromium/background-scripts/rules.js
@@ -562,10 +562,10 @@ RuleSets.prototype = {
       return nullIterable;
     }
 
-    // Replace www.example.com with *.example.com, however, this
-    // SHOULD NOT replace example.com with *.com
+    // Replace www.example.com with www.example.*
+    // eat away from the right for once and only once
     let segmented = host.split(".");
-    if (segmented.length > 2) {
+    if (segmented.length > 1) {
       let tmp = segmented[segmented.length - 1];
 
       results = (this.targets.has(segmented.join(".")) ?

--- a/chromium/background-scripts/rules.js
+++ b/chromium/background-scripts/rules.js
@@ -566,7 +566,7 @@ RuleSets.prototype = {
     // eat away from the right for once and only once
     let segmented = host.split(".");
     if (segmented.length > 1) {
-      let tmp = segmented[segmented.length - 1];
+      const tmp = segmented[segmented.length - 1];
       segmented[segmented.length - 1] = "*";
 
       results = (this.targets.has(segmented.join(".")) ?

--- a/chromium/background-scripts/rules.js
+++ b/chromium/background-scripts/rules.js
@@ -567,6 +567,7 @@ RuleSets.prototype = {
     let segmented = host.split(".");
     if (segmented.length > 1) {
       let tmp = segmented[segmented.length - 1];
+      segmented[segmented.length - 1] = "*";
 
       results = (this.targets.has(segmented.join(".")) ?
         new Set([...results, ...this.targets.get(segmented.join("."))]) :

--- a/chromium/background-scripts/rules.js
+++ b/chromium/background-scripts/rules.js
@@ -562,22 +562,22 @@ RuleSets.prototype = {
       return nullIterable;
     }
 
-    // Replace each portion of the domain with a * in turn
+    // Replace www.example.com with *.example.com, however, this
+    // SHOULD NOT replace example.com with *.com
     let segmented = host.split(".");
-    for (let i = 0; i < segmented.length; i++) {
-      let tmp = segmented[i];
-      segmented[i] = "*";
+    if (segmented.length > 2) {
+      let tmp = segmented[segmented.length - 1];
 
       results = (this.targets.has(segmented.join(".")) ?
         new Set([...results, ...this.targets.get(segmented.join("."))]) :
         results);
 
-      segmented[i] = tmp;
+      segmented[segmented.length - 1] = tmp;
     }
 
     // now eat away from the left, with *, so that for x.y.z.google.com we
-    // check *.z.google.com and *.google.com (we did *.y.z.google.com above)
-    for (let i = 2; i <= segmented.length - 2; i++) {
+    // check *.y.z.google.com, *.z.google.com and *.google.com
+    for (let i = 1; i <= segmented.length - 2; i++) {
       let t = "*." + segmented.slice(i, segmented.length).join(".");
 
       results = (this.targets.has(t) ?

--- a/chromium/test/rules_test.js
+++ b/chromium/test/rules_test.js
@@ -204,21 +204,21 @@ describe('rules.js', function() {
         });
 
         it('matches right wildcards', function() {
-          let target = host + '.*';
+          const target = host + '.*';
           this.rsets.targets.set(target, value);
 
-          let res1 = this.rsets.potentiallyApplicableRulesets(host + '.tld');
+          const res1 = this.rsets.potentiallyApplicableRulesets(host + '.tld');
           assert.deepEqual(res1, new Set(value), 'default case');
 
-          let res2 = this.rsets.potentiallyApplicableRulesets(host + '.tld.com');
+          const res2 = this.rsets.potentiallyApplicableRulesets(host + '.tld.com');
           assert.isEmpty(res2, 'wildcard matches second level domains');
         });
 
         it('ignore middle wildcards', function() {
-          let target = 'www.*.' + host;
+          const target = 'www.*.' + host;
           this.rsets.targets.set(target, value);
 
-          let res1 = this.rsets.potentiallyApplicableRulesets('www.cdn.' + host);
+          const res1 = this.rsets.potentiallyApplicableRulesets('www.cdn.' + host);
           assert.isEmpty(res1, 'middle wildcards are matched');
         });
       });

--- a/chromium/test/rules_test.js
+++ b/chromium/test/rules_test.js
@@ -203,15 +203,15 @@ describe('rules.js', function() {
           assert.deepEqual(res3, new Set(value), 'wildcard matches sub domains');
         });
 
-        it('matches middle wildcards', function() {
-          let target = 'sub.*.' + host;
+        it('matches right wildcards', function() {
+          let target = host + '.*';
           this.rsets.targets.set(target, value);
 
-          let res1 = this.rsets.potentiallyApplicableRulesets('sub.star.' + host);
+          let res1 = this.rsets.potentiallyApplicableRulesets(host + '.tld');
           assert.deepEqual(res1, new Set(value), 'default case');
 
-          let res2 = this.rsets.potentiallyApplicableRulesets('sub.foo.bar.' + host);
-          assert.isEmpty(res2, new Set(value), 'only matches one label');
+          let res2 = this.rsets.potentiallyApplicableRulesets(host + '.tld.com');
+          assert.isEmpty(res2, 'wildcard matches second level domains');
         });
       });
     });

--- a/chromium/test/rules_test.js
+++ b/chromium/test/rules_test.js
@@ -213,6 +213,14 @@ describe('rules.js', function() {
           let res2 = this.rsets.potentiallyApplicableRulesets(host + '.tld.com');
           assert.isEmpty(res2, 'wildcard matches second level domains');
         });
+
+        it('ignore middle wildcards', function() {
+          let target = 'www.*.' + host;
+          this.rsets.targets.set(target, value);
+
+          let res1 = this.rsets.potentiallyApplicableRulesets('www.cdn.' + host);
+          assert.isEmpty(res1, 'middle wildcards are matched');
+        });
       });
     });
   });


### PR DESCRIPTION
This replaces #17669 to drop support for middle wildcards in the runtime. hopefully #17711 