### PR TITLE
fixes #18103

### DIFF
--- a/utils/android-push.sh
+++ b/utils/android-push.sh
@@ -20,7 +20,7 @@ if type adb > /dev/null 2>/dev/null ; then
     we_started_adb_daemon=0
   fi
   on_exit() {
-    if test "0$we_started_adb_daemon" == "01"; then
+    if test "$we_started_adb_daemon" == "1"; then
       #if we started it we kill it, to avoid constant dmesg PME# spam, see issue 18103
       adb kill-server
     fi

--- a/utils/android-push.sh
+++ b/utils/android-push.sh
@@ -11,15 +11,32 @@ fi
 
 # Push to Android Firefox if device is connected
 # XXX on some systems, adb may require sudo...
-if type adb > /dev/null 2>/dev/null && adb devices >/dev/null 2>/dev/null ; then
-  ADB_FOUND=`adb devices | grep -v 'offline$' | tail -2 | head -1 | cut -f 1 | sed 's/ *$//g'`
-  if [ "$ADB_FOUND" != "List of devices attached" ]; then
-    echo Pushing "$XPI_NAME" to /sdcard/"$XPI_NAME"
-    adb push "../$XPI_NAME" /sdcard/"$XPI_NAME"
-    adb shell am start -a android.intent.action.VIEW \
-                       -c android.intent.category.DEFAULT \
-                       -d file:///mnt/sdcard/pkg/ \
-                       -n $ANDROID_APP_ID/.App
+if type adb > /dev/null 2>/dev/null ; then
+  #running `adb devices` below will start adb server/daemon if it wasn't running already
+  #we start it and make note if it's us that started it or not, so we can stop it afterwards
+  if adb start-server 2>&1 |grep -qF 'daemon not running' ; then
+    we_started_adb_daemon=1
+  else
+    we_started_adb_daemon=0
+  fi
+  on_exit() {
+    if test "0$we_started_adb_daemon" == "01"; then
+      #if we started it we kill it, to avoid constant dmesg PME# spam, see issue 18103
+      adb kill-server
+    fi
+  }
+  trap on_exit EXIT SIGINT
+
+  if adb devices >/dev/null 2>/dev/null ; then
+    ADB_FOUND=`adb devices | grep -v 'offline$' | tail -2 | head -1 | cut -f 1 | sed 's/ *$//g'`
+    if [ "$ADB_FOUND" != "List of devices attached" ]; then
+      echo Pushing "$XPI_NAME" to /sdcard/"$XPI_NAME"
+      adb push "../$XPI_NAME" /sdcard/"$XPI_NAME"
+      adb shell am start -a android.intent.action.VIEW \
+                         -c android.intent.category.DEFAULT \
+                         -d file:///mnt/sdcard/pkg/ \
+                         -n $ANDROID_APP_ID/.App
+    fi
   fi
 fi
 


### PR DESCRIPTION
Killing `adb` server(aka daemon) prevents seeing groups of these messages
on `dmesg` every second:
```
[ 1460.763742] pcieport 0000:00:1c.4: restoring config space at offset 0x2c (was 0x0, writing 0x0)
[ 1460.763748] pcieport 0000:00:1c.4: restoring config space at offset 0x28 (was 0x0, writing 0x0)
[ 1460.763752] pcieport 0000:00:1c.4: restoring config space at offset 0x24 (was 0x1fff1, writing 0x1fff1)
[ 1460.763813] pcieport 0000:00:1c.4: PME# disabled
[ 1460.763920] xhci_hcd 0000:03:00.0: PME# disabled
[ 1460.763928] xhci_hcd 0000:03:00.0: enabling bus mastering
[ 1460.770239] xhci_hcd 0000:03:00.0: PME# enabled
[ 1460.770377] xhci_hcd 0000:03:00.0: PME# disabled
[ 1460.770383] xhci_hcd 0000:03:00.0: enabling bus mastering
[ 1460.884813] xhci_hcd 0000:03:00.0: PME# enabled
[ 1460.884925] pcieport 0000:00:1c.4: PME# enabled
```

safety bonus: we only kill it if we started it.

issue is here: https://github.com/EFForg/https-everywhere/issues/18103