### PR TITLE
Fix redirect on feedback.ebay.co.uk

### DIFF
--- a/src/chrome/content/rules/ebay.co.uk.xml
+++ b/src/chrome/content/rules/ebay.co.uk.xml
@@ -326,6 +326,8 @@
 	<!-- fix http redirect -->
 	<rule from="^http://ebay\.co\.uk/"
 		to="https://www.ebay.co.uk/" />
+	<rule from="^http://feedback\.ebay\.co\.uk/"
+		to="https://feedback.ebay.co.uk/" />
 
 	<rule from="^http:"
 		to="https:" />


### PR DESCRIPTION
User was having an issue feedback not using/redirecting using https: 

https://community.brave.com/t/non-https-links-not-loading-pages/85838


1. `https://www.ebay.co.uk/itm/401786990949`
2. On the right-side, under Seller Information.
3. Click on the Seller number '54388'
4. `http://feedback.ebay.co.uk` is attempted.

Does this patch look okay?