### PR TITLE
Update acast.com (fixes bbc.co.uk podcast playback)

### DIFF
--- a/src/chrome/content/rules/acast.com.xml
+++ b/src/chrome/content/rules/acast.com.xml
@@ -16,11 +16,9 @@
 	<target host="flex.acast.com" />
 	<target host="media.acast.com" />
 	<target host="rss.acast.com" />
-	<target host="status.acast.com" />
 
 	<securecookie host=".+" name=".+" />
 
-	<rule from="^http://status\.acast\.com/" to="https://acast.statuspage.io/" />
 	<rule from="^http://acast\.com/" to="https://www.acast.com/" />
 	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/acast.com.xml
+++ b/src/chrome/content/rules/acast.com.xml
@@ -1,64 +1,26 @@
 <!--
-	CDN buckets:
+	Timeout:
+		- ^
 
-		- az801177.vo.msecnd.net
-		- acastprod.blob.core.windows.net
+	Mismatched:
+		- status
 
-
-	Problematic hosts in *acast.com:
-
-		- ^ ᵈ
-		- status ᵐ
-
-	ᵈ Dropped; preemptable redirect
-	ᵐ StatusPage.io/mismatched
-
-
-	Insecure cookies are set for these domains and hosts: ᶜ
-
-		- rss.acast.com
-		- .rss.acast.com
-
-	ᶜ See https://owasp.org/index.php/SecureFlag
-
+	HTTP != HTTPS (due to link signatures):
+		- stitcher
 -->
 <ruleset name="acast.com">
-
-	<!--	Direct rewrites:
-				-->
+	<target host="acast.com" />
+	<target host="www.acast.com" />
 	<target host="ads-creative-cdn.acast.com" />
 	<target host="embed.acast.com" />
+	<target host="flex.acast.com" />
 	<target host="media.acast.com" />
 	<target host="rss.acast.com" />
-	<target host="stitcher.acast.com" />
-	<target host="www.acast.com" />
-
-		<!--	Sets cookies without Secure:
-							-->
-		<!--test url="http://rss.acast.com/historyofthepapacy" /-->
-
-	<!--	Complications:
-				-->
-	<target host="acast.com" />
 	<target host="status.acast.com" />
 
+	<securecookie host=".+" name=".+" />
 
-	<!--	Not secured by server:
-					-->
-	<!--securecookie host="^rss\.acast\.com$" name="^acastRss$" /-->
-	<!--securecookie host="^\.rss\.acast\.com$" name="^TiPMix$" /-->
-
-	<securecookie host="^\.rss\." name=".+" />
-	<securecookie host="^\w" name=".+" />
-
-
-	<rule from="^http://acast\.com/"
-		to="https://www.acast.com/" />
-
-	<rule from="^http://status\.acast\.com/"
-		to="https://acast.statuspage.io/" />
-
-	<rule from="^http:"
-		to="https:" />
-
+	<rule from="^http://status\.acast\.com/" to="https://acast.statuspage.io/" />
+	<rule from="^http://acast\.com/" to="https://www.acast.com/" />
+	<rule from="^http:" to="https:" />
 </ruleset>


### PR DESCRIPTION
High priority since current ruleset breaks bbc.co.uk (Alexa rank 109).