### PR TITLE
 Use the latest node LTS builds for unittests 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
     - env: TEST="unittests"
       language: node_js
       node_js:
-        - "lts/dubnium"
+        - "lts/*"
     - env: TEST="validations"
     - env: TEST="fetch"
     - env: TEST="preloaded"

--- a/chromium/package-lock.json
+++ b/chromium/package-lock.json
@@ -1331,18 +1331,6 @@
         }
       }
     },
-    "node-webcrypto-ossl": {
-      "version": "1.0.37",
-      "resolved": "https://registry.npmjs.org/node-webcrypto-ossl/-/node-webcrypto-ossl-1.0.37.tgz",
-      "integrity": "sha512-AQSux10u8NoUhRPqb2bapqM8EKMawKGYIBbGNWsBUTeq0uXYtuIheujcaJo5XY1Yy6HffC/fP7AHHtSA4KP2ig==",
-      "dev": true,
-      "requires": {
-        "mkdirp": "^0.5.1",
-        "nan": "^2.10.0",
-        "tslib": "^1.9.0",
-        "webcrypto-core": "^0.1.22"
-      }
-    },
     "normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -1936,12 +1924,6 @@
         "punycode": "^1.4.1"
       }
     },
-    "tslib": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
-      "dev": true
-    },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -2022,15 +2004,6 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
-      }
-    },
-    "webcrypto-core": {
-      "version": "0.1.22",
-      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-0.1.22.tgz",
-      "integrity": "sha512-UoNP+/3I74foiQLe1m4ToxoN3oloWnH3Na0TPWNzu/ALhDl1MbhgS0QEezdNNQbkj/6i9cf59k7LeOAAvd0hzg==",
-      "dev": true,
-      "requires": {
-        "tslib": "^1.7.1"
       }
     },
     "which": {

--- a/chromium/package-lock.json
+++ b/chromium/package-lock.json
@@ -1331,6 +1331,26 @@
         }
       }
     },
+    "node-webcrypto-ossl": {
+      "version": "1.0.48",
+      "resolved": "https://registry.npmjs.org/node-webcrypto-ossl/-/node-webcrypto-ossl-1.0.48.tgz",
+      "integrity": "sha512-MWUkQ/5wrs7lpAr+fhsLMfjdxKGd3dQFVqWbNMkyYyCMRW8E7ScailqtCZYDLTnJtU6B+91rXxCJNyZvbYaSOg==",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1",
+        "nan": "^2.13.2",
+        "tslib": "^1.9.3",
+        "webcrypto-core": "^0.1.26"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+          "dev": true
+        }
+      }
+    },
     "normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -1924,6 +1944,12 @@
         "punycode": "^1.4.1"
       }
     },
+    "tslib": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+      "dev": true
+    },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -2004,6 +2030,15 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
+      }
+    },
+    "webcrypto-core": {
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-0.1.26.tgz",
+      "integrity": "sha512-BZVgJZkkHyuz8loKvsaOKiBDXDpmMZf5xG4QAOlSeYdXlFUl9c1FRrVnAXcOdb4fTHMG+TRu81odJwwSfKnWTA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.7.1"
       }
     },
     "which": {

--- a/chromium/package-lock.json
+++ b/chromium/package-lock.json
@@ -772,9 +772,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.3.tgz",
-      "integrity": "sha512-B0W4A2U1ww3q7VVthTKfh+epHx+q4mCt6iK+zEAzbMBpWQAwxCeKxEGpj/1oQTpzPXDNSOG7hmG14TsISH50yw==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
+      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -1973,20 +1973,20 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.1.tgz",
-      "integrity": "sha512-+dSJLJpXBb6oMHP+Yvw8hUgElz4gLTh82XuX68QiJVTXaE5ibl6buzhNkQdYhBlIhozWOC9ge16wyRmjG4TwVQ==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.2.tgz",
+      "integrity": "sha512-uhRwZcANNWVLrxLfNFEdltoPNhECUR3lc+UdJoG9CBpMcSnKyWA94tc3eAujB1GcMY5Uwq8ZMp4qWpxWYDQmaA==",
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "2.20.0",
+        "commander": "~2.20.3",
         "source-map": "~0.6.1"
       },
       "dependencies": {
         "commander": {
-          "version": "2.20.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
           "dev": true,
           "optional": true
         },

--- a/chromium/package.json
+++ b/chromium/package.json
@@ -12,6 +12,7 @@
     "fetch-mock": "^6.3.0",
     "mocha": "^4.1.0",
     "nan": "^2.10.0",
+    "node-webcrypto-ossl": "^1.0.48",
     "nyc": "^14.1.1",
     "sinon": "^4.4.8",
     "sinon-chrome": "^2.3.1",

--- a/chromium/package.json
+++ b/chromium/package.json
@@ -12,7 +12,6 @@
     "fetch-mock": "^6.3.0",
     "mocha": "^4.1.0",
     "nan": "^2.10.0",
-    "node-webcrypto-ossl": "^1.0.37",
     "nyc": "^14.1.1",
     "sinon": "^4.4.8",
     "sinon-chrome": "^2.3.1",
@@ -24,7 +23,9 @@
     "report": "nyc report --reporter=text-lcov | coveralls"
   },
   "nyc": {
-    "exclude": ["external"]
+    "exclude": [
+      "external"
+    ]
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Unit tests pass with the latest LTS version of node, reverting #18601 and applying patches. This PR also supersede #18762 