### PR TITLE
Do not call safeToSecureCookie until necessary

### DIFF
--- a/chromium/background-scripts/rules.js
+++ b/chromium/background-scripts/rules.js
@@ -663,7 +663,10 @@ RuleSets.prototype = {
     const potentiallyApplicable = this.potentiallyApplicableRulesets(hostname);
     for (const ruleset of potentiallyApplicable) {
       if (ruleset.cookierules !== null && ruleset.active) {
+        // safe is false only indicate the lack of a cached result
+        // we cannot use it to avoid looping here
         for (const cookierule of ruleset.cookierules) {
+          // if safe is true, it is case (b); otherwise it is case (c)
           if (cookierule.host_c.test(cookie.domain) && cookierule.name_c.test(cookie.name)) {
             return safe || this.safeToSecureCookie(hostname, potentiallyApplicable);
           }

--- a/chromium/background-scripts/rules.js
+++ b/chromium/background-scripts/rules.js
@@ -638,11 +638,11 @@ RuleSets.prototype = {
       return false;
     }
 
-    // Second, we need a cookie pass two tests before securing patching it
+    // Second, we need a cookie pass two tests before patching it
     //   (1) it is safe to secure the cookie, as per safeToSecureCookie()
     //   (2) it matches with the CookieRule
     //
-    // We kept a cache of the results for (1), if we have cached results...
+    // We kept a cache of the results for (1), if we have a cached result which
     //   (a) is false, we should not secure the cookie for sure
     //   (b) is true, we need to perform test (2)
     //


### PR DESCRIPTION
In the past, we call safeToSecureCookie for every new cookie regardless we will ever secure the cookie or not. It is more sane to delay the call until we know it is necessary. The proposed change also reduce calls to potentiallyApplicableRulesets to avoid search in a huge (cached) Map object .

IMHO, the code logic is more complicated but I am not sure if it worth the trade off. Given the complexity of this change, I don't think it is necessary to merge it before the next release. 

P.S. This is also likely the last major change I will make before the next release. thanks!!