### PR TITLE
Delay all requests until rewriting is possible

### DIFF
--- a/chromium/background-scripts/background.js
+++ b/chromium/background-scripts/background.js
@@ -778,9 +778,6 @@ const isSecureURL = url => {
   }
 }
 
-// Registers the handler for requests
-// See: https://github.com/EFForg/https-everywhere/issues/10039
-
 // Delay all requests until ruleset intialization to mitigate some types of unencrypted HTTP leaks.
 
 let requestHandler = details => {
@@ -795,6 +792,8 @@ extensionReady.then(() => {
   requestHandler = onBeforeRequest
 })
 
+// Registers the handler for requests
+// See: https://github.com/EFForg/https-everywhere/issues/10039
 chrome.webRequest.onBeforeRequest.addListener(details => requestHandler(details), {urls: ["*://*/*", "ftp://*/*"]}, ["blocking"]);
 
 // Try to catch redirect loops on URLs we've redirected to HTTPS.

--- a/chromium/background-scripts/background.js
+++ b/chromium/background-scripts/background.js
@@ -22,9 +22,6 @@ async function initialize() {
   await incognito.onIncognitoDestruction(destroy_caches);
 }
 const extensionReady = initialize();
-const timeStarted = performance.now()
-
-extensionReady.then(() => { console.log(performance.now() - timeStarted) })
 
 async function initializeAllRules() {
   const r = new rules.RuleSets();

--- a/chromium/background-scripts/background.js
+++ b/chromium/background-scripts/background.js
@@ -777,7 +777,9 @@ let requestHandler = details => {
   }
 }
 
-extensionReady.then(() => { requestHandler = onBeforeRequest })
+extensionReady.then(() => {
+  requestHandler = onBeforeRequest
+})
 
 chrome.webRequest.onBeforeRequest.addListener(details => requestHandler(details), {urls: ["*://*/*", "ftp://*/*"]}, ["blocking"]);
 


### PR DESCRIPTION
**Extremely experimental. Please test before merging. I did brief testing on Chromium but not Firefox.**

This is supposed to close #17716 and another security vulnerability related on how HTTPS Everywhere is caching rewrites.