### PR TITLE
Upgrade travis ci distro from trusty to bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 sudo: required
 os: linux
-dist: trusty
+dist: bionic
 language: python
 python: 3.6
 group: bionic
 services:
   - docker
+  - xvfb
 matrix:
   fast_finish: true
   include:
@@ -32,8 +33,5 @@ matrix:
     - addons:
         firefox: latest-esr
       env: TEST="firefox esr" BROWSER=firefox
-before_install:
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
 before_script: travis_retry test/setup_travis.sh
 script: . test/run_travis.sh


### PR DESCRIPTION
Since `trusty` reached its End of Standard Support in April 2019 and the docker image we use for testing is `bionic`, it seems more sane and consistent to use `bionic` for the travis ci distro.

https://wiki.ubuntu.com/Releases 

Note: Travis fails for PRs because Google Chrome Beta does not install properly. It seems that this error does not affect `bionic` in this very PR.

```
Installing Google Chrome beta

1.07s$ wget --no-verbose -O /tmp/$(basename $CHROME_SOURCE_URL) $CHROME_SOURCE_URL

2019-09-02 12:29:01 URL:https://dl.google.com/dl/linux/direct/google-chrome-beta_current_amd64.deb [64064808/64064808] -> "/tmp/google-chrome-beta_current_amd64.deb" [1]

dpkg-deb: error: archive '/tmp/google-chrome-beta_current_amd64.deb' has premature member 'control.tar.xz' before 'control.tar.gz', giving up

dpkg: error processing archive /tmp/google-chrome-beta_current_amd64.deb (--install):

 subprocess dpkg-deb --control returned error exit status 2

Errors were encountered while processing:

 /tmp/google-chrome-beta_current_amd64.deb

```

cc @zoracon @Hainish 