### PR TITLE
Revert "Update Cipher List for Pending Fetch Test"

### DIFF
--- a/test/rules/src/https_everywhere_checker/http_client.py
+++ b/test/rules/src/https_everywhere_checker/http_client.py
@@ -46,7 +46,9 @@ class CertificatePlatforms(object):
 class FetchOptions(object):
     """HTTP fetcher options like timeouts."""
 
-    # The default list of cipher suites that ships with Firefox 51.0.1
+    # The default list of cipher suites that are supported in Firefox ESR, Chrome
+    # These naming formats are from OpenSSL
+    # This list is crosschecked with https://wiki.mozilla.org/Security/Cipher_Suites and https://clienttest.ssllabs.com
     _DEFAULT_CIPHERLIST = "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA:AES128-SHA:AES256-SHA:DES-CBC3-SHA"
 
     def __init__(self, config):

--- a/test/rules/src/https_everywhere_checker/http_client.py
+++ b/test/rules/src/https_everywhere_checker/http_client.py
@@ -46,10 +46,8 @@ class CertificatePlatforms(object):
 class FetchOptions(object):
     """HTTP fetcher options like timeouts."""
 
-    # The default list of cipher suites that are supported in Firefox ESR, Chrome
-    # These naming formats are from OpenSSL
-    # This list is crosschecked with https://wiki.mozilla.org/Security/Cipher_Suites and https://clienttest.ssllabs.com
-    _DEFAULT_CIPHERLIST = "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384"
+    # The default list of cipher suites that ships with Firefox 51.0.1
+    _DEFAULT_CIPHERLIST = "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA:AES128-SHA:AES256-SHA:DES-CBC3-SHA"
 
     def __init__(self, config):
         """Parse options from [http] section


### PR DESCRIPTION
Reverts EFForg/https-everywhere#18964

Even though not preferred, these weaker ciphers are still supported within the browsers. 

@todo create a tool to crosscheck these among Tor (FF ESR), Chrome, and Firefox

Closes  #19034, however not sure with cipher suite triggered this error in particular