### PR TITLE
Fix rule hostname typos (#12297)

### DIFF
--- a/src/chrome/content/rules/City-Mail.xml
+++ b/src/chrome/content/rules/City-Mail.xml
@@ -11,7 +11,7 @@
 	<securecookie host="^(?:www\.)?cityemail\.com$" name=".+" />
 
 
-	<rule from="^http://(www\.)?citymail\.com/"
-		to="https://$1citymail.com/" />
+	<rule from="^http://(www\.)?cityemail\.com/"
+		to="https://$1cityemail.com/" />
 
 </ruleset>

--- a/src/chrome/content/rules/EPEAT.xml
+++ b/src/chrome/content/rules/EPEAT.xml
@@ -3,7 +3,7 @@
 	<target host="ww2.epeat.net" />
 
 
-	<rule from="^http://ww2\.epeat\.com/"
-		to="https://ww2.epeat.com/" />
+	<rule from="^http://ww2\.epeat\.net/"
+		to="https://ww2.epeat.net/" />
 
 </ruleset>

--- a/src/chrome/content/rules/MVG-mobil.de.xml
+++ b/src/chrome/content/rules/MVG-mobil.de.xml
@@ -13,7 +13,7 @@
 	<securecookie host="^www\.mvg-mobil\.de$" name=".+" />
 
 
-	<rule from="^http://(?:www\.)?mvg-mobile\.de/"
-		to="https://www.mvg-mobile.de/" />
+	<rule from="^http://(?:www\.)?mvg-mobil\.de/"
+		to="https://www.mvg.de/" />
 
 </ruleset>

--- a/src/chrome/content/rules/OHeffernan.xml
+++ b/src/chrome/content/rules/OHeffernan.xml
@@ -3,7 +3,7 @@
 	<target host="inachinashop.com"/>
 	<target host="www.inachinashop.com"/>
 
-	<rule from="^http://(?:www\.)?inchinashop\.com/"
+	<rule from="^http://(?:www\.)?inachinashop\.com/"
 		to="https://pingplanet.squarespace.com/"/>
 
 </ruleset>

--- a/src/chrome/content/rules/The-Republic.xml
+++ b/src/chrome/content/rules/The-Republic.xml
@@ -14,7 +14,7 @@
 
 
 	<!--	Akamai, 403	-->
-	<rule from="^http://cdn\.therepublic\.com/"
+	<rule from="^http://cdn1\.therepublic\.com/"
 		to="https://c348471.ssl.cf1.rackcdn.com/" />
 
 </ruleset>

--- a/src/chrome/content/rules/Whisper-Gifts.xml
+++ b/src/chrome/content/rules/Whisper-Gifts.xml
@@ -1,16 +1,17 @@
+<!--
+	Nonfunctional subdomains:
+		- whispergifts.com	(invalid cert)
+-->
 <ruleset name="Whisper Gifts (partial)">
 
 	<target host="whispergifts.com" />
 	<target host="www.whispergifts.com" />
 
 
-	<!--	Unsupported paths redirect to www, so this is safe.	-->
 	<rule from="^http://whispergifts\.com/"
-		to="https://whispergifts.com/" />
+		to="https://www.whispergifts.com/" />
 
-	<!--	There may be more paths than are
-		handled here that don't redirect to http.	-->
-	<rule from="^http://www\.whispergifts/(media/|whisper/(?:login|manage|signup))"
-		to="https://www.whispergifts/$1" />
+	<rule from="^http:"
+		to="https:" />
 
 </ruleset>


### PR DESCRIPTION
The simplest subset of #12297 hosts in regex that are not in targets.
