### PR TITLE
Making the options and cancel pages more mobile friendly

### DIFF
--- a/chromium/pages/cancel/index.html
+++ b/chromium/pages/cancel/index.html
@@ -2,6 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=.6">
     <meta http-equiv="Content-Style-Type" content="text/css" />
     <title>⚠ HTTPS Everywhere ⚠</title>
     <style type="text/css">code{white-space: pre;}</style>

--- a/chromium/pages/cancel/style.css
+++ b/chromium/pages/cancel/style.css
@@ -20,6 +20,12 @@ form, button, p{
   line-height: 150%;
 }
 
+@media screen and (max-width: 800px) {
+  form, button, p{
+    font-size: 17pt;
+  }
+}
+
 form{
   overflow: auto;
   margin-bottom: 1em;

--- a/chromium/pages/options/index.html
+++ b/chromium/pages/options/index.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=.8">
     <title></title>
     <link href="style.css" rel="stylesheet">
   </head>

--- a/chromium/pages/options/style.css
+++ b/chromium/pages/options/style.css
@@ -3,6 +3,18 @@ body{
   display: block;
 }
 
+a.settings{
+	background-color: #1c87c9;
+	border: none;
+	color: white;
+	padding: 20px 34px;
+	text-align: center;
+	text-decoration: none;
+	display: inline-block;
+	font-size: 20px;
+	margin: 4px 2px;
+}
+
 .settings-wrapper{
   margin: 10px 0 0 0;
 }

--- a/chromium/pages/options/ux.js
+++ b/chromium/pages/options/ux.js
@@ -5,6 +5,20 @@
 
 "use strict";
 
+if (~navigator.userAgent.indexOf("Android")) {
+  const url = new URL(window.location.href);
+  if (!url.searchParams.get('redirected')) {
+    url.searchParams.set('redirected', true);
+    document.body.innerText = "";
+    let link = document.createElement("a");
+    link.href = url.href;
+    link.target = "_blank";
+    link.className = "settings";
+    link.innerText = chrome.i18n.getMessage("options_settings");
+    document.body.appendChild(link);
+  }
+}
+
 document.addEventListener("DOMContentLoaded", () => {
   const secretArea = document.getElementById('secretArea')
 

--- a/chromium/pages/options/ux.js
+++ b/chromium/pages/options/ux.js
@@ -5,7 +5,7 @@
 
 "use strict";
 
-if (~navigator.userAgent.indexOf("Android")) {
+if (navigator.userAgent.includes("Android")) {
   const url = new URL(window.location.href);
   if (!url.searchParams.get('redirected')) {
     url.searchParams.set('redirected', true);

--- a/src/chrome/locale/en/https-everywhere.dtd
+++ b/src/chrome/locale/en/https-everywhere.dtd
@@ -19,6 +19,7 @@
 <!ENTITY https-everywhere.menu.showCounter "Show Counter">
 <!ENTITY https-everywhere.menu.viewAllRules "View All Rules">
 
+<!ENTITY https-everywhere.options.settings "Settings">
 <!ENTITY https-everywhere.options.generalSettings "General Settings">
 <!ENTITY https-everywhere.options.advancedSettings "Advanced Settings">
 <!ENTITY https-everywhere.options.updateChannels "Update Channels">


### PR DESCRIPTION
The options page in Firefox for Android looks weird, and opening it in a new tab looks much better.  We could do this with `"open_in_tab": true` in `manifest.json`, but opening the options page in a separate tab in desktop also looks a bit weird.  Thus the slightly hacky "Settings" link.