### PR TITLE
Fix Non-www requests on costco.com

### DIFF
--- a/src/chrome/content/rules/Costco.xml
+++ b/src/chrome/content/rules/Costco.xml
@@ -9,6 +9,7 @@
 
 		- video *
 		- www2 ²
+        - Non-www (redirection needed)
 
 	* Shows another domain
 	² Reset
@@ -37,6 +38,9 @@
 	<target host="customerservice.costco.com" />
 
 	<securecookie host=".+" name=".+" />
+
+    <rule from="^https://costco\.com/"
+        to="https://www.costco.com/" />
 
 	<rule from="^http:"	to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Costco.xml
+++ b/src/chrome/content/rules/Costco.xml
@@ -9,7 +9,7 @@
 
 		- video *
 		- www2 ²
-        - Non-www (redirection needed)
+      - Non-www (redirection needed)
 
 	* Shows another domain
 	² Reset
@@ -39,8 +39,8 @@
 
 	<securecookie host=".+" name=".+" />
 
-    <rule from="^https://costco\.com/"
-        to="https://www.costco.com/" />
+  <rule from="^https://costco\.com/"
+      to="https://www.costco.com/" />
 
 	<rule from="^http:"	to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/Costco.xml
+++ b/src/chrome/content/rules/Costco.xml
@@ -10,7 +10,6 @@
 		- video *
 
 	* Shows another domain
-	² Reset
 
     Timeout:
       - ^

--- a/src/chrome/content/rules/Costco.xml
+++ b/src/chrome/content/rules/Costco.xml
@@ -8,12 +8,13 @@
 	Nonfunctional hosts in *costco.com:
 
 		- video *
-		- www2 ²
-      - Non-www (redirection needed)
 
 	* Shows another domain
 	² Reset
 
+    Timeout:
+      - ^
+      - www2
 
 	Problematic hosts in *costco.com:
 
@@ -39,8 +40,7 @@
 
 	<securecookie host=".+" name=".+" />
 
-  <rule from="^https://costco\.com/"
-      to="https://www.costco.com/" />
+  <rule from="^http://costco\.com/" to="https://www.costco.com/" />
 
 	<rule from="^http:"	to="https:" />
 </ruleset>


### PR DESCRIPTION
We had a report of https://costco.com not responding and can confirm the non-www isn't responding.


Was reported here, https://community.brave.com/t/https-anywhere-stops-costco-com-loading/103072/2

Any questions let me know.