### PR TITLE
Fix bug causes MCB issues in EASE mode for some disabled sites

### DIFF
--- a/chromium/background-scripts/background.js
+++ b/chromium/background-scripts/background.js
@@ -335,7 +335,7 @@ function onBeforeRequest(details) {
 
     // Check if an user has disabled HTTPS Everywhere on this site.  We should
     // ensure that all subresources are not run through HTTPS Everywhere as well.
-    browserSession.putTab(details.tabId, 'first_party_host', uri.host, true);
+    browserSession.putTab(details.tabId, 'first_party_host', uri.hostname, true);
   }
 
   if (disabledList.has(browserSession.getTab(details.tabId, 'first_party_host', null)) ||


### PR DESCRIPTION
This bug will cause mixed content blocking issues if a `first_party_host` (which an user disabled HTTPSE in EASE mode) specifies a port and serves mixed content.

The `first_party_host` attribute in the `browserSession` object is used to disable HTTPSE rewrite on the third-party resources within the same tab in EASE mode. It is matched against the `disabledList` and `httpOnceList`. Since both `disabledList` and `httpOnceList` use normalised `uri.hostname` instead of `uri.host`, `first_party_host` should be configured to `uri.hostname` as well. Otherwise, third-party resources will be upgrade and cause MCB issues.