### PR TITLE
HOTFIX: Statically write versions for Chromedriver

### DIFF
--- a/test/setup_travis.sh
+++ b/test/setup_travis.sh
@@ -5,12 +5,13 @@ toplevel=$(git rev-parse --show-toplevel)
 function setup_chrome {
     # Install the latest version of the chromedriver
     version=$(wget https://chromedriver.storage.googleapis.com/LATEST_RELEASE -q -O -)
+    static="84.0.4147.30"
 
     # Mismatch on Chromedriver Latest and Chrome Beta, hardcode for Chrome Beta
     if [ "$1" == "chrome beta" ]; then
-      url="https://chromedriver.storage.googleapis.com/83.0.4103.14/chromedriver_linux64.zip"
+      url="https://chromedriver.storage.googleapis.com/85.0.4183.38/chromedriver_linux64.zip"
     elif [ "$1" == "chrome stable" ]; then
-      url="https://chromedriver.storage.googleapis.com/${version}/chromedriver_linux64.zip"
+      url="https://chromedriver.storage.googleapis.com/${static}/chromedriver_linux64.zip"
     fi
 
     wget -O /tmp/chromedriver.zip ${url}
@@ -21,7 +22,7 @@ function setup_chrome {
 function setup_firefox {
     #version=$(curl -s https://api.github.com/repos/mozilla/geckodriver/releases/latest | grep tag_name | cut -d '"' -f 4)
     # hard-code latest version, since apparently the above `curl` is fucking up in travis
-    version="v0.23.0"
+    version="v0.26.0"
     url="https://github.com/mozilla/geckodriver/releases/download/${version}/geckodriver-${version}-linux64.tar.gz"
     wget -O /tmp/geckodriver.tar.gz ${url}
     sudo tar -xvf /tmp/geckodriver.tar.gz -C /usr/local/bin/


### PR DESCRIPTION
- For an unknown reason, Travis is pulling one version below on stable
- This causes a mismatch in Chromedriver version to Chrome
- Statically update for now and update statically versioned Beta
- Also updating Geckodriver proactively