### PR TITLE
Add codeforces.com

### DIFF
--- a/src/chrome/content/rules/Codeforces.com.xml
+++ b/src/chrome/content/rules/Codeforces.com.xml
@@ -1,0 +1,18 @@
+<!--
+	Nonfunctional hosts in *.codeforces.com (as of 2019-01-02):
+		# m1.codeforces.com (m)
+		# m3.codeforces.com (r)
+
+	m: certificate mismatch
+	r: connection refused
+-->
+<ruleset name="Codeforces.com">
+	<target host="codeforces.com" />
+		<test url="http://codeforces.com/enter" />
+	<target host="www.codeforces.com" />
+		<test url="http://www.codeforces.com/enter" />
+	<target host="m2.codeforces.com" />
+		<test url="http://m2.codeforces.com/enter" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>


### PR DESCRIPTION
Previous PR which was rejected: https://github.com/EFForg/https-everywhere/pull/16661

codeforces.ru currently redirects to codeforces.com.
I'm not sure what to do about that rule-wise, so I've only considered the .com TLD in this PR.