### PR TITLE
Updated chromedriver path to ensure correct symlink creation

### DIFF
--- a/install-dev-dependencies.sh
+++ b/install-dev-dependencies.sh
@@ -52,8 +52,8 @@ if type apt-get>/dev/null 2>&1;  then
     $SUDO_SHIM chown root /usr/bin/geckodriver
     $SUDO_SHIM chmod 755 /usr/bin/geckodriver
   fi
-  if [ ! -f /usr/lib/chromium/chromedriver ] && [ -f `which chromedriver` ]; then
-    $SUDO_SHIM ln -s `which chromedriver` /usr/lib/chromium/chromedriver
+  if [ ! -f /usr/lib/chromium-browser/chromedriver ] && [ -f `which chromedriver` ]; then
+    $SUDO_SHIM ln -s `which chromedriver` /usr/lib/chromium-browser/chromedriver
   fi
 
 # macOS installation


### PR DESCRIPTION
The latest versions of the chromium-browser package now install by
default to /usr/lib/chromium-browser, not /usr/lib/chromium. By
updating the locations where /usr/lib/chromium is used to the new
path, the symlink for the chromedriver is properly created.

Further details can be found in issue #19174 

### List related issues if any

- Solves issue #19174