### PR TITLE
Create Japanese-Communist-Party.xml

### DIFF
--- a/src/chrome/content/rules/Japanese-Communist-Party.xml
+++ b/src/chrome/content/rules/Japanese-Communist-Party.xml
@@ -1,6 +1,7 @@
 <!--
 	Mismatched:
 		- ^ (jcp.or.jp)
+		- hd
 -->
 <ruleset name="Japanese Communist Party">
 	<target host="www.jcp.or.jp" />

--- a/src/chrome/content/rules/Japanese-Communist-Party.xml
+++ b/src/chrome/content/rules/Japanese-Communist-Party.xml
@@ -1,0 +1,9 @@
+<!--
+	Mismatched:
+		- ^ (jcp.or.jp)
+-->
+<ruleset name="Japanese Communist Party">
+	<target host="www.jcp.or.jp" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/Japanese-Communist-Party.xml
+++ b/src/chrome/content/rules/Japanese-Communist-Party.xml
@@ -9,6 +9,6 @@
 	<target host="jcp.or.jp" />
 	<target host="www.jcp.or.jp" />
 
-	<rule from="^(http|https)://jcp\.or\.jp/" to="https://www.jcp.or.jp/" />
+	<rule from="^http://jcp\.or\.jp/" to="https://www.jcp.or.jp/" />
 	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Japanese-Communist-Party.xml
+++ b/src/chrome/content/rules/Japanese-Communist-Party.xml
@@ -1,10 +1,14 @@
 <!--
 	Mismatched:
-		- ^ (jcp.or.jp)
 		- hd
+		- mail
+		- ptv
+		- www.ptv
 -->
 <ruleset name="Japanese Communist Party">
+	<target host="jcp.or.jp" />
 	<target host="www.jcp.or.jp" />
 
+	<rule from="^(http|https)://jcp\.or\.jp/" to="https://www.jcp.or.jp/" />
 	<rule from="^http:" to="https:" />
 </ruleset>


### PR DESCRIPTION
#### Non-working hosts
##### Invalid certificate
```
jcp.or.jp
hd.jcp.or.jp
```
##### 403 Forbidden (even on HTTP)
```
admin.jcp.or.jp
ftp.jcp.or.jp [1]
mail.jcp.or.jp
pop.jcp.or.jp [1]
pop3.jcp.or.jp [1]
ptv.jcp.or.jp
www.ptv.jcp.or.jp
admin.ptv.jcp.or.jp
ftp.ptv.jcp.or.jp [1]
mail.ptv.jcp.or.jp
pop.ptv.jcp.or.jp [1]
pop3.ptv.jcp.or.jp [1]
smtp.ptv.jcp.or.jp [1]
smtp.jcp.or.jp [1]

[1] Apparently these domains are not used for web hosting - they are likely to be used for Email (POP/SMTP) or FTP.
```
##### "File not found" error, unable to find any valid URL to test
`live.jcp.or.jp`