### PR TITLE
Update Macromedia.com.xml to fix #18726

### DIFF
--- a/src/chrome/content/rules/Macromedia.com.xml
+++ b/src/chrome/content/rules/Macromedia.com.xml
@@ -1,40 +1,14 @@
 <!--
 	For other Adobe coverage, see Adobe.xml.
 
-
-	Problematic domains:
-
-		- macromedia.com ⁷
-
-	⁷ Cert only matches www
-
-
-	Fully covered domains:
-
-		- macromedia.com subdomains:
-
-			- (www.)		(^ → www)
-			- download
-			- fpdownload
-
+	Timeout:
+		- ^
 -->
-<ruleset name="Macromedia.com">
-
-	<!--	Direct rewrites:
-				-->
-	<target host="download.macromedia.com" />
-	<target host="fpdownload.macromedia.com" />
-	<target host="www.macromedia.com" />
-
-	<!--	Special cases:
-				-->
+<ruleset name="Macromedia.com (partial)">
 	<target host="macromedia.com" />
+	<target host="www.macromedia.com" />
+	<target host="download.macromedia.com" />
 
-
-	<rule from="^http://macromedia\.com/"
-		to="https://www.macromedia.com/" />
-
-	<rule from="^http:"
-		to="https:" />
-
+	<rule from="^http://macromedia\.com/" to="https://www.macromedia.com/" />
+	<rule from="^http:" to="https:" />
 </ruleset>


### PR DESCRIPTION
@zoracon Can our extension somehow detect if request is coming from Flash plugin? I don't want to disable the entire `fpdownload.macromedia.com` subdomain.