### PR TITLE
Create bay12games.com.xml

### DIFF
--- a/src/chrome/content/rules/bay12games.com.xml
+++ b/src/chrome/content/rules/bay12games.com.xml
@@ -4,6 +4,7 @@
 		- www.bay12forums.com
 -->
 <ruleset name="bay12games.com">
+	<target host="bay12games.com" />
 	<target host="www.bay12games.com" />
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/bay12games.com.xml
+++ b/src/chrome/content/rules/bay12games.com.xml
@@ -2,7 +2,7 @@
 	Secure connection failed:
 		- dffd.bay12games.com
 		- www.bay12forums.com
---->
+-->
 <ruleset name="bay12games.com">
 	<target host="www.bay12games.com" />
 

--- a/src/chrome/content/rules/bay12games.com.xml
+++ b/src/chrome/content/rules/bay12games.com.xml
@@ -1,7 +1,17 @@
 <!--
-	Secure connection failed:
+	Refused:
 		- dffd.bay12games.com
-		- www.bay12forums.com
+
+	Mismatched:
+		- ftp.bay12games.com
+		- lists.bay12games.com
+		- mail.bay12games.com
+		- ns1.bay12games.com
+		- ns2.bay12games.com
+		- vps.bay12games.com
+
+	Self-signed:
+		- webmail.bay12games.com
 -->
 <ruleset name="bay12games.com">
 	<target host="bay12games.com" />

--- a/src/chrome/content/rules/bay12games.com.xml
+++ b/src/chrome/content/rules/bay12games.com.xml
@@ -1,0 +1,11 @@
+<ruleset name="bay12games.com">
+    <!--
+        Secure connection failed:
+
+            dffd.bay12games.com
+            www.bay12forums.com
+    --->
+	<target host="www.bay12games.com" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/bay12games.com.xml
+++ b/src/chrome/content/rules/bay12games.com.xml
@@ -1,10 +1,9 @@
+<!--
+	Secure connection failed:
+		- dffd.bay12games.com
+		- www.bay12forums.com
+--->
 <ruleset name="bay12games.com">
-    <!--
-        Secure connection failed:
-
-            dffd.bay12games.com
-            www.bay12forums.com
-    --->
 	<target host="www.bay12games.com" />
 
 	<rule from="^http:" to="https:" />


### PR DESCRIPTION
This lets `www.bay12games.com` be picked up as an `https`-preferred site.  Unfortunately the related hosts `dffd.bay12games.com` and `www.bay12forums.com` aren't capable of `https`.