### PR TITLE
Add ruleset for my-aime.net

### DIFF
--- a/src/chrome/content/rules/My-Aime.net.xml
+++ b/src/chrome/content/rules/My-Aime.net.xml
@@ -1,0 +1,11 @@
+<!--
+	Timeout:
+		- mx
+-->
+<ruleset name="My-Aime.net">
+	<target host="my-aime.net" />
+
+	<securecookie host=".+" name=".+" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>


### PR DESCRIPTION
Note: `my-aime.net` has HSTS for subdomains, but it isn't preloaded and it doesn't set secure cookies.