### PR TITLE
Update pinboard.in ruleset

### DIFF
--- a/src/chrome/content/rules/Pinboard.xml
+++ b/src/chrome/content/rules/Pinboard.xml
@@ -1,8 +1,5 @@
 
 <!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://blog.pinboard.in/ => https://blog.pinboard.in/: (60, 'SSL certificate problem: unable to get local issuer certificate')
-
 	Fully covered subdomains:
 
 		- (www.)
@@ -11,7 +8,7 @@ Fetch error: http://blog.pinboard.in/ => https://blog.pinboard.in/: (60, 'SSL ce
 		- static
 
 -->
-<ruleset name="Pinboard.in" default_off="failed ruleset test">
+<ruleset name="Pinboard.in">
 
 	<target host="pinboard.in" />
 	<target host="blog.pinboard.in" />


### PR DESCRIPTION
This ruleset was disabled due to an SSL certificate problem on
blog.pinboard.in. The problem no longer exists, so enable the ruleset.