### PR TITLE
Fix typo causing abccommercial.com unprotected

### DIFF
--- a/src/chrome/content/rules/ABC-Online.xml
+++ b/src/chrome/content/rules/ABC-Online.xml
@@ -5,12 +5,12 @@
 
 	Non-functional hosts in *.abc.net.au
 		Timeout:
-		- abc.net.au
 		- shop.abc.net.au
 -->
 <ruleset name="ABC Online (partial)">
 
 	<!-- *.abc.net.au -->
+	<target host="abc.net.au" />
 	<target host="www.abc.net.au" />
 	<target host="about.abc.net.au" />
 

--- a/src/chrome/content/rules/ABC-Online.xml
+++ b/src/chrome/content/rules/ABC-Online.xml
@@ -2,6 +2,10 @@
 	Other ABC Online rulesets:
 
 		- ABC-Music-Publishing.xml
+
+	Non-functional hosts in *.abc.net.au
+		Timeout:
+		- shop.abc.net.au
 -->
 <ruleset name="ABC Online (partial)">
 
@@ -9,7 +13,6 @@
 	<target host="abc.net.au" />
 	<target host="www.abc.net.au" />
 	<target host="about.abc.net.au" />
-	<target host="shop.abc.net.au" />
 
 	<!-- *.abccommercial.com -->
 	<target host="abccommercial.com" />

--- a/src/chrome/content/rules/ABC-Online.xml
+++ b/src/chrome/content/rules/ABC-Online.xml
@@ -5,12 +5,12 @@
 
 	Non-functional hosts in *.abc.net.au
 		Timeout:
+		- abc.net.au
 		- shop.abc.net.au
 -->
 <ruleset name="ABC Online (partial)">
 
 	<!-- *.abc.net.au -->
-	<target host="abc.net.au" />
 	<target host="www.abc.net.au" />
 	<target host="about.abc.net.au" />
 

--- a/src/chrome/content/rules/ABC-Online.xml
+++ b/src/chrome/content/rules/ABC-Online.xml
@@ -2,49 +2,19 @@
 	Other ABC Online rulesets:
 
 		- ABC-Music-Publishing.xml
-
-
-	CDN buckets:
-
-		- d1ros97qkrwjf5.cloudfront.net
-		- d3mfbaa198drag.cloudfront.net
-		- cp44823.edgefcs.net
-
-
-	Nonfunctional:
-
-		- about.abc.net.au ¹
-		- mpegmedia.abc.net.au ²
-		- origin.abc.net.au ³		(redirects to www via http)
-		- (www.)abc.net.au ²
-		- www2b.abc.net.au ³
-		- (www.)abccommercial.com.au ³
-		- (www.)abccontentsales.com.au ³
-		- (www.)abcdigmusic.net.au
-		- (www.)radioaustralianews.net.au ³
-		- (www.)triplejunearthed.com ³
-
-	¹ 503, akamai
-	² 504, akamai
-	³ Dropped
-
 -->
 <ruleset name="ABC Online (partial)">
 
+	<!-- *.abc.net.au -->
+	<target host="abc.net.au" />
+	<target host="www.abc.net.au" />
+	<target host="about.abc.net.au" />
 	<target host="shop.abc.net.au" />
+
+	<!-- *.abccommercial.com -->
 	<target host="abccommercial.com" />
-	<target host="*.abccommercial.com" />
+	<target host="www.abccommercial.com" />
 
-
-	<securecookie host="^shop.abc.net.au$" name=".+" />
-	<securecookie host="^\.abccommercial\.com$" name=".+" />
-
-
-	<rule from="^http://shop\.abc\.net\.au/"
-		to="https://shop.abc.net.au/" />
-
-	<!--	Cert isn't valid for !www	-->
-	<rule from="^http://(?:www\.)?abccomercial\.com/"
-		to="https://abccomercial.com/"/>
+	<rule from="^http:" to="https:" />
 
 </ruleset>


### PR DESCRIPTION
there was a typo in the complicated rule for `abccommercial.com`