### PR TITLE
Create Dailynous.com.xml

### DIFF
--- a/src/chrome/content/rules/Dailynous.com.xml
+++ b/src/chrome/content/rules/Dailynous.com.xml
@@ -1,0 +1,8 @@
+<ruleset name="Dailynous.com">
+	<target host="dailynous.com" />
+	<target host="www.dailynous.com" />
+
+	<securecookie host=".+" name=".+" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>  


### PR DESCRIPTION
dailynous.com supports HTTPS on both www.dailynous.com and dailynous.com but doesn't redirect users to the HTTPS page.

(there is no mixed content) 