### PR TITLE
Exempt localhost from header rewrite

### DIFF
--- a/chromium/background-scripts/background.js
+++ b/chromium/background-scripts/background.js
@@ -603,7 +603,7 @@ function onHeadersReceived(details) {
     // See https://github.com/EFForg/https-everywhere/pull/14600#discussion_r168072480
     const uri = new URL(details.url);
     const hostname = util.getNormalisedHostname(uri.hostname);
-    if (hostname.slice(-6) == '.onion') {
+    if (hostname.slice(-6) == '.onion' || hostname == 'localhost') {
       return {};
     }
 


### PR DESCRIPTION
While developing a website that requests `http://localhost:8080`, I noticed that HTTPS Everywhere rewrites the `Access-Control-Allow-Origin` header to `https://localhost:8080`. This is undesirable with `localhost`.
