### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 sudo: required
 os: linux
-dist: trusty
+dist: xenial
 language: python
 python: 3.6
 group: bionic
 services:
   - docker
+  - xvfb
 matrix:
   fast_finish: true
   include:
@@ -32,8 +33,5 @@ matrix:
     - addons:
         firefox: latest-esr
       env: TEST="firefox esr" BROWSER=firefox
-before_install:
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
 before_script: travis_retry test/setup_travis.sh
 script: . test/run_travis.sh


### PR DESCRIPTION
`trusty` reached its End of Standard Support in April 2019, we should update the Travis build distro from `trusty` to `xenial` if nothing breaks.

Ref: https://wiki.ubuntu.com/Releases