### PR TITLE
Use the latest LTS Node.js release for unittests, fix #17829

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,11 @@ matrix:
     - env: TEST="lint"
       language: node_js
       node_js:
-        - "node"
+        - "lts/*"
     - env: TEST="unittests"
       language: node_js
       node_js:
-        - "node"
+        - "lts/*"
     - env: TEST="validations"
     - env: TEST="fetch"
     - env: TEST="preloaded"


### PR DESCRIPTION
This PR makes unit tests run in the latest LTS Node.js release. In order to avoid pinning a older Node.js version every time there is a new version (#15254) and then manually switch to a newer version when `node-webcrypto-ossl` make a new release (#17071).

Personally, I don't think it is worth using the latest stable version of Node.js for unit tests. This is because stability should be preferred over the new features a newer version can bring. 

In the long term, we might want to investigate whether this dependency is really needed for our tests.

Ref: https://docs.travis-ci.com/user/languages/javascript-with-nodejs/

Related: #15254, #17071