### PR TITLE
Fix fetch test fails when response header cannot be utf-8 decoded

### DIFF
--- a/src/chrome/content/rules/eti.hket.com.xml
+++ b/src/chrome/content/rules/eti.hket.com.xml
@@ -1,8 +1,0 @@
-<!--
-	Note: this ruleset is for testing purpose, it will be removed afterward.
--->
-<ruleset name="eti.hket.com">
-	<target host="eti.hket.com" />
-	
-	<rule from="^http:" to="https:" />
-</ruleset>

--- a/src/chrome/content/rules/eti.hket.com.xml
+++ b/src/chrome/content/rules/eti.hket.com.xml
@@ -1,0 +1,8 @@
+<!--
+	Note: this ruleset is for testing purpose, it will be removed afterward.
+-->
+<ruleset name="eti.hket.com">
+	<target host="eti.hket.com" />
+	
+	<rule from="^http:" to="https:" />
+</ruleset>

--- a/test/rules/src/https_everywhere_checker/http_client.py
+++ b/test/rules/src/https_everywhere_checker/http_client.py
@@ -346,7 +346,7 @@ class HTTPFetcher(object):
             c.perform()
 
             bufValue = buf.getvalue()
-            headerStr = headerBuf.getvalue().decode('utf-8')
+            headerStr = headerBuf.getvalue().decode('utf-8', 'ignore')
             httpCode = c.getinfo(pycurl.HTTP_CODE)
         finally:
             buf.close()


### PR DESCRIPTION
When Travis performs the `fetch` test, it will throw an `UnicodeDecodeError` error when the response header cannot be utf-8 decoded. This can be shown in the Travis log, see https://travis-ci.org/EFForg/https-everywhere/jobs/581484797#L344.

The proposed fix is to change the encoding's rule to `ignore` (just leave the character out of the Unicode result). See https://docs.python.org/3/howto/unicode.html#the-string-type

cc @zoracon @Hainish 

### List related PRs if any

- #18385 

### List related issues if any

- issue link
