### PR TITLE
Temporarily disable www.bbc.com

### DIFF
--- a/src/chrome/content/rules/BBC.com.xml
+++ b/src/chrome/content/rules/BBC.com.xml
@@ -3,7 +3,9 @@
 -->
 <ruleset name="BBC.com (partial)">
 	<target host="bbc.com" />
-	<target host="www.bbc.com" />
+<!--	
+    <target host="www.bbc.com" />
+-->
 	<target host="ssl.bbc.com" />
 
 	<rule from="^http:" to="https:" />


### PR DESCRIPTION
Was reported `http://www.bbc.com/travel/story/20200309-ogopogo-the-monster-lurking-in-okanagan-lake` is having issues when converting http to https on `www.bbc.com`.

### List related PRs if any

- pr link

### List related issues if any

- issue link

***May delete note after reading***

### Note to contributor:
Thank you for contributing! If this is a new ruleset and your first time contributing, congratulations! There will be some tests ran through our continuous integration in Travis. For example, checking for duplicate hosts, problematic hosts, etc. in the ruleset file. You will see this testing begin when you open this pull request.

If this is not your first time and you have open PRs that have not been closed or merged, please revisit them by searching: `https://github.com/EFForg/https-everywhere/issues?q=is%3Aopen+assignee%3A[yourusernamehere]`. If there is something not being addressed by other maintainers or a project lead, link them to the PR with your question. Thank you for your patience.

More helpful filters in Pull Request search:
- Changes requested: 
`is:pr is:open type:pr review:changes_requested author:[your username]`
- Updated from specific date: 
`is:pr updated:>yyyy-mm-dd`
- Merged PRs: 
 `is:pr is:merged author:[your username]`
- Approved PRs: 
`is:pr review:approved author:[your username]`
