### PR TITLE
Create 5ch.xml

### DIFF
--- a/src/chrome/content/rules/5ch.xml
+++ b/src/chrome/content/rules/5ch.xml
@@ -1,44 +1,44 @@
 <ruleset name="5ch.net">
-        <target host="5ch.net" />
-        <target host="*.5ch.net" />
+	<target host="5ch.net" />
+	<target host="*.5ch.net" />
 
-        <test url="http://5ch.net/" />
-        <test url="http://www2.5ch.net/" />
-        <test url="http://itest.5ch.net/" />
-        <test url="http://premium.5ch.net/" />
-        <test url="http://be.5ch.net/" />
-        <test url="http://i.5ch.net/" />
-        <test url="http://headline.5ch.net/" />
-        <test url="http://newsnavi.5ch.net/" />
-        <test url="http://info.5ch.net/" />
-        <test url="http://o.5ch.net/" />
-        <test url="http://stat.5ch.net/" />
-        <test url="http://dig.5ch.net/" />
-        <test url="http://qb5.5ch.net/" />
-        
-        <test url="http://agree.5ch.net/" />
-        <test url="http://asahi.5ch.net/" />
-        <test url="http://egg.5ch.net/" />
-        <test url="http://fate.5ch.net/" />
-        <test url="http://hayabusa9.5ch.net/" />
-        <test url="http://hebi.5ch.net/" />
-        <test url="http://himawari.5ch.net/" />
-        <test url="http://krsw.5ch.net/" />
-        <test url="http://lavender.5ch.net/" />
-        <test url="http://leia.5ch.net/" />
-        <test url="http://mao.5ch.net/" />
-        <test url="http://matsuri.5ch.net/" />
-        <test url="http://medaka.5ch.net/" />
-        <test url="http://mevius.5ch.net/" />
-        <test url="http://nhk2.5ch.net/" />
-        <test url="http://rio2016.5ch.net/" />
-        <test url="http://rosie.5ch.net/" />
-        <test url="http://swallow.5ch.net/" />
-        <test url="http://tanuki.5ch.net/" />
+	<test url="http://5ch.net/" />
+	<test url="http://www2.5ch.net/" />
+	<test url="http://itest.5ch.net/" />
+	<test url="http://premium.5ch.net/" />
+	<test url="http://be.5ch.net/" />
+	<test url="http://i.5ch.net/" />
+	<test url="http://headline.5ch.net/" />
+	<test url="http://newsnavi.5ch.net/" />
+	<test url="http://info.5ch.net/" />
+	<test url="http://o.5ch.net/" />
+	<test url="http://stat.5ch.net/" />
+	<test url="http://dig.5ch.net/" />
+	<test url="http://qb5.5ch.net/" />
+	
+	<test url="http://agree.5ch.net/" />
+	<test url="http://asahi.5ch.net/" />
+	<test url="http://egg.5ch.net/" />
+	<test url="http://fate.5ch.net/" />
+	<test url="http://hayabusa9.5ch.net/" />
+	<test url="http://hebi.5ch.net/" />
+	<test url="http://himawari.5ch.net/" />
+	<test url="http://krsw.5ch.net/" />
+	<test url="http://lavender.5ch.net/" />
+	<test url="http://leia.5ch.net/" />
+	<test url="http://mao.5ch.net/" />
+	<test url="http://matsuri.5ch.net/" />
+	<test url="http://medaka.5ch.net/" />
+	<test url="http://mevius.5ch.net/" />
+	<test url="http://nhk2.5ch.net/" />
+	<test url="http://rio2016.5ch.net/" />
+	<test url="http://rosie.5ch.net/" />
+	<test url="http://swallow.5ch.net/" />
+	<test url="http://tanuki.5ch.net/" />
 
-        <securecookie host=".+" name=".+" />
+	<securecookie host=".+" name=".+" />
 
-        <rule from="^http:"
-                to="https:" />
+	<rule from="^http:"
+		to="https:" />
 
 </ruleset>

--- a/src/chrome/content/rules/5ch.xml
+++ b/src/chrome/content/rules/5ch.xml
@@ -1,7 +1,6 @@
 <ruleset name="5ch.net">
+	<target host="5ch.net" />
 	<target host="*.5ch.net" />
-
-	<test url="http://5ch.net/" />
 	<test url="http://www2.5ch.net/" />
 	<test url="http://itest.5ch.net/" />
 	<test url="http://premium.5ch.net/" />

--- a/src/chrome/content/rules/5ch.xml
+++ b/src/chrome/content/rules/5ch.xml
@@ -12,7 +12,7 @@
         <test url="http://newsnavi.5ch.net/" />
         <test url="http://info.5ch.net/" />
         <test url="http://o.5ch.net/" />
-        <test url="http://stat.5ch.net" />
+        <test url="http://stat.5ch.net/" />
         <test url="http://dig.5ch.net/" />
         <test url="http://qb5.5ch.net/" />
         

