### PR TITLE
Mimetype rulesets change for Opera

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ chromium.pem
 from-preloads/
 pkg/
 src/chrome/content/rules/default.rulesets
-src/chrome/content/rulesets.json
+src/chrome/content/rules/default.rulesets.json
 src/defaults/rulesets.sqlite
 test_profile/
 tokenkeys.py*

--- a/test/validations/filename/run.py
+++ b/test/validations/filename/run.py
@@ -24,7 +24,7 @@ def validate_filenames():
 
     for fi in filenames:
         basename = fi.split(os.path.sep)[-1]
-        if basename == '00README' or basename == 'make-trivial-rule' or basename == 'default.rulesets':
+        if basename == '00README' or basename == 'make-trivial-rule' or basename == 'default.rulesets' or basename == 'default.rulesets.json':
             continue
 
         if " " in fi:

--- a/test/validations/special/run.py
+++ b/test/validations/special/run.py
@@ -157,7 +157,7 @@ for filename in filenames:
     xml_parser = etree.XMLParser(remove_blank_text=True)
 
     basename = filename.split(os.path.sep)[-1]
-    if basename == '00README' or basename == 'make-trivial-rule' or basename == 'default.rulesets':
+    if basename == '00README' or basename == 'make-trivial-rule' or basename == 'default.rulesets' basename == 'default.rulesets.json':
         continue
 
     try:

--- a/test/validations/special/run.py
+++ b/test/validations/special/run.py
@@ -157,7 +157,7 @@ for filename in filenames:
     xml_parser = etree.XMLParser(remove_blank_text=True)
 
     basename = filename.split(os.path.sep)[-1]
-    if basename == '00README' or basename == 'make-trivial-rule' or basename == 'default.rulesets' basename == 'default.rulesets.json':
+    if basename == '00README' or basename == 'make-trivial-rule' or basename == 'default.rulesets' or basename == 'default.rulesets.json':
         continue
 
     try:

--- a/utils/merge-rulesets.py
+++ b/utils/merge-rulesets.py
@@ -30,6 +30,7 @@ args = parser.parse_args()
 
 # output filename, pointed to the merged ruleset
 ofn = os.path.join(args.source_dir, "default.rulesets")
+ojson = os.path.join(args.source_dir, "default.rulesets.json")
 
 # XML Ruleset Files
 files = map(normalize, glob.glob(os.path.join(args.source_dir, "*.xml")))
@@ -37,6 +38,8 @@ files = map(normalize, glob.glob(os.path.join(args.source_dir, "*.xml")))
 # Under git bash, sed -i issues errors and sets the file "read-only".
 if os.path.isfile(ofn):
     os.system("chmod u+w " + ofn)
+if os.path.isfile(ojson):
+    os.system("chmod u+w " + ojson)
 
 # Library (JSON Object)
 library = []
@@ -97,10 +100,15 @@ for filename in sorted(files):
     library.append(ruleset);
 
 # Write to default.rulesets
-print(" * Writing JSON library to %s" % ofn)
+print(" * Writing JSON library to %s and %s"% (ofn, ojson) )
 outfile = open(ofn, "w")
+jsonout = open(ojson, "w")
+
 outfile.write(json.dumps(library, separators=(",", ":")))
+jsonout.write(json.dumps(library, separators=(",", ":")))
+
 outfile.close()
+jsonout.close()
 
 # Everything is okay.
 print(" * Everything is okay.")


### PR DESCRIPTION
Changing the `default.rulesets` file over by naming the extension.

This is because Opera will not accept this file unfortunately as is. I tried to find ways to make this work without having to create a new file. But coming up short on good ideas. If anyone would like to suggest a work around, I'd appreciate it.

My last idea is packaging the CRX file for Opera differently in the build process to include `.json`. But leaving this draft up for the time being until I make the final decision to change. Which would entail migrating over in small phases and letting stakeholders who use the hosted set of rulesets know that this file name is changing.
