### PR TITLE
Fix TransLink.ca.xml ruleset (#19003)

### DIFF
--- a/src/chrome/content/rules/TransLink.ca.xml
+++ b/src/chrome/content/rules/TransLink.ca.xml
@@ -24,8 +24,8 @@
 		<test url="http://www.translink.ca/" />
 		<test url="http://10yearvision.translink.ca/" />
 		<test url="http://developer.translink.ca/" />
-		<test url="http://fav.translink.ca/" />
 		<test url="http://feedback.translink.ca/" />
+		<test url="http://infomaps.translink.ca/" />
 		<test url="http://m.translink.ca/" />
 		<test url="http://mfb.translink.ca/" />
 		<test url="http://msft.translink.ca/" />
@@ -42,6 +42,8 @@
 	<target host="www.translinkstore.ca" />
 
 	<securecookie host=".+" name=".+" />
+
+	<exclusion pattern="^http://infomaps\.translink\.ca/" />
 
 	<rule from="^http:"
 		to="https:" />


### PR DESCRIPTION
Closes #19003.

This ruleset doesn't deal with anything other than fixing this bug.

`fav.translink.ca` is NXDOMAIN.