### PR TITLE
Fix options page appearance on Firefox when dark mode is on

### DIFF
--- a/chromium/pages/options/style.css
+++ b/chromium/pages/options/style.css
@@ -1,6 +1,23 @@
 body{
   min-width: 500px;
+  min-height: 250px;
   display: block;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background-color: #202023;
+    color: #f9f9fa;
+  }
+
+  .section-header-span, div#update-channels-warning {
+    color: #000;
+  }
+
+  textarea, input[type=text] {
+    background-color: #202023;
+    color: #f9f9fa;
+  }
 }
 
 a.settings{


### PR DESCRIPTION
Related PR: #17896.

## Screenshots

<details>
<summary><strong>Firefox</strong></summary>

![ff1](https://user-images.githubusercontent.com/46632672/75422757-55cc6080-594e-11ea-8abc-9056d0f7602f.png)
![ff2](https://user-images.githubusercontent.com/46632672/75422755-5533ca00-594e-11ea-81a3-00f36ac886ef.png)
![ff3](https://user-images.githubusercontent.com/46632672/75422751-536a0680-594e-11ea-84b2-dc7ea99c70c5.png)

</details>

<details>
<summary><strong>Chrome</strong></summary>

![cr1](https://user-images.githubusercontent.com/46632672/75422761-56fd8d80-594e-11ea-8bc2-ad5125b55d89.png)
![cr2](https://user-images.githubusercontent.com/46632672/75422760-5664f700-594e-11ea-9654-c7c07f44d22b.png)
![cr3](https://user-images.githubusercontent.com/46632672/75422758-55cc6080-594e-11ea-993c-d192822082b7.png)

</details>
