### PR TITLE
Orion_Magazine.org.xml: Add .com target

### DIFF
--- a/src/chrome/content/rules/Orion_Magazine.org.xml
+++ b/src/chrome/content/rules/Orion_Magazine.org.xml
@@ -4,7 +4,7 @@
 	<target host="www.orionmagazine.org" />
 
 
-	<rule from="^http://(www\.)?orionmagazine\.com/"
-		to="https://$1orionmagazine.com/" />
+	<rule from="^http:"
+		to="https:" />
 
 </ruleset>


### PR DESCRIPTION
Rule was for .com, which wasnt listed as a target.

.com is not functional; redirect to .org which is functional.

### List related issues if any

Related to https://github.com/EFForg/https-everywhere/issues/12297

