### PR TITLE
Update CUHK.xml

### DIFF
--- a/src/chrome/content/rules/CUHK.xml
+++ b/src/chrome/content/rules/CUHK.xml
@@ -1,11 +1,5 @@
 
 <!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://www.ee.cuhk.edu.hk/ => https://www.ee.cuhk.edu.hk/: (7, 'Failed to connect to www.ee.cuhk.edu.hk port 443: No route to host')
-Fetch error: http://home.ie.cuhk.edu.hk/ => https://home.ie.cuhk.edu.hk/: (51, "SSL: no alternative certificate subject name matches target host name 'home.ie.cuhk.edu.hk'")
-Fetch error: http://iest2.ie.cuhk.edu.hk/ => https://iest2.ie.cuhk.edu.hk/: (51, "SSL: no alternative certificate subject name matches target host name 'iest2.ie.cuhk.edu.hk'")
-Fetch error: http://personal.ie.cuhk.edu.hk/ => https://personal.ie.cuhk.edu.hk/: (51, "SSL: no alternative certificate subject name matches target host name 'personal.ie.cuhk.edu.hk'")
-Fetch error: http://webmail.ie.cuhk.edu.hk/ => https://webmail.ie.cuhk.edu.hk/: (51, "SSL: no alternative certificate subject name matches target host name 'webmail.ie.cuhk.edu.hk'")
 
 	Problematic domains:
 
@@ -32,6 +26,7 @@ Fetch error: http://webmail.ie.cuhk.edu.hk/ => https://webmail.ie.cuhk.edu.hk/: 
 		- msc.cse.cuhk.edu.hk¹
 		- www.cse.cuhk.edu.hk¹
 		- www.cwchu.cuhk.edu.hk¹
+		- www.ee.cuhk.edu.hk¹
 		- calendar.ee.cuhk.edu.hk¹
 		- dept.ee.cuhk.edu.hk¹
 		- ivp.ee.cuhk.edu.hk¹
@@ -52,6 +47,7 @@ Fetch error: http://webmail.ie.cuhk.edu.hk/ => https://webmail.ie.cuhk.edu.hk/: 
 		- course.ie.cuhk.edu.hk¹
 		- cscit.ie.cuhk.edu.hk⁴
 		- hii.ie.cuhk.edu.hk⁴
+		- iest2.ie.cuhk.edu.hk¹
 		- isc14.ie.cuhk.edu.hk⁴
 		- jianwei.ie.cuhk.edu.hk⁴
 		- mmlab.ie.cuhk.edu.hk⁴
@@ -60,6 +56,7 @@ Fetch error: http://webmail.ie.cuhk.edu.hk/ => https://webmail.ie.cuhk.edu.hk/: 
 		- s25.ierg4210.ie.cuhk.edu.hk¹
 		- snsapi.ie.cuhk.edu.hk¹
 		- ssl.ie.cuhk.edu.hk⁴
+		- webmail.ie.cuhk.edu.hk¹
 		- wireless.ie.cuhk.edu.hk⁴
 		- www.igef.cuhk.edu.hk¹
 		- www.itcsc.cuhk.edu.hk¹
@@ -122,7 +119,7 @@ Fetch error: http://webmail.ie.cuhk.edu.hk/ => https://webmail.ie.cuhk.edu.hk/: 
 	⁵: Timeout
 
 -->
-<ruleset name="The Chinese University of Hong Kong" default_off="failed ruleset test">
+<ruleset name="The Chinese University of Hong Kong">
 
 	<target host="www.cuhk.edu.hk" />
 	<target host="www6.cuhk.edu.hk" />

--- a/src/chrome/content/rules/CUHK.xml
+++ b/src/chrome/content/rules/CUHK.xml
@@ -5,6 +5,7 @@
 
 		- www.50.cuhk.edu.hk¹
 		- www.adm.cuhk.edu.hk¹
