### PR TITLE
Update DLsite.com.xml

### DIFF
--- a/src/chrome/content/rules/DLsite.com.xml
+++ b/src/chrome/content/rules/DLsite.com.xml
@@ -23,6 +23,7 @@
 		- home-info.dlsite.com
 		- staffblog.dlsite.com
 		- blog.it.dlsite.com
+		- b.dlsite.net
 
 		SSL peer certificate was not OK:
 		- www.fujita.dlsite.com

--- a/src/chrome/content/rules/DLsite.com.xml
+++ b/src/chrome/content/rules/DLsite.com.xml
@@ -36,30 +36,31 @@
 		- www.dlsite.com
 -->
 <ruleset name="DLsite.com" platform="mixedcontent">
-	<target host="ch.dlsite.com" />
-	<target host="download.dlsite.com" />
-	<target host="play.dl.dlsite.com" />
-	<target host="login.dlsite.com" />
-	<target host="play.dlsite.com" />
-	<target host="ssl.dlsite.com" />
-	<target host="trial.dlsite.com" />
+	<target host="dlsite.com" />
 	<target host="www.dlsite.com" />
-	<target host="click.mg.dlsite.com" />
-	<target host="view.mg.dlsite.com" />
-	<target host="ci-en.dlsite.com" />
-	<target host="media.dlsite.com" />
-	<target host="eng.dlsite.com" />
-	<target host="maniax.dlsite.com" />
-	<target host="pro.dlsite.com" />
-	<target host="pro2.dlsite.com" />
-	<target host="home.dlsite.com" />
-	<target host="books.dlsite.com" />
-	<target host="comic.dlsite.com" />
-	<target host="www.origin.dlsite.com" />
 	<target host="blog.dlsite.com" />
-	<target host="ssldownload.dlsite.com" />
-	<target host="img.dlsite.jp" />
+	<target host="books.dlsite.com" />
+	<target host="ch.dlsite.com" />
+	<target host="ci-en.dlsite.com" />
+	<target host="click.mg.dlsite.com" />
+	<target host="comic.dlsite.com" />
 	<target host="dlsite.blogimg.jp" />
+	<target host="download.dlsite.com" />
+	<target host="eng.dlsite.com" />
+	<target host="home.dlsite.com" />
+	<target host="img.dlsite.jp" />
+	<target host="login.dlsite.com" />
+	<target host="maniax.dlsite.com" />
+	<target host="media.dlsite.com" />
+	<target host="play.dl.dlsite.com" />
+	<target host="play.dlsite.com" />
+	<target host="pro2.dlsite.com" />
+	<target host="pro.dlsite.com" />
+	<target host="ssl.dlsite.com" />
+	<target host="ssldownload.dlsite.com" />
+	<target host="trial.dlsite.com" />
+	<target host="view.mg.dlsite.com" />
+	<target host="www.origin.dlsite.com" />
 
 	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/DLsite.com.xml
+++ b/src/chrome/content/rules/DLsite.com.xml
@@ -3,20 +3,34 @@
 		Couldn't connect to server:
 		- circle.upload001.dlsite.com
 		- circle.upload002.dlsite.com
+		- admin.dlsite.com
+		- github.dlsite.com
+		- announce.dlsite.com
+		- dille.dlsite.com
+		- elle.dlsite.com
+		- ch.stg.dlsite.com
+		- trial.gaku.dlsite.com
 
 		Timeout was reached:
 		- maid.dlsite.com
 		- support.dlsite.com
+		- trial.origin.dlsite.com
 
 		SSL connect error:
 		- ch-info.dlsite.com
 		- eng-info.dlsite.com
 		- girls-info.dlsite.com
 		- home-info.dlsite.com
+		- staffblog.dlsite.com
+		- blog.it.dlsite.com
 
 		SSL peer certificate was not OK:
 		- www.fujita.dlsite.com
 		- it.dlsite.com
+
+		SSL Connection Refused:
+		- adv.dlsite.com
+		- trinity.dlsite.com
 
 		Mixed content blocking (MCB) triggered:
 		- www.dlsite.com
@@ -40,8 +54,10 @@
 	<target host="pro2.dlsite.com" />
 	<target host="home.dlsite.com" />
 	<target host="books.dlsite.com" />
