### PR TITLE
Update Github-Pages.xml

### DIFF
--- a/src/chrome/content/rules/Github-Pages.xml
+++ b/src/chrome/content/rules/Github-Pages.xml
@@ -16,6 +16,7 @@
 		<test url="http://duckietv.github.io/DuckieTV/" />
 
 	<exclusion pattern="^http://googletrends\.github\.io/iframe-scaffolder/?" />
+		<test url="http://googletrends.github.io/iframe-scaffolder" />
 		<test url="http://googletrends.github.io/iframe-scaffolder/" />
 
 	<exclusion pattern="^http://schizoduckie\.github\.io/DuckieTorrent/?" />

--- a/src/chrome/content/rules/Github-Pages.xml
+++ b/src/chrome/content/rules/Github-Pages.xml
@@ -15,11 +15,6 @@
 		<test url="http://duckietv.github.io/DuckieTV" />
 		<test url="http://duckietv.github.io/DuckieTV/" />
 
-	<!-- See https://github.com/EFForg/https-everywhere/issues/2507 -->
-	<exclusion pattern="^http://googletrends\.github\.io/(GOPDebate1|iframe-scaffolder)/" />
-		<test url="http://googletrends.github.io/GOPDebate1/" />
-		<test url="http://googletrends.github.io/iframe-scaffolder/" />
-
 	<exclusion pattern="^http://schizoduckie\.github\.io/DuckieTorrent/?" />
 	<exclusion pattern="^http://schizoduckie\.github\.io/PimpMyuTorrent/?" />
 		<test url="http://schizoduckie.github.io/DuckieTorrent" />

--- a/src/chrome/content/rules/Github-Pages.xml
+++ b/src/chrome/content/rules/Github-Pages.xml
@@ -15,7 +15,7 @@
 		<test url="http://duckietv.github.io/DuckieTV" />
 		<test url="http://duckietv.github.io/DuckieTV/" />
 
-	<exclusion pattern="^http://googletrends\.github\.io/iframe-scaffolder/?" />
+	<exclusion pattern="^http://googletrends\.github\.io/iframe-scaffolder" />
 		<test url="http://googletrends.github.io/iframe-scaffolder" />
 		<test url="http://googletrends.github.io/iframe-scaffolder/" />
 

--- a/src/chrome/content/rules/Github-Pages.xml
+++ b/src/chrome/content/rules/Github-Pages.xml
@@ -15,6 +15,9 @@
 		<test url="http://duckietv.github.io/DuckieTV" />
 		<test url="http://duckietv.github.io/DuckieTV/" />
 
+	<exclusion pattern="^http://googletrends\.github\.io/iframe-scaffolder/?" />
+		<test url="http://googletrends.github.io/iframe-scaffolder/" />
+
 	<exclusion pattern="^http://schizoduckie\.github\.io/DuckieTorrent/?" />
 	<exclusion pattern="^http://schizoduckie\.github\.io/PimpMyuTorrent/?" />
 		<test url="http://schizoduckie.github.io/DuckieTorrent" />


### PR DESCRIPTION
googletrends.github.io/GOPDebate1 returns 404, and i don't get any mixed content warning with the other googletrends page