+		- nweb.adm.cuhk.edu.hk⁶
 		- alumni.baf.cuhk.edu.hk¹
 		- alumnidb.baf.cuhk.edu.hk¹
 		- embachinese.baf.cuhk.edu.hk¹
@@ -88,6 +89,7 @@
 		- cns.mect.cuhk.edu.hk¹
 		- wellness.mect.cuhk.edu.hk¹
 		- www.mect.cuhk.edu.hk¹
+		- internet.mfpo.cuhk.edu.hk⁶
 		- www.morningside.cuhk.edu.hk¹
 		- www.na.cuhk.edu.hk¹
 		- www.oafa.cuhk.edu.hk (connection refused)
@@ -130,13 +132,13 @@
 	³: Redirects to HTTP
 	⁴: Different content in HTTP and HTTPS
 	⁵: Timeout
+	⁶: Travis problem - unable to get local issuer certificate
 
 -->
 <ruleset name="The Chinese University of Hong Kong">
 
 	<target host="www.cuhk.edu.hk" />
 
-	<target host="nweb.adm.cuhk.edu.hk" />
 	<target host="www.aic.cuhk.edu.hk" />
 	<target host="www.arts.cuhk.edu.hk" />
 	<target host="humanum.arts.cuhk.edu.hk" />
@@ -176,7 +178,6 @@
 	<target host="pcp.med.cuhk.edu.hk" />
 	<target host="webapps.med.cuhk.edu.hk" />
 	<target host="cog.mect.cuhk.edu.hk" />
-	<target host="internet.mfpo.cuhk.edu.hk" />
 	<target host="www.oia.cuhk.edu.hk" />
 	<target host="onepass.cuhk.edu.hk" />
 	<target host="www.orkts.cuhk.edu.hk" />

--- a/src/chrome/content/rules/CUHK.xml
+++ b/src/chrome/content/rules/CUHK.xml
@@ -4,6 +4,7 @@
 	Problematic domains:
 
 		- www.50.cuhk.edu.hk¹
+		- www.adm.cuhk.edu.hk¹
 		- alumni.baf.cuhk.edu.hk¹
 		- alumnidb.baf.cuhk.edu.hk¹
 		- embachinese.baf.cuhk.edu.hk¹
@@ -25,6 +26,7 @@
 		- www.crec.cuhk.edu.hk¹
 		- msc.cse.cuhk.edu.hk¹
 		- www.cse.cuhk.edu.hk¹
+		- cusis.cuhk.edu.hk¹
 		- www.cwchu.cuhk.edu.hk¹
 		- www.ee.cuhk.edu.hk¹
 		- calendar.ee.cuhk.edu.hk¹
@@ -59,19 +61,25 @@
 		- webmail.ie.cuhk.edu.hk¹
 		- wireless.ie.cuhk.edu.hk⁴
 		- www.igef.cuhk.edu.hk¹
+		- ilcnte.ilc.cuhk.edu.hk¹
 		- www.itcsc.cuhk.edu.hk¹
 		- itunes.cuhk.edu.hk¹
+		- cai.itsc.cuhk.edu.hk¹
 		- epss.itsc.cuhk.edu.hk¹
 		- helpdesk.itsc.cuhk.edu.hk¹
 		- hkhiso.itsc.cuhk.edu.hk¹
 		- servicedesk.itsc.cuhk.edu.hk¹
+		- webconf2.itsc.cuhk.edu.hk⁵
 		- wms.itsc.cuhk.edu.hk¹
 		- www.itsc.cuhk.edu.hk¹
 		- www.lasec.cuhk.edu.hk¹
 		- dspace.lib.cuhk.edu.hk¹
 		- easysearch.lib.cuhk.edu.hk³
+		- iii.lib.cuhk.edu.hk⁵
 		- libanswers.lib.cuhk.edu.hk¹
 		- libguides.lib.cuhk.edu.hk¹