+	<target host="comic.dlsite.com" />
 	<target host="www.origin.dlsite.com" />
 	<target host="blog.dlsite.com" />
+	<target host="ssldownload.dlsite.com" />
 	<target host="img.dlsite.jp" />
 	<target host="dlsite.blogimg.jp" />
 

--- a/src/chrome/content/rules/DLsite.com.xml
+++ b/src/chrome/content/rules/DLsite.com.xml
@@ -44,6 +44,7 @@
 	<target host="ci-en.dlsite.com" />
 	<target host="click.mg.dlsite.com" />
 	<target host="comic.dlsite.com" />
+	<target host="dealer.dlsite.com" />
 	<target host="dlsite.blogimg.jp" />
 	<target host="download.dlsite.com" />
 	<target host="eng.dlsite.com" />
@@ -59,6 +60,7 @@
 	<target host="ssl.dlsite.com" />
 	<target host="ssldownload.dlsite.com" />
 	<target host="trial.dlsite.com" />
+	<target host="trial.origin.dlsite.com" />
 	<target host="view.mg.dlsite.com" />
 	<target host="www.origin.dlsite.com" />
 

--- a/src/chrome/content/rules/DLsite.com.xml
+++ b/src/chrome/content/rules/DLsite.com.xml
@@ -18,13 +18,6 @@
 		- www.fujita.dlsite.com
 		- it.dlsite.com
 
-		Peer certificate cannot be authenticated with given CA certificates:
-		- dlsite.com
-		- eng.dlsite.com
-		- maniax.dlsite.com
-		- pro.dlsite.com
-		- pro2.dlsite.com
-
 		Mixed content blocking (MCB) triggered:
 		- www.dlsite.com
 -->

--- a/src/chrome/content/rules/DLsite.com.xml
+++ b/src/chrome/content/rules/DLsite.com.xml
@@ -33,7 +33,6 @@
 	<target host="click.mg.dlsite.com" />
 	<target host="view.mg.dlsite.com" />
 	<target host="ci-en.dlsite.com" />
-	<target host="img.dlsite.jp" />
 	<target host="media.dlsite.com" />
 	<target host="eng.dlsite.com" />
 	<target host="maniax.dlsite.com" />
@@ -42,7 +41,9 @@
 	<target host="home.dlsite.com" />
 	<target host="books.dlsite.com" />
 	<target host="www.origin.dlsite.com" />
-	<target host="blog.dlsite.com " />
+	<target host="blog.dlsite.com" />
+	<target host="img.dlsite.jp" />
+	<target host="dlsite.blogimg.jp" />
 
 	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/DLsite.com.xml
+++ b/src/chrome/content/rules/DLsite.com.xml
@@ -60,7 +60,6 @@
 	<target host="ssl.dlsite.com" />
 	<target host="ssldownload.dlsite.com" />
 	<target host="trial.dlsite.com" />
-	<target host="trial.origin.dlsite.com" />
 	<target host="view.mg.dlsite.com" />
 	<target host="www.origin.dlsite.com" />
 

--- a/src/chrome/content/rules/DLsite.com.xml
+++ b/src/chrome/content/rules/DLsite.com.xml
@@ -15,10 +15,8 @@
 		- home-info.dlsite.com
 
 		SSL peer certificate was not OK:
-		- blog.dlsite.com
 		- www.fujita.dlsite.com
 		- it.dlsite.com
-		- www.origin.dlsite.com
 
 		Peer certificate cannot be authenticated with given CA certificates:
 		- dlsite.com
@@ -39,6 +37,19 @@
 	<target host="ssl.dlsite.com" />
 	<target host="trial.dlsite.com" />
 	<target host="www.dlsite.com" />
+	<target host="click.mg.dlsite.com" />
+	<target host="view.mg.dlsite.com" />
+	<target host="ci-en.dlsite.com" />
+	<target host="img.dlsite.jp" />
+	<target host="media.dlsite.com" />
+	<target host="eng.dlsite.com" />
+	<target host="maniax.dlsite.com" />
+	<target host="pro.dlsite.com" />
+	<target host="pro2.dlsite.com" />
+	<target host="home.dlsite.com" />
+	<target host="books.dlsite.com" />
+	<target host="www.origin.dlsite.com" />
+	<target host="blog.dlsite.com " />
 
 	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/DLsite.com.xml
