### PR TITLE
gegl.org: expired certificate

### DIFF
--- a/src/chrome/content/rules/Gegl.org.xml
+++ b/src/chrome/content/rules/Gegl.org.xml
@@ -2,7 +2,7 @@
 	Mismatched:
 		- ftp
 -->
-<ruleset name="Gegl.org">
+<ruleset name="Gegl.org" default_off="expired">
 	<target host="gegl.org" />
 	<target host="www.gegl.org" />
 


### PR DESCRIPTION
- <https://gegl.org/>
- <https://www.gegl.org/>
