### PR TITLE
Upgrade readdirp to 2.0.1 to Fix Vulnerability

### DIFF
--- a/utils/rewriter/package.json
+++ b/utils/rewriter/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "event-stream": "3.0.20",
-    "readdirp": "0.3.2",
+    "readdirp": "2.0.1",
     "urijs": "^1.18.1",
     "xmldom": "0.1.17"
   }


### PR DESCRIPTION
This fixes a [ReDoS vulnerability found by Snyk](https://app.snyk.io/test/npm/readdirp/0.3.2).