+++ b/src/chrome/content/rules/DLsite.com.xml
@@ -34,9 +34,6 @@
 		SSL Connection Refused:
 		- adv.dlsite.com
 		- trinity.dlsite.com
-
-		Mixed content blocking (MCB) triggered:
-		- www.dlsite.com
 -->
 <ruleset name="DLsite.com">
 	<target host="dlsite.com" />

--- a/src/chrome/content/rules/DLsite.com.xml
+++ b/src/chrome/content/rules/DLsite.com.xml
@@ -35,7 +35,7 @@
 		Mixed content blocking (MCB) triggered:
 		- www.dlsite.com
 -->
-<ruleset name="DLsite.com" platform="mixedcontent">
+<ruleset name="DLsite.com">
 	<target host="dlsite.com" />
 	<target host="www.dlsite.com" />
 	<target host="blog.dlsite.com" />

--- a/src/chrome/content/rules/DLsite.com.xml
+++ b/src/chrome/content/rules/DLsite.com.xml
@@ -25,8 +25,10 @@
 		- blog.it.dlsite.com
 		- b.dlsite.net
 
-		SSL peer certificate was not OK:
+		NXDOMAIN:
 		- www.fujita.dlsite.com
+
+		Mixed content:
 		- it.dlsite.com
 
 		SSL Connection Refused:

--- a/src/chrome/content/rules/DLsite.com.xml
+++ b/src/chrome/content/rules/DLsite.com.xml
@@ -34,6 +34,10 @@
 		SSL Connection Refused:
 		- adv.dlsite.com
 		- trinity.dlsite.com
+
+		Rules related to this:
+		- dlsite.blogimg.jp
+		- img.dlsite.jp
 -->
 <ruleset name="DLsite.com">
 	<target host="dlsite.com" />
@@ -45,11 +49,9 @@
 	<target host="click.mg.dlsite.com" />
 	<target host="comic.dlsite.com" />
 	<target host="dealer.dlsite.com" />
-	<target host="dlsite.blogimg.jp" />
 	<target host="download.dlsite.com" />
 	<target host="eng.dlsite.com" />
 	<target host="home.dlsite.com" />
-	<target host="img.dlsite.jp" />
 	<target host="login.dlsite.com" />
 	<target host="maniax.dlsite.com" />
 	<target host="media.dlsite.com" />
@@ -62,6 +64,9 @@
 	<target host="trial.dlsite.com" />
 	<target host="view.mg.dlsite.com" />
 	<target host="www.origin.dlsite.com" />
+
+	<test url="https://dealer.dlsite.com/login" />
+	<test url="http://trial.dlsite.com/error404.html" />
 
 	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/DLsite.com.xml
+++ b/src/chrome/content/rules/DLsite.com.xml
@@ -1,4 +1,8 @@
 <!--
+	Related rules:
+	- dlsite.blogimg.jp
+	- img.dlsite.jp
+
 	Non-functional hosts
 		Couldn't connect to server:
 		- circle.upload001.dlsite.com
@@ -34,10 +38,6 @@
 		SSL Connection Refused:
 		- adv.dlsite.com
 		- trinity.dlsite.com
-
-		Rules related to this:
-		- dlsite.blogimg.jp
-		- img.dlsite.jp
 
 		https://trial.dlsite.com will redir to http://trial.origin.dlsite.com/error404.html,
 		but the actual trial links work, for example https://trial.dlsite.com/doujin/RJ119000/RJ118525_trial.zip

--- a/src/chrome/content/rules/DLsite.com.xml
+++ b/src/chrome/content/rules/DLsite.com.xml
@@ -66,7 +66,7 @@
 	<target host="www.origin.dlsite.com" />
 
 	<test url="https://dealer.dlsite.com/login" />
-	<test url="http://trial.dlsite.com/error404.html" />
+	<test url="https://trial.dlsite.com/error404.html" />
 
 	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/DLsite.com.xml
+++ b/src/chrome/content/rules/DLsite.com.xml
@@ -1,7 +1,7 @@
 <!--
 	Related rules:
 	- blogimg.jp.xml
