### PR TITLE
Update profile skeleton `extensions.json` file to most recent Firefox

### DIFF
--- a/test/firefox.sh
+++ b/test/firefox.sh
@@ -17,7 +17,7 @@ source utils/mktemp.sh
 # We'll create a Firefox profile here and install HTTPS Everywhere into it.
 PROFILE_DIRECTORY="$(mktemp -d)"
 trap 'rm -r "$PROFILE_DIRECTORY"' EXIT
-HTTPSE_INSTALL_DIRECTORY=$PROFILE_DIRECTORY/extensions/https-everywhere-eff@eff.org
+HTTPSE_INSTALL_FILE=$PROFILE_DIRECTORY/extensions/https-everywhere-eff@eff.org.xpi
 
 # Build the XPI to run all the validations in make.sh, and to ensure that
 # we test what is actually getting built.
@@ -28,14 +28,14 @@ XPI_NAME="`ls -tr pkg/https-everywhere-20*.xpi | tail -1`"
 # The skeleton contains a few files required to trick Firefox into thinking
 # that the extension was fully installed rather than just unpacked.
 cp -a test/firefox/test_profile_skeleton/* $PROFILE_DIRECTORY
-unzip -qd $HTTPSE_INSTALL_DIRECTORY $XPI_NAME
+cp $XPI_NAME $HTTPSE_INSTALL_FILE
 
 die() {
   echo "$@"
   exit 1
 }
 
-if [ ! -d "$HTTPSE_INSTALL_DIRECTORY" ]; then
+if [ ! -f "$HTTPSE_INSTALL_FILE" ]; then
   die "Firefox profile does not have HTTPS Everywhere installed"
 fi
 

--- a/test/firefox/test_profile_skeleton/extensions.json
+++ b/test/firefox/test_profile_skeleton/extensions.json
@@ -1,43 +1,48 @@
 {
     "addons": [
         {
-            "aboutURL": "chrome://https-everywhere/content/about.xul",
+            "aboutURL": null,
             "active": true,
             "appDisabled": false,
             "applyBackgroundUpdates": 1,
-            "bootstrap": false,
+            "blocklistState": 0,
+            "blocklistURL": null,
             "defaultLocale": {
-                "creator": "EFF Technologists",
+                "contributors": null,
+                "creator": "extension-devs@eff.org",
                 "description": "Encrypt the Web! Automatically use HTTPS security on many sites.",
+                "developers": null,
                 "homepageURL": "https://www.eff.org/https-everywhere",
-                "name": "HTTPS Everywhere"
+                "name": "HTTPS Everywhere",
+                "translators": null
             },
-            "descriptor": "/tmp/tmp.KvR5nzzEal/extensions/https-everywhere-eff@eff.org",
+            "dependencies": [],
             "foreignInstall": false,
-            "hasBinaryComponents": false,
-            "icon64URL": null,
-            "iconURL": "chrome://https-everywhere/skin/https-everywhere.png",
-            "icons": {},
+            "hidden": false,
+            "iconURL": null,
             "id": "https-everywhere-eff@eff.org",
-            "installDate": 1451269062000,
-            "internalName": null,
-            "locales": [],
+            "installDate": 1559865340000,
+            "installTelemetryInfo": {
+                "method": "link",
+                "source": "unknown"
+            },
+            "loader": null,
             "location": "app-profile",
-            "multiprocessCompatible": true,
-            "optionsType": null,
-            "optionsURL": "chrome://https-everywhere/content/observatory-preferences.xul",
+            "optionsBrowserStyle": true,
+            "optionsType": 5,
             "releaseNotesURI": null,
-            "signedState": 1,
-            "size": 9460335,
+            "seen": true,
+            "signedState": 2,
             "skinnable": false,
             "softDisabled": false,
-            "strictCompatibility": false,
-            "syncGUID": "L3vNFuFgQJ4m",
+            "sourceURI": "https://www.eff.org/files/https-everywhere-latest.xpi",
+            "startupData": null,
+            "strictCompatibility": true,
+            "targetPlatforms": [],
             "type": "extension",
-            "updateDate": 1451269062000,
+            "updateDate": 1559865340000,
             "userDisabled": false,
             "visible": true
         }
-    ],
-    "schemaVersion": 17
+    ]
 }


### PR DESCRIPTION
standards.  Fixes test installation breaking in Firefox 67+.