### PR TITLE
[Labeller Dockerfile] pin node version

### DIFF
--- a/utils/labeller/Dockerfile
+++ b/utils/labeller/Dockerfile
@@ -1,5 +1,5 @@
-FROM node
-MAINTAINER William Budington <bill@eff.org>
+FROM node:8-alpine
+LABEL maintainer="William Budington <bill@eff.org>"
 
 WORKDIR /opt
 


### PR DESCRIPTION
Labeller is broken with current versions.
