### PR TITLE
Update Experian.xml

### DIFF
--- a/src/chrome/content/rules/Experian.xml
+++ b/src/chrome/content/rules/Experian.xml
@@ -6,27 +6,13 @@
 		- Chtah.net.xml
 		- Fagms.net.xml
 
-
-	Problematic domains:
-
-		- experian.com		(cert only matches www)
-
 -->
-<ruleset name="Experian">
+<ruleset name="Experian (partial)">
 
 	<target host="experian.com" />
 	<target host="www.experian.com" />
 	<target host="experian.experiandirect.com" />
-	<target host="*.experian.experiandirect.com" />
 
-
-	<securecookie host="^\.?experian\.experiandirect\.com$" name=".+" />
-
-
-	<rule from="^http://(?:www\.)?experian\.com/"
-		to="https://www.experian.com/" />
-
-	<rule from="^http://experian\.experiandirect\.com/"
-		to="https://experian.experiandirect.com/" />
+	<rule from="^http:" to="https:" />
 
 </ruleset>


### PR DESCRIPTION
It seems that this site is broken regardless to the present of HTTS Everywhere on Firefox. I am open to delete this ruleset completely. #17965 

```
[WARN] Experian.xml: ruleset contains targets *.experian.experiandirect.com not applied to any rewrites
```