### PR TITLE
Create Cht.sh.xml

### DIFF
--- a/src/chrome/content/rules/Cht.sh.xml
+++ b/src/chrome/content/rules/Cht.sh.xml
@@ -1,0 +1,10 @@
+<ruleset name="Cht.sh">
+	<target host="cht.sh" />
+	<target host="*.cht.sh" />
+		<test url="http://valid.cht.sh/curl" />
+		<test url="http://example.cht.sh/wget" />
+		<test url="http://test.cht.sh/rpm" />
+		<test url="http://cht.sh/apt" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>


### PR DESCRIPTION
Propose a rule for cht.sh.

This site is using the wildcard certs so `*.cht.sh` should work fine.
