### PR TITLE
Create Ping.pe.xml

### DIFF
--- a/src/chrome/content/rules/Ping.pe.xml
+++ b/src/chrome/content/rules/Ping.pe.xml
@@ -1,0 +1,21 @@
+<ruleset name="Ping.pe">
+	<target host="ping.pe" />
+	<target host="www.ping.pe" />
+		<test url="http://www.ping.pe/cloudflare.com" />
+
+	<target host="port.ping.pe" />
+		<test url="http://port.ping.pe/1.2.3.4:22" />
+
+	<target host="dig.ping.pe" />
+		<test url="http://dig.ping.pe/dns.google:A:1.0.0.1" />
+
+	<target host="mrtg.ping.pe" />
+		<test url="http://mrtg.ping.pe/load.html" />
+
+	<target host="i.ping.pe" />
+		<test url="http://i.ping.pe/n/Y/img_nYlIKgrb.png" />
+		<test url="http://i.ping.pe/y/1/img_y1WLfjiE.png" />
+		<test url="http://i.ping.pe/8/O/img_8Oi1R3Vr.png" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>


### PR DESCRIPTION
Propose a rule for ping.pe.

Though this site is using the wildcard cert `*.ping.pe`, but as I run through some test it turns out that `*.ping.pe` doesn't have a CNAME record. So any other subdomains that are not list here should count the NX error.