### PR TITLE
Add tekram.com

### DIFF
--- a/src/chrome/content/rules/tekram.com.xml
+++ b/src/chrome/content/rules/tekram.com.xml
@@ -1,9 +1,8 @@
 <ruleset name="tekram.com">
-        <target host="tekram.com" />
-        <target host="www.tekram.com" />
+	<target host="tekram.com" />
+	<target host="www.tekram.com" />
 
-        <rule from="^http:"
-              to="https:" />
+	<rule from="^http:" to="https:" />
 
 	<securecookie host="^\.tekram\.com$" name=".+" />
 </ruleset>

--- a/src/chrome/content/rules/tekram.com.xml
+++ b/src/chrome/content/rules/tekram.com.xml
@@ -1,0 +1,9 @@
+<ruleset name="tekram.com">
+        <target host="tekram.com" />
+        <target host="www.tekram.com" />
+
+        <rule from="^http:"
+              to="https:" />
+
+	<securecookie host="^\.tekram\.com$" name=".+" />
+</ruleset>


### PR DESCRIPTION
Rule only targets the two domains that don't use redirect.
In the backend, tekram seems to use bigcommerce for everything,
which supports https and in the site it's being included as https.

It's strange that they set the hsts header with max-age=0, yet
backend consistently use https for everything.

Added all cookies as securecookies, while there are cookies
with the flag, some SESSION ones weren't.