### PR TITLE
Use native bytes value as the default sort order

### DIFF
--- a/utils/ruleset-whitelist-cleanup.sh
+++ b/utils/ruleset-whitelist-cleanup.sh
@@ -38,5 +38,5 @@ done) < "$WLIST"
 
 # Sorting by the 4th column (ruleset name)
 TMPFILE=`mktemp`
-(head -n1 "$WLIST" && tail -n +2 "$WLIST" | sort -t"," -b -u -k4) > "$TMPFILE"
+(head -n1 "$WLIST" && tail -n +2 "$WLIST" | LC_ALL=C sort -t"," -b -u -k4) > "$TMPFILE"
 mv "$TMPFILE" "$WLIST"


### PR DESCRIPTION
As per the documentation `sort(1)`

```
***  WARNING  ***  The locale specified by the environment affects sort
       order.  Set LC_ALL=C to get the traditional sort order that uses native
       byte values.
```