### PR TITLE
Update CUHK.xml

### DIFF
--- a/src/chrome/content/rules/CUHK.xml
+++ b/src/chrome/content/rules/CUHK.xml
@@ -10,8 +10,6 @@ Fetch error: http://webmail.ie.cuhk.edu.hk/ => https://webmail.ie.cuhk.edu.hk/: 
 	Problematic domains:
 
 		- www.50.cuhk.edu.hk¹
-		- humanum.arts.cuhk.edu.hk¹
-		- www.arts.cuhk.edu.hk¹
 		- alumni.baf.cuhk.edu.hk¹
 		- alumnidb.baf.cuhk.edu.hk¹
 		- embachinese.baf.cuhk.edu.hk¹
@@ -131,6 +129,8 @@ Fetch error: http://webmail.ie.cuhk.edu.hk/ => https://webmail.ie.cuhk.edu.hk/: 
 
 	<target host="www.adm.cuhk.edu.hk" />
 	<target host="www.aic.cuhk.edu.hk" />
+	<target host="www.arts.cuhk.edu.hk" />
+	<target host="humanum.arts.cuhk.edu.hk" />
 	<target host="www.cintec.cuhk.edu.hk" />
 	<target host="www.cpr.cuhk.edu.hk" />
 	<target host="cusis.cuhk.edu.hk" />
@@ -142,6 +142,7 @@ Fetch error: http://webmail.ie.cuhk.edu.hk/ => https://webmail.ie.cuhk.edu.hk/: 
 	<target host="star.erg.cuhk.edu.hk" />
 	<target host="www.erg.cuhk.edu.hk" />
 	<target host="www2.erg.cuhk.edu.hk" />
+	<target host="www.fed.cuhk.edu.hk" />
 	<target host="www.gradsch.cuhk.edu.hk" />
 	<target host="ewebmail.ie.cuhk.edu.hk" />
 	<target host="home.ie.cuhk.edu.hk" />


### PR DESCRIPTION
`www.arts.cuhk.edu.hk` and `humanum.arts.cuhk.edu.hk` now have valid certificates.
`www.fed.cuhk.edu.hk` can be accessed using HTTPS.