### PR TITLE
Fix WASM implementation missed wildcard targets, closes #18589

### DIFF
--- a/chromium/background-scripts/rules.js
+++ b/chromium/background-scripts/rules.js
@@ -562,42 +562,40 @@ RuleSets.prototype = {
     }
 
     let results;
-    let expressions = util.getWildcardExpressions(host);
 
     if (this.wasm_rs) {
-      for (const expression of expressions) {
-        let pa = this.wasm_rs.potentially_applicable(expression);
-        results = new Set([...pa].map(ruleset => {
-          let rs = new RuleSet(ruleset.name, ruleset.default_state, getScope(ruleset.scope), ruleset.note);
+      let pa = this.wasm_rs.potentially_applicable(host);
+      results = new Set([...pa].map(ruleset => {
+        let rs = new RuleSet(ruleset.name, ruleset.default_state, getScope(ruleset.scope), ruleset.note);
 
-          if (ruleset.cookierules) {
-            let cookierules = ruleset.cookierules.map(cookierule => {
-              return new CookieRule(cookierule.host, cookierule.name);
-            });
-            rs.cookierules = cookierules;
-          } else {
-            rs.cookierules = null;
-          }
-
-          let rules = ruleset.rules.map(rule => {
-            return getRule(rule.from, rule.to);
+        if (ruleset.cookierules) {
+          let cookierules = ruleset.cookierules.map(cookierule => {
+            return new CookieRule(cookierule.host, cookierule.name);
           });
-          rs.rules = rules;
+          rs.cookierules = cookierules;
+        } else {
+          rs.cookierules = null;
+        }
 
-          if (ruleset.exclusions) {
-            rs.exclusions = new RegExp(ruleset.exclusions);
-          } else {
-            rs.exclusions = null;
-          }
-          return rs;
-        }));
-      }
+        let rules = ruleset.rules.map(rule => {
+          return getRule(rule.from, rule.to);
+        });
+        rs.rules = rules;
+
+        if (ruleset.exclusions) {
+          rs.exclusions = new RegExp(ruleset.exclusions);
+        } else {
+          rs.exclusions = null;
+        }
+        return rs;
+      }));
     } else {
       // Let's begin search
       results = (this.targets.has(host) ?
         new Set([...this.targets.get(host)]) :
         new Set());
 
+      let expressions = util.getWildcardExpressions(host);
       for (const expression of expressions) {
         results = (this.targets.has(expression) ?
           new Set([...results, ...this.targets.get(expression)]) :

--- a/chromium/background-scripts/rules.js
+++ b/chromium/background-scripts/rules.js
@@ -13,19 +13,6 @@ let settings = {
 // To reduce memory usage for the numerous rules/cookies with trivial rules
 const trivial_cookie_rule_c = /.+/;
 
-// Empty iterable singleton to reduce memory usage
-const nullIterable = Object.create(null, {
-  [Symbol.iterator]: {
-    value: function* () {
-      // do nothing
-    }
-  },
-
-  size: {
-    value: 0
-  },
-});
-
 /* A map of all scope RegExp objects */
 const scopes = new Map();
 
@@ -575,66 +562,45 @@ RuleSets.prototype = {
     }
 
     let results;
+    let expressions = util.getWildcardExpressions(host);
+
     if (this.wasm_rs) {
-      let pa = this.wasm_rs.potentially_applicable(host);
-      results = new Set([...pa].map(ruleset => {
-        let rs = new RuleSet(ruleset.name, ruleset.default_state, getScope(ruleset.scope), ruleset.note);
+      for (const expression of expressions) {
+        let pa = this.wasm_rs.potentially_applicable(expression);
+        results = new Set([...pa].map(ruleset => {
+          let rs = new RuleSet(ruleset.name, ruleset.default_state, getScope(ruleset.scope), ruleset.note);
 
-        if (ruleset.cookierules) {
-          let cookierules = ruleset.cookierules.map(cookierule => {
-            return new CookieRule(cookierule.host, cookierule.name);
+          if (ruleset.cookierules) {
+            let cookierules = ruleset.cookierules.map(cookierule => {
+              return new CookieRule(cookierule.host, cookierule.name);
+            });
+            rs.cookierules = cookierules;
+          } else {
+            rs.cookierules = null;
+          }
+
+          let rules = ruleset.rules.map(rule => {
+            return getRule(rule.from, rule.to);
           });
-          rs.cookierules = cookierules;
-        } else {
-          rs.cookierules = null;
-        }
+          rs.rules = rules;
 
-        let rules = ruleset.rules.map(rule => {
-          return getRule(rule.from, rule.to);
-        });
-        rs.rules = rules;
-
-        if (ruleset.exclusions) {
-          rs.exclusions = new RegExp(ruleset.exclusions);
-        } else {
-          rs.exclusions = null;
-        }
-        return rs;
-      }));
+          if (ruleset.exclusions) {
+            rs.exclusions = new RegExp(ruleset.exclusions);
+          } else {
+            rs.exclusions = null;
+          }
+          return rs;
+        }));
+      }
     } else {
       // Let's begin search
-      // Copy the host targets so we don't modify them.
       results = (this.targets.has(host) ?
         new Set([...this.targets.get(host)]) :
         new Set());
 
-      // Ensure host is well-formed (RFC 1035)
-      if (host.length <= 0 || host.length > 255 || host.indexOf("..") != -1) {
-        util.log(util.WARN, "Malformed host passed to potentiallyApplicableRulesets: " + host);
-        return nullIterable;
-      }
-
-      // Replace www.example.com with www.example.*
-      // eat away from the right for once and only once
-      let segmented = host.split(".");
-      if (segmented.length > 1) {
-        const tmp = segmented[segmented.length - 1];
-        segmented[segmented.length - 1] = "*";
-
-        results = (this.targets.has(segmented.join(".")) ?
-          new Set([...results, ...this.targets.get(segmented.join("."))]) :
-          results);
-
-        segmented[segmented.length - 1] = tmp;
-      }
-
-      // now eat away from the left, with *, so that for x.y.z.google.com we
-      // check *.y.z.google.com, *.z.google.com and *.google.com
-      for (let i = 1; i <= segmented.length - 2; i++) {
-        let t = "*." + segmented.slice(i, segmented.length).join(".");
-
-        results = (this.targets.has(t) ?
-          new Set([...results, ...this.targets.get(t)]) :
+      for (const expression of expressions) {
+        results = (this.targets.has(expression) ?
+          new Set([...results, ...this.targets.get(expression)]) :
           results);
       }
 
@@ -644,7 +610,7 @@ RuleSets.prototype = {
       util.log(util.DBUG,"Applicable rules for " + host + ":");
       if (results.size == 0) {
         util.log(util.DBUG, "  None");
-        results = nullIterable;
+        results = util.nullIterable;
       } else {
         results.forEach(result => util.log(util.DBUG, "  " + result.name));
       }
@@ -778,7 +744,6 @@ RuleSets.prototype = {
 };
 
 Object.assign(exports, {
-  nullIterable,
   settings,
   trivial_rule,
   Rule,

--- a/chromium/background-scripts/util.js
+++ b/chromium/background-scripts/util.js
@@ -70,6 +70,54 @@ function getNormalisedHostname(hostname) {
   return hostname;
 }
 
+// Empty iterable singleton to reduce memory usage
+const nullIterable = Object.create(null, {
+  [Symbol.iterator]: {
+    value: function* () {
+      // do nothing
+    }
+  },
+
+  size: {
+    value: 0
+  },
+});
+
+/**
+ * Return a list of wildcard expressions which support
+ * the trivial under HTTPS Everywhere's implementation
+ */
+function getWildcardExpressions(host) {
+  // Ensure host is well-formed (RFC 1035)
+  if (host.length <= 0 || host.length > 255 || host.indexOf("..") != -1) {
+    return nullIterable;
+  }
+
+  // Ensure host does not contain a wildcard itself
+  if (host.indexOf("*") != -1) {
+    return nullIterable;
+  }
+
+  let results = [];
+
+  // Replace www.example.com with www.example.*
+  // eat away from the right for once and only once
+  let segmented = host.split(".");
+  if (segmented.length > 1) {
+    let t = [...segmented.slice(0, segmented.length - 1), '*'].join(".");
+    results.push(t);
+  }
+
+  // now eat away from the left, with *, so that for x.y.z.google.com we
+  // check *.y.z.google.com, *.z.google.com and *.google.com
+  for (let i = 1; i <= segmented.length - 2; i++) {
+    let t = "*." + segmented.slice(i, segmented.length).join(".");
+    results.push(t);
+  }
+
+  return results;
+}
+
 /**
  * Convert an ArrayBuffer to string
  *
@@ -94,7 +142,9 @@ Object.assign(exports, {
   NOTE,
   WARN,
   log,
+  nullIterable,
   getNormalisedHostname,
+  getWildcardExpressions,
   setDefaultLogLevel,
   getDefaultLogLevel,
   loadExtensionFile,

--- a/chromium/test/rules_test.js
+++ b/chromium/test/rules_test.js
@@ -18,18 +18,6 @@ const Rule = rules.Rule,
 describe('rules.js', function() {
   let test_str = 'test';
 
-  describe('nullIterable', function() {
-    it('is iterable zero times and is size 0', function() {
-      let count = 0;
-      for (let _ of rules.nullIterable) { // eslint-disable-line no-unused-vars
-        count += 1;
-      }
-      assert.strictEqual(count, 0);
-      assert.strictEqual(rules.nullIterable.size,  0);
-      assert.isEmpty(rules.nullIterable);
-    });
-  });
-
   describe('Rule', function() {
     it('constructs trivial rule', function() {
       let rule = new Rule('^http:', 'https:');


### PR DESCRIPTION
It is found that the WASM implementation of HTTPS Everywhere does not support wildcard targets. This can be reproduce by setting `javascript.option.wasm` to `false` on the `about:config` page on Firefox with #18589 .

This PR was initially intended for adding wildcard support for disable host so it includes some refactorization. Besides, I am unable to add back the unit test for `nullIterable` because #18563 is blocking.

Note that this affect browsing outside of EASE mode since `2019.6.27` (current stable).

P.S. it seems that this straight forward fix will increase the memory usage by quite a bit.... 

### List related PRs if any

- #18093, #18563 

### List related issues if any

- #18589 