### PR TITLE
Create Openid.org.cn.xml

### DIFF
--- a/src/chrome/content/rules/Openid.org.cn.xml
+++ b/src/chrome/content/rules/Openid.org.cn.xml
@@ -1,0 +1,8 @@
+<ruleset name="Openid.org.cn">
+	<target host="openid.org.cn" />
+	<target host="www.openid.org.cn" />
+
+	<securecookie host=".+" name=".+" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>  


### PR DESCRIPTION
OpenID identity page can't be redirected to HTTPS due to invalid SSL certificate. For example: http://rany.openid.org.cn .

This doesn't matter because passwords are only sent to either openid.org.cn or www.openid.org.cn which don't redirect to HTTPS by default.