### PR TITLE
Update hko.gov.hk.xml to include weather.gov.hk

### DIFF
--- a/src/chrome/content/rules/hko.gov.hk.xml
+++ b/src/chrome/content/rules/hko.gov.hk.xml
@@ -19,6 +19,10 @@
 	<target host="elderly.hko.gov.hk" />
 	<target host="maps.hko.gov.hk" />
 	<target host="my.hko.gov.hk" />
+	<target host="www.weather.gov.hk" />
+	<target host="elderly.weather.gov.hk" />
+	<target host="maps.weather.gov.hk" />
+	<target host="my.weather.gov.hk" />
 
 	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/hko.gov.hk.xml
+++ b/src/chrome/content/rules/hko.gov.hk.xml
@@ -20,7 +20,11 @@
 	<target host="maps.hko.gov.hk" />
 	<target host="my.hko.gov.hk" />
 	<target host="www.weather.gov.hk" />
+	<target host="data.weather.gov.hk" />
 	<target host="elderly.weather.gov.hk" />
+	<target host="gb.weather.gov.hk" />
+	<target host="gowise2.weather.gov.hk" />
+	<target host="kids.weather.gov.hk" />
 	<target host="maps.weather.gov.hk" />
 	<target host="my.weather.gov.hk" />
 


### PR DESCRIPTION
Most webpages from Hong Kong Observatory are available under the alternative domain `weather.gov.hk`. Note that there is no `avrdp` subdomain under `weather.gov.hk`.