### PR TITLE
Add k2b-bulk.ebay.de, fix ebay.de ruleset

### DIFF
--- a/src/chrome/content/rules/ebay.de.xml
+++ b/src/chrome/content/rules/ebay.de.xml
@@ -274,7 +274,6 @@
 	<target host="shipping.ebay.de" />
 	<target host="shiptrack.ebay.de" />
 	<target host="signin.ebay.de" />
-	<target host="signinalert.ebay.de" />
 	<target host="sofe.ebay.de" />
 	<target host="spd.ebay.de" />
 	<target host="www.sps.ebay.de" />

--- a/src/chrome/content/rules/ebay.de.xml
+++ b/src/chrome/content/rules/ebay.de.xml
@@ -8,12 +8,14 @@
 		- ebay.de	(h)
 		- aetka	(m)
 		- arribada	(t)
+		- autodiscover (r)
 		- autoservice	(r)
 		- axa	(h)
 		- blogs	(m)
 		- buyvrfn	(m)
 		- cancel	(r)
 		- cgi1	(m)
+		- msa-b1.cgi3 (i)
 		- cgi4	(r)
 		- comm	(r)
 		- community-legacy	(m)
@@ -28,6 +30,7 @@
 		- dsa	(m)
 		- einkaufstipps	(r)
 		- einladen	(r)
+		- elektronik-ankauf (e)
 		- entwickler	(m)
 		- epluswap	(m)
 		- scgi.express	(m)
@@ -37,11 +40,14 @@
 		- heute	(m)
 		- hrs	(h)
 		- hub	(m)
+		- influencernetwork (e)
 		- inspiriert	(r)
 		- internationalverkaufen	(r)
+		- item (h)
 		- console.internationalverkaufen	(r)
 		- www.kleinanzeigen	(m)
 		- lego	(m)
+		- lers (m)
 		- mail	(r)
 		- members	(m)
 		- mesgmy	(r)
@@ -57,11 +63,14 @@
 		- presse	(m)
 		- presseconsole	(t)
 		- previewitem	(r)
+		- programm (t)
 		- www.proxy	(HTTP 404 error)
 		- recommendations	(r)
 		- returns	(m)
+		- feedback.rtl (m)
 		- www.sandbox	(r)
 		- fedsignin.sandbox	(HTTP 503 error)
+		- merchant.sandbox (t)
 		- www.mipapplication.sandbox	(r)
 		- my.sandbox	(r)
 		- payments.sandbox	(m)
@@ -74,6 +83,7 @@
 		- scat	(r)
 		- search-completed	(r)
 		- seat	(m)
+		- securepromo (t)
 		- selfiecup	(r)
 		- sell	(m)
 		- shop	(r)
@@ -108,6 +118,7 @@
 		- wohnen.stores.shop	(m)
 		- sm	(r)
 		- www.sm	(r)
+		- sofortverkauf (e)
 		- specials	(h)
 		- spielplatz	(m)
 		- stage-partner	(t)
@@ -127,6 +138,7 @@
 		- upload	(r)
 		- vattenfall	(h)
 		- verimonitor	(r)
+		- versand (t)
 		- versand-staging	(t)
 		- volkswagen	(m)
 		- wap	(m)
@@ -150,7 +162,6 @@
 	<target host="applications.ebay.de" />
 	<target host="arbd.ebay.de" />
 	<target host="auth.ebay.de" />
-	<target host="autodiscover.ebay.de" />
 	<target host="www.billing.ebay.de" />
 	<target host="www.bizpolicy.ebay.de" />
 	<target host="www.bizvrfn.ebay.de" />
@@ -161,11 +172,9 @@
 	<target host="cart.ebay.de" />
 	<target host="cgi.ebay.de" />
 	<target host="cgi3.ebay.de" />
-	<target host="msa-b1.cgi3.ebay.de" />
 	<target host="cgi5.ebay.de" />
 	<target host="msa-b1.cgi5.ebay.de" />
 	<target host="cgi6.ebay.de" />
-	<target host="checkout.ebay.de" />
 	<target host="checkoutweb.ebay.de" />
 	<target host="community.ebay.de" />
 	<target host="connect.ebay.de" />
@@ -175,7 +184,6 @@
 	<target host="donation.ebay.de" />
 	<target host="www.donation.ebay.de" />
 	<target host="www.signup.ebayplus.ebay.de" />
-	<target host="elektronik-ankauf.ebay.de" />
 	<target host="epn.ebay.de" />
 	<target host="epnt.ebay.de" />
 	<target host="epsvc.ebay.de" />
@@ -189,19 +197,15 @@
 	<target host="fundinginstrument.ebay.de" />
 	<target host="fyp.ebay.de" />
 	<target host="fyp2.ebay.de" />
-	<target host="gewinnen.ebay.de" />
 	<target host="gha.ebay.de" />
 	<target host="gslblui.ebay.de" />
 	<target host="www.ilvrfn.ebay.de" />
-	<target host="influencernetwork.ebay.de" />
 	<target host="invoice.ebay.de" />
