### PR TITLE
Add gitlab subdomain to FreeDesktop.org ruleset

### DIFF
--- a/src/chrome/content/rules/FreeDesktop.xml
+++ b/src/chrome/content/rules/FreeDesktop.xml
@@ -16,6 +16,7 @@
 	<target host="dri.freedesktop.org" />
 	<target host="fontconfig.freedesktop.org" />
 	<target host="freetype.freedesktop.org" />
+	<target host="gitlab.freedesktop.org" />
 	<target host="gstreamer.freedesktop.org" />
 	<target host="gypsy.freedesktop.org" />
 	<target host="hal.freedesktop.org" />


### PR DESCRIPTION
What is says on the tin :)

We use GitLab for pretty much all FreeDesktop.org projects now, so let's add a rule to always load it via https :+1: