### PR TITLE
Ignore /kr/ pages in fedex.com

### DIFF
--- a/src/chrome/content/rules/FedEx.com.xml
+++ b/src/chrome/content/rules/FedEx.com.xml
@@ -33,6 +33,8 @@
 	<target host="samedaycity.fedex.com" />
 	<target host="supplychain.fedex.com" />
 	<target host="wwwtest.fedex.com" />
+	
+	<exclusion pattern="^http://www\.fedex\.com/kr/" />
 
 	<rule from="^http://fedex\.com/"
 		to="https://www.fedex.com/" />

--- a/src/chrome/content/rules/FedEx.com.xml
+++ b/src/chrome/content/rules/FedEx.com.xml
@@ -36,6 +36,10 @@
 	
 	<exclusion pattern="^http://www\.fedex\.com/kr/" />
 
+	<test url="http://www.fedex.com/kr/docs/" />
+	<test url="http://www.fedex.com/kr/registration/" />
+	<test url="http://www.fedex.com/kr/tools/commercialinvoice.html" />
+
 	<rule from="^http://fedex\.com/"
 		to="https://www.fedex.com/" />
 


### PR DESCRIPTION
Examples:

* http://www.fedex.com/kr/docs/
* http://www.fedex.com/kr/registration/
* http://www.fedex.com/kr/tools/commercialinvoice.html

Modern pages use `/ko-kr/` and it seems some older pages using `/kr/` are HTTP-only.