### PR TITLE
Properly change ON/OFF switch description, fix #17891

### DIFF
--- a/chromium/pages/popup/ux.js
+++ b/chromium/pages/popup/ux.js
@@ -151,10 +151,11 @@ function updateEnabledDisabledUI() {
     // Hide or show the rules sections
     if (item.globalEnabled) {
       document.body.className = ""
+      e('onoffswitch_label').innerText = chrome.i18n.getMessage("menu_globalEnable");
       showHttpNowhereUI();
     } else {
       document.body.className = "disabled";
-      e('onoffswitch_label').innerText = 'HTTPS Everywhere is OFF';
+      e('onoffswitch_label').innerText = chrome.i18n.getMessage("menu_globalDisable");
     }
   });
 }

--- a/src/chrome/locale/en/https-everywhere.dtd
+++ b/src/chrome/locale/en/https-everywhere.dtd
@@ -7,7 +7,7 @@
 
 <!ENTITY https-everywhere.menu.donate_eff_imperative "Donate to EFF">
 <!ENTITY https-everywhere.menu.observatory "SSL Observatory Preferences">
-<!ENTITY https-everywhere.menu.globalEnable "HTTPS Everywhere is OFF">
+<!ENTITY https-everywhere.menu.globalDisable "HTTPS Everywhere is OFF">
 <!ENTITY https-everywhere.menu.globalEnable "HTTPS Everywhere is ON">
 <!ENTITY https-everywhere.menu.encryptAllSitesEligible "Encrypt All Sites Eligible is ON">
 <!ENTITY https-everywhere.menu.encryptAllSitesEligible "Encrypt All Sites Eligible is OFF">


### PR DESCRIPTION
this close #17891, related to #17918 

These duplicates in the messages.json need to be fixed to ensure proper translation of the extension. Some of them just "work" currently, because the display strings are hard-coded in JavaScript. 

https://github.com/EFForg/https-everywhere/blob/66c2e971c0582066d90d404294e215763eab6275/src/chrome/locale/en/https-everywhere.dtd#L10-L15