--- a/src/chrome/content/rules/5ch.xml
+++ b/src/chrome/content/rules/5ch.xml
@@ -1,0 +1,45 @@
+<ruleset name="5ch.net">
+        <target host="5ch.net" />
+        <target host="*.5ch.net" />
+
+        <test url="http://5ch.net/" />
+        <test url="http://www2.5ch.net/" />
+        <test url="http://itest.5ch.net/" />
+        <test url="http://premium.5ch.net/" />
+        <test url="http://be.5ch.net/" />
+        <test url="http://i.5ch.net/" />
+        <test url="http://headline.5ch.net/" />
+        <test url="http://newsnavi.5ch.net" />
+        <test url="http://info.5ch.net" />
+        <test url="http://o.5ch.net/" />
+        <test url="http://stat.5ch.net" />
+        <test url="http://dig.5ch.net/" />
+        <test url="http://qb5.5ch.net/" />
+        
+        <test url="http://agree.5ch.net/" />
+        <test url="http://asahi.5ch.net/" />
+        <test url="http://egg.5ch.net/" />
+        <test url="http://fate.5ch.net/" />
+        <test url="http://hayabusa9.5ch.net/" />
+        <test url="http://hebi.5ch.net/" />
+        <test url="http://himawari.5ch.net/" />
+        <test url="http://krsw.5ch.net/" />
+        <test url="http://lavender.5ch.net/" />
+        <test url="http://leia.5ch.net/" />
+        <test url="http://mao.5ch.net/" />
+        <test url="http://matsuri.5ch.net/" />
+        <test url="http://medaka.5ch.net/" />
+        <test url="http://mevius.5ch.net/" />
+        <test url="http://nhk2.5ch.net/" />
+        <test url="http://rio2016.5ch.net/" />
+        <test url="http://rosie.5ch.net/" />
+        <test url="http://swallow.5ch.net/" />
+        <test url="http://tanuki.5ch.net/" />
+
+        <securecookie host="^\." name="^(?:__cfduid|cf_clearance)$" />
+        <securecookie host="^\w" name=".+" />
+
+        <rule from="^http:"
+                to="https:" />
+
+</ruleset>

--- a/src/chrome/content/rules/5ch.xml
+++ b/src/chrome/content/rules/5ch.xml
@@ -36,8 +36,7 @@
         <test url="http://swallow.5ch.net/" />
         <test url="http://tanuki.5ch.net/" />
 
-        <securecookie host="^\." name="^(?:__cfduid|cf_clearance)$" />
-        <securecookie host="^\w" name=".+" />
+        <securecookie host=".+" name=".+" />
 
         <rule from="^http:"
                 to="https:" />

--- a/src/chrome/content/rules/5ch.xml
+++ b/src/chrome/content/rules/5ch.xml
@@ -1,5 +1,4 @@
 <ruleset name="5ch.net">
-	<target host="5ch.net" />
 	<target host="*.5ch.net" />
 
 	<test url="http://5ch.net/" />
@@ -13,9 +12,11 @@
 	<test url="http://info.5ch.net/" />
 	<test url="http://o.5ch.net/" />
 	<test url="http://stat.5ch.net/" />
+	<test url="http://find.5ch.net/" />
+	<test url="http://menu.5ch.net/" />
 	<test url="http://dig.5ch.net/" />
 	<test url="http://qb5.5ch.net/" />
-	
+
 	<test url="http://agree.5ch.net/" />
 	<test url="http://asahi.5ch.net/" />
 	<test url="http://egg.5ch.net/" />

--- a/src/chrome/content/rules/5ch.xml
+++ b/src/chrome/content/rules/5ch.xml
@@ -10,7 +10,7 @@
         <test url="http://i.5ch.net/" />
         <test url="http://headline.5ch.net/" />
         <test url="http://newsnavi.5ch.net/" />
-        <test url="http://info.5ch.net" />
+        <test url="http://info.5ch.net/" />
         <test url="http://o.5ch.net/" />
         <test url="http://stat.5ch.net" />
         <test url="http://dig.5ch.net/" />

--- a/src/chrome/content/rules/5ch.xml
+++ b/src/chrome/content/rules/5ch.xml
@@ -9,7 +9,7 @@
         <test url="http://be.5ch.net/" />
         <test url="http://i.5ch.net/" />
         <test url="http://headline.5ch.net/" />
-        <test url="http://newsnavi.5ch.net" />
+        <test url="http://newsnavi.5ch.net/" />
         <test url="http://info.5ch.net" />
         <test url="http://o.5ch.net/" />
         <test url="http://stat.5ch.net" />


### PR DESCRIPTION
### List related ruleset

Currently `2ch.net` is being redirected to `5ch.net`.

- [2ch.xml](https://github.com/EFForg/https-everywhere/blob/master/src/chrome/content/rules/2ch.net.xml)

P.S. ( September 8, 2020)
- 1st test group: Non-forum server: relatively easy for servers to be rejected.
- 2nd test group: Forum server

Checked on September 8, 2020 at [here](https://ss1.xrea.com/z4s85ttt.s1007.xrea.com/5chkanshi/disp_status.php)