### PR TITLE
Revert "[Fasthosts] Add coverage"

### DIFF
--- a/src/chrome/content/rules/Fasthosts.xml
+++ b/src/chrome/content/rules/Fasthosts.xml
@@ -39,7 +39,7 @@
 	<rule from="^http://(?:www\.)?fasthosts\.co\.uk/"
 		to="https://www.fasthosts.co.uk/" />
 
-	<rule from="^http://secure(\d|1[0-3-9]|2[0-4]|5[26])\.prositehosting\.co\.uk/"
+	<rule from="^http://secure(\d|1[013-9]|2[0-4]|5[26])\.prositehosting\.co\.uk/"
 		to="https://secure$1.prositehosting.co.uk/" />
 		<test url="http://secure32.prositehosting.co.uk/" />
 		<test url="http://secure4.prositehosting.co.uk/" />


### PR DESCRIPTION
This reverts commit a9d02a014841be7da0e15ce6e8bd5ebbfb918e13
because it used invalid regex syntax.
