### PR TITLE
Re-enable da.gd

### DIFF
--- a/src/chrome/content/rules/Da.gd.xml
+++ b/src/chrome/content/rules/Da.gd.xml
@@ -1,11 +1,4 @@
-
-<!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://6.da.gd/ => https://6.da.gd/: (7, '')
-Fetch error: http://ipv6.da.gd/ => https://ipv6.da.gd/: (7, '')
-
--->
-<ruleset name="Da.gd" default_off="failed ruleset test">
+<ruleset name="Da.gd">
 	<target host="da.gd" />
 	<target host="www.da.gd" />
 	<target host="4.da.gd" />


### PR DESCRIPTION
The ruleset for da.gd was disabled in commit https://github.com/EFForg/https-everywhere/commit/9bf49cbeb4696cdea76df23f685da1d11031f693. This site works over IPv6 without issue.