### PR TITLE
Add rule for mkwrs.com

### DIFF
--- a/src/chrome/content/rules/mkwrs.com.xml
+++ b/src/chrome/content/rules/mkwrs.com.xml
@@ -1,0 +1,7 @@
+<ruleset name="MKWRs">
+        <target host="mkwrs.com" />
+        <target host="www.mkwrs.com" />
+
+        <rule from="^http:"
+                to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/mkwrs.com.xml
+++ b/src/chrome/content/rules/mkwrs.com.xml
@@ -1,3 +1,6 @@
+<!--
+	Host sends a HSTS header and has a wildcard DNS record, but no wildcard certificate. This breaks other subdomains.
+-->
 <ruleset name="MKWRs">
         <target host="mkwrs.com" />
         <target host="www.mkwrs.com" />


### PR DESCRIPTION
mkwrs.com tracks the world record time trials for every game in the _Mario Kart_ video game series. This adds a rule-set to convert HTTP requests to HTTPS links.