-	- img.dlsite.jp
+	- DLsite.jp.xml
 
 	Non-functional hosts
 		Couldn't connect to server:

--- a/src/chrome/content/rules/DLsite.com.xml
+++ b/src/chrome/content/rules/DLsite.com.xml
@@ -1,6 +1,6 @@
 <!--
 	Related rules:
-	- dlsite.blogimg.jp
+	- blogimg.jp.xml
 	- img.dlsite.jp
 
 	Non-functional hosts

--- a/src/chrome/content/rules/DLsite.com.xml
+++ b/src/chrome/content/rules/DLsite.com.xml
@@ -38,6 +38,9 @@
 		Rules related to this:
 		- dlsite.blogimg.jp
 		- img.dlsite.jp
+
+		https://trial.dlsite.com will redir to http://trial.origin.dlsite.com/error404.html,
+		but the actual trial links work, for example https://trial.dlsite.com/doujin/RJ119000/RJ118525_trial.zip
 -->
 <ruleset name="DLsite.com">
 	<target host="dlsite.com" />
@@ -65,8 +68,7 @@
 	<target host="view.mg.dlsite.com" />
 	<target host="www.origin.dlsite.com" />
 
-	<test url="https://dealer.dlsite.com/login" />
-	<test url="https://trial.dlsite.com/error404.html" />
+	<test url="http://dealer.dlsite.com/login" />
 
 	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/DLsite.jp.xml
+++ b/src/chrome/content/rules/DLsite.jp.xml
@@ -1,6 +1,6 @@
 <!--
 	Related rules:
-	- dlsite.com
+	- DLsite.com.xml
 -->
 
 <ruleset name="dlsite.jp">

--- a/src/chrome/content/rules/DLsite.jp.xml
+++ b/src/chrome/content/rules/DLsite.jp.xml
@@ -1,0 +1,5 @@
+<ruleset name="dlsite.jp">
+	<target host="img.dlsite.jp" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/DLsite.jp.xml
+++ b/src/chrome/content/rules/DLsite.jp.xml
@@ -1,3 +1,8 @@
+<!--
+	Related rules:
+	- dlsite.com
+-->
+
 <ruleset name="dlsite.jp">
 	<target host="img.dlsite.jp" />
 

--- a/src/chrome/content/rules/blogimg.jp.xml
+++ b/src/chrome/content/rules/blogimg.jp.xml
@@ -1,0 +1,5 @@
+<ruleset name="blogimg.jp">
+	<target host="dlsite.blogimg.jp" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/blogimg.jp.xml
+++ b/src/chrome/content/rules/blogimg.jp.xml
@@ -1,6 +1,6 @@
 <!--
 	Related rules:
-	- dlsite.com
+	- DLsite.com.xml
 -->
 
 <ruleset name="blogimg.jp">

--- a/src/chrome/content/rules/blogimg.jp.xml
+++ b/src/chrome/content/rules/blogimg.jp.xml
@@ -1,3 +1,8 @@
+<!--
+	Related rules:
+	- dlsite.com
+-->
+
 <ruleset name="blogimg.jp">
 	<target host="dlsite.blogimg.jp" />
 


### PR DESCRIPTION
Add more domains and remove `mixedcontent`(Didn't see anything broken during my limited usage, though I can't 100% guarantee).

Note two of them are `img.dlsite.jp` and `dlsite.blogimg.jp` which are not the subdomain of `dlsite.com` (especially `dlsite.blogimg.jp`, it's used in `b.dlsite.net`), but they are indeed used by DLsite. I don't know whether it's appropriate. If not, should I create another `.xml` entry?

And two of them will redir to http once. I have sent a feedback email, ~~thus I marked this PR as WIP.~~

---

* `https://trial.dlsite.com` will redir to `http://trial.origin.dlsite.com/error404.html` but the actual trial links work (for example `https://trial.dlsite.com/doujin/RJ119000/RJ118525_trial.zip`).
* `https://dealer.dlsite.com` will redir to `http://dealer.dlsite.com/login/...` but `https://dealer.dlsite.com/login` works.

From the email they said it's on their TODO list, but the priority seems not high.