### PR TITLE
Scale the popup window to device width

### DIFF
--- a/chromium/pages/popup/index.html
+++ b/chromium/pages/popup/index.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title data-i18n="about_ext_name"></title>
 
     <link href="style.css" rel="stylesheet">


### PR DESCRIPTION
This change makes the popup scale better on [Firefox for Android](https://www.mozilla.org/firefox/mobile/).

Screenshots [before](https://user-images.githubusercontent.com/1102886/59396221-ff030480-8d87-11e9-9514-581ea059e03f.jpeg) and [after](https://user-images.githubusercontent.com/1102886/59396511-6cfbfb80-8d89-11e9-8823-ed3e74130b0a.jpeg).