### PR TITLE
Remove empty line at beginning of ruleset-whitelist.csv

### DIFF
--- a/utils/ruleset-whitelist.csv
+++ b/utils/ruleset-whitelist.csv
@@ -1,4 +1,3 @@
-
 hash,auto-pass coverage test,auto-pass fetch test,filename
 fbb2d56d33f886b53c314eac3446eed8bad7916660ad0709367936fe8335d987,0,1,112_Cafe.com.xml
 43a7a917b89600c8dd3495359879ad1dfe468d9a478e63d5bbc6430a31cc41c2,1,1,123-reg.xml


### PR DESCRIPTION
This empty line was introduced by #18351.