### PR TITLE
Update chromium/pages/popup/ux.js, fix #17916

### DIFF
--- a/chromium/pages/popup/ux.js
+++ b/chromium/pages/popup/ux.js
@@ -13,8 +13,8 @@
 function toggleRuleLine(event) {
   getTab(activeTab => {
     const set_ruleset = {
-      active: event.target.parentNode.firstChild.checked,
-      name: event.target.innerText,
+      active: event.target.checked,
+      name: event.target.parentNode.innerText,
       tab_id: activeTab.id,
     };
 
@@ -111,6 +111,9 @@ function appendRulesToListDiv(rulesets, list_div, ruleType) {
       checkbox.checked = ruleset.active;
       text.innerText = ruleset.name;
 
+      // Add listener to capture the toggle event
+      line.addEventListener("click", toggleRuleLine);
+
       if (ruleset.note && ruleset.note.length) {
         line.title = ruleset.note;
 
@@ -187,9 +190,6 @@ function listRules(activeTab) {
 
       appendRulesToListDiv(stableRules, e("StableRules"), 'stable');
       appendRulesToListDiv(unstableRules, e("UnstableRules"), 'unstable');
-
-      // Add listener to capture the toggle event
-      e("add-new-rule-button").addEventListener("click", toggleRuleLine);
     }
 
     // Only show the "Add a rule" section if we're on an HTTPS page


### PR DESCRIPTION
As a result of the UI redesign, #15532 is partially reverted. 

P.S. Ideally we should have a unittest on this when the UI stabilize. 