### PR TITLE
Add boards.4channel.org to ruleset

### DIFF
--- a/src/chrome/content/rules/4chan.xml
+++ b/src/chrome/content/rules/4chan.xml
@@ -33,6 +33,7 @@
 
 	<target host="4channel.org" />
 	<target host="www.4channel.org" />
+	<target host="boards.4channel.org" />
 
 	<securecookie host=".+" name=".+" />
 


### PR DESCRIPTION
Added a missing ruleset for the website. Quite recently, 4chan adopted the usage of boards.4channel.* in their service.