+		- my.lib.cuhk.edu.hk⁵
+		- library.cuhk.edu.hk¹
 		- logitsco.cuhk.edu.hk¹
 		- www.logitsco.cuhk.edu.hk¹
 		- epymt.math.cuhk.edu.hk¹
@@ -82,15 +90,18 @@
 		- www.mect.cuhk.edu.hk¹
 		- www.morningside.cuhk.edu.hk¹
 		- www.na.cuhk.edu.hk¹
+		- www.oafa.cuhk.edu.hk (connection refused)
 		- www.oal.cuhk.edu.hk¹
-		- pdc.obg.cuhk.edu.hk¹
 		- www.obg.cuhk.edu.hk³
+		- department.obg.cuhk.edu.hk¹
+		- pdc.obg.cuhk.edu.hk¹
 		- cpdc.osa.cuhk.edu.hk¹
 		- sams.osa.cuhk.edu.hk¹
 		- www.osa.cuhk.edu.hk¹
 		- www.osp.cuhk.edu.hk¹
 		- ug.pharmacy.cuhk.edu.hk¹
 		- www.pharmacy.cuhk.edu.hk⁵
+		- portal.cuhk.edu.hk¹
 		- www.provost.cuhk.edu.hk¹
 		- biomedsci.sbs.cuhk.edu.hk¹
 		- www.scs.cuhk.edu.hk²
@@ -106,11 +117,13 @@
 		- www.uc.cuhk.edu.hk¹
 		- www.udean.cuhk.edu.hk¹
 		- www.urbanstudies.cuhk.edu.hk¹
+		- www.vco.cuhk.edu.hk¹
 		- www.ws.cuhk.edu.hk¹
 		- www.wys.cuhk.edu.hk¹
 		- www3.cuhk.edu.hk¹
 		- www4.cuhk.edu.hk¹
 		- www5.cuhk.edu.hk¹
+		- www6.cuhk.edu.hk¹
 
 	¹: Invalid cert
 	²: Mixed content
@@ -122,15 +135,13 @@
 <ruleset name="The Chinese University of Hong Kong">
 
 	<target host="www.cuhk.edu.hk" />
-	<target host="www6.cuhk.edu.hk" />
 
-	<target host="www.adm.cuhk.edu.hk" />
+	<target host="nweb.adm.cuhk.edu.hk" />
 	<target host="www.aic.cuhk.edu.hk" />
 	<target host="www.arts.cuhk.edu.hk" />
 	<target host="humanum.arts.cuhk.edu.hk" />
 	<target host="www.cintec.cuhk.edu.hk" />
 	<target host="www.cpr.cuhk.edu.hk" />
-	<target host="cusis.cuhk.edu.hk" />
 	<target host="veriguide1.cse.cuhk.edu.hk" />
 	<target host="veriguide4.cse.cuhk.edu.hk" />
 	<target host="elearn.cuhk.edu.hk" />
@@ -145,27 +156,20 @@
 	<target host="personal.ie.cuhk.edu.hk" />
 	<target host="staff.ie.cuhk.edu.hk" />
 	<target host="www.ie.cuhk.edu.hk" />
-	<target host="ilcnte.ilc.cuhk.edu.hk" />
 	<target host="www.ilc.cuhk.edu.hk" />
 	<target host="www.iso.cuhk.edu.hk" />
 	<target host="apps.itsc.cuhk.edu.hk" />
-	<target host="cai.itsc.cuhk.edu.hk" />
 	<target host="campusapps.itsc.cuhk.edu.hk" />
 	<target host="cloud.itsc.cuhk.edu.hk" />
 	<target host="cumassmail.itsc.cuhk.edu.hk" />
 	<target host="gradsrv.itsc.cuhk.edu.hk" />
 	<target host="oiss.itsc.cuhk.edu.hk" />
-	<target host="training.itsc.cuhk.edu.hk" />
 	<target host="webapp.itsc.cuhk.edu.hk" />