-	<target host="item.ebay.de" />
 	<target host="k2b-bulk.ebay.de" />
 	<target host="www.kgvrfn.ebay.de" />
 	<target host="kleinanzeigen.ebay.de" />
 	<target host="m.kleinanzeigen.ebay.de" />
 	<target host="komfort.ebay.de" />
-	<target host="lers.ebay.de" />
 	<target host="m.ebay.de" />
 	<target host="www.m.ebay.de" />
 	<target host="reg.m.ebay.de" />
@@ -217,7 +221,6 @@
 	<target host="www.mipapplication.ebay.de" />
 	<target host="namechange.ebay.de" />
 	<target host="news.ebay.de" />
-	<target host="notifyweb.ebay.de" />
 	<target host="ocs.ebay.de" />
 	<target host="ocsnext.ebay.de" />
 	<target host="ocsrest.ebay.de" />
@@ -225,7 +228,6 @@
 	<target host="offer.ebay.de" />
 	<target host="ofr.ebay.de" />
 	<target host="pages.ebay.de" />
-	<target host="paisapay.ebay.de" />
 	<target host="partnernetwork.ebay.de" />
 	<target host="pay.ebay.de" />
 	<target host="payments.ebay.de" />
@@ -236,16 +238,13 @@
 	<target host="paymentscmd.ebay.de" />
 	<target host="www.picupload.ebay.de" />
 	<target host="pls.ebay.de" />
-	<target host="plusbeimverkaufen.ebay.de" />
 	<target host="postage.ebay.de" />
 	<target host="nw.pp.ebay.de" />
 	<target host="www.nw.pp.ebay.de" />
 	<target host="ppm1.ebay.de" />
 	<target host="ppm3.ebay.de" />
 	<target host="prefs.ebay.de" />
-	<target host="privatretouren.ebay.de" />
 	<target host="profisuche.ebay.de" />
-	<target host="programm.ebay.de" />
 	<target host="pulsar.ebay.de" />
 	<target host="qu.ebay.de" />
 	<target host="rebulk.ebay.de" />
@@ -256,12 +255,10 @@
 	<target host="rewards.ebay.de" />
 	<target host="rover.ebay.de" />
 	<target host="www.rsvp.ebay.de" />
-	<target host="feedback.rtl.ebay.de" />
 	<target host="www.bizpolicy.sandbox.ebay.de" />
 	<target host="checkout.sandbox.ebay.de" />
 	<target host="community.sandbox.ebay.de" />
 	<target host="fedauth.sandbox.ebay.de" />
-	<target host="merchant.sandbox.ebay.de" />
 	<target host="mesg.sandbox.ebay.de" />
 	<target host="www.mip.sandbox.ebay.de" />
 	<target host="resolutioncenter.sandbox.ebay.de" />
@@ -269,29 +266,21 @@
 	<target host="signin.sandbox.ebay.de" />
 	<target host="saturn.ebay.de" />
 	<target host="scgi.ebay.de" />
-	<target host="securefeedback.ebay.de" />
 	<target host="secureportal.ebay.de" />
-	<target host="securepromo.ebay.de" />
-	<target host="secureregistration.ebay.de" />
 	<target host="sellerstandards.ebay.de" />
 	<target host="sellerupdate.ebay.de" />
 	<target host="sellvrfn.ebay.de" />
 	<target host="www.sellvrfn.ebay.de" />
-	<target host="settings.ebay.de" />
 	<target host="shipping.ebay.de" />
 	<target host="shiptrack.ebay.de" />
 	<target host="signin.ebay.de" />
 	<target host="signinalert.ebay.de" />
-	<target host="socialapp.ebay.de" />
 	<target host="sofe.ebay.de" />
-	<target host="sofortverkauf.ebay.de" />
 	<target host="spd.ebay.de" />
 	<target host="www.sps.ebay.de" />
 	<target host="srtm.ebay.de" />
 	<target host="www.subs.ebay.de" />
 	<target host="verkaeuferportal.ebay.de" />
-	<target host="versand.ebay.de" />
-	<target host="versandetikett.ebay.de" />
 	<target host="viv.ebay.de" />
 	<target host="vod.ebay.de" />
 	<target host="wantitnow.ebay.de" />

--- a/src/chrome/content/rules/ebay.de.xml
+++ b/src/chrome/content/rules/ebay.de.xml
@@ -196,6 +196,7 @@
 	<target host="influencernetwork.ebay.de" />
 	<target host="invoice.ebay.de" />
 	<target host="item.ebay.de" />
+	<target host="k2b-bulk.ebay.de" />
 	<target host="www.kgvrfn.ebay.de" />
 	<target host="kleinanzeigen.ebay.de" />
 	<target host="m.kleinanzeigen.ebay.de" />


### PR DESCRIPTION
This is a page for sellers on ebay - some links are still HTTP but HTTPS is available.

To see any content on this domain, you have to register on ebay.de, enable "Verkäufer-Cockpit Pro" on https://www.ebay.de/sh/landing, open "Mein ebay" at the top right, click on "Bestellungen" (orders), and select "Archiviert" (archived) on the left hand side. Adding a rule to HTTPS Everywhere upgrades this HTTP connection to HTTPS and does not break things.