-	<target host="webconf2.itsc.cuhk.edu.hk" />
 	<target host="wifipartners.itsc.cuhk.edu.hk" />
 	<target host="alumni.law.cuhk.edu.hk" />
 	<target host="webapp1.law.cuhk.edu.hk" />
-	<target host="iii.lib.cuhk.edu.hk" />
 	<target host="illiad.lib.cuhk.edu.hk" />
-	<target host="my.lib.cuhk.edu.hk" />
 	<target host="rbs.lib.cuhk.edu.hk" />
-	<target host="library.cuhk.edu.hk" />
 	<target host="www.lihs.cuhk.edu.hk" />
 	<target host="hlma.math.cuhk.edu.hk" />
 	<target host="www.math.cuhk.edu.hk" />
@@ -173,25 +177,18 @@
 	<target host="webapps.med.cuhk.edu.hk" />
 	<target host="cog.mect.cuhk.edu.hk" />
 	<target host="internet.mfpo.cuhk.edu.hk" />
-	<target host="www.oafa.cuhk.edu.hk" />
-	<target host="department.obg.cuhk.edu.hk" />
 	<target host="www.oia.cuhk.edu.hk" />
 	<target host="onepass.cuhk.edu.hk" />
 	<target host="www.orkts.cuhk.edu.hk" />
-	<target host="osantd.osa.cuhk.edu.hk" />
 	<target host="www2.osa.cuhk.edu.hk" />
-	<target host="adm.osp.cuhk.edu.hk" />
 	<target host="www.per.cuhk.edu.hk" />
 	<target host="www2.per.cuhk.edu.hk" />
-	<target host="portal.cuhk.edu.hk" />
 	<target host="eshop.rct.cuhk.edu.hk" />
 	<target host="rgsntl.rgs.cuhk.edu.hk" />
 	<target host="webmail.se.cuhk.edu.hk" />
-	<target host="www.sitc.cuhk.edu.hk" />
 	<target host="sts.cuhk.edu.hk" />
 	<target host="www.surgery.cuhk.edu.hk" />
 	<target host="timetable4.cuhk.edu.hk" />
-	<target host="www.vco.cuhk.edu.hk" />
 
 	<!-- to prevent redirect loop on main pages -->
 		<exclusion pattern="^http://www\.cuhk\.edu\.hk/(chinese|english)/(?!css/|fonts/|images|js/)" />

--- a/src/chrome/content/rules/CUHK.xml
+++ b/src/chrome/content/rules/CUHK.xml
@@ -134,7 +134,6 @@
 	<target host="veriguide1.cse.cuhk.edu.hk" />
 	<target host="veriguide4.cse.cuhk.edu.hk" />
 	<target host="elearn.cuhk.edu.hk" />
-	<target host="www.ee.cuhk.edu.hk" />
 	<target host="info5.erg.cuhk.edu.hk" />
 	<target host="star.erg.cuhk.edu.hk" />
 	<target host="www.erg.cuhk.edu.hk" />
@@ -143,10 +142,8 @@
 	<target host="www.gradsch.cuhk.edu.hk" />
 	<target host="ewebmail.ie.cuhk.edu.hk" />
 	<target host="home.ie.cuhk.edu.hk" />
-	<target host="iest2.ie.cuhk.edu.hk" />
 	<target host="personal.ie.cuhk.edu.hk" />
 	<target host="staff.ie.cuhk.edu.hk" />
-	<target host="webmail.ie.cuhk.edu.hk" />
 	<target host="www.ie.cuhk.edu.hk" />
 	<target host="ilcnte.ilc.cuhk.edu.hk" />
 	<target host="www.ilc.cuhk.edu.hk" />


### PR DESCRIPTION
Changes:
- Removed and documented non-working / non-existent hosts
- These domains seem to work fine under HTTPS:
  - `home.ie.cuhk.edu.hk`
  - `personal.ie.cuhk.edu.hk`
- Removed `default_off="failed ruleset test"`