### PR TITLE
Expand tu-darmstadt.de

### DIFF
--- a/src/chrome/content/rules/TU-Darmstadt.de.xml
+++ b/src/chrome/content/rules/TU-Darmstadt.de.xml
@@ -1,50 +1,283 @@
 <!--
 	Technische Universitaet Darmstadt
 
-
-	Fully covered subdomains:
-
-		- www.cs
-		- idm-bi01.hrz
-		- sso.hrz
-		- www.hrz
-		- www.idm
-		- wiki.cdc.informatik
-		- www.cdc.informatik
-		- www.informatik
-		- www.ulb
-		- www
-
-
 	^tu-darmstadt.de doesn't exist.
 
-
-	These altnames don't exist:
-
-		- cs.tu-darmstadt.de
-		- cdc.cs.tu-darmstadt.de
-		- www.cdc.cs.tu-darmstadt.de
-		- informatik.tu-darmstadt.de
-		- cdc.informatik.tu-darmstadt.de
-
+	This includes: 
+		- all manually added subdomains from 210332db950e2b4a3a89a51ba59c3629dc7c6407
+		- all subdomains from brutelist3r that returned a HTTP200 status code
 -->
-<ruleset name="TU-Darmstadt.de (partial)">
+<ruleset name="TU-Darmstadt.de">
 
-	<target host="www.cs.tu-darmstadt.de" />
-	<target host="idm-bi01.hrz.tu-darmstadt.de" />
-	<target host="sso.hrz.tu-darmstadt.de" />
-	<target host="www.hrz.tu-darmstadt.de" />
-	<target host="www.idm.tu-darmstadt.de" />
-	<target host="wiki.cdc.informatik.tu-darmstadt.de" />
-	<target host="www.cdc.informatik.tu-darmstadt.de" />
-	<target host="www.informatik.tu-darmstadt.de" />
-	<target host="www.ulb.tu-darmstadt.de" />
 	<target host="www.tu-darmstadt.de" />
-
-
-	<!--	Not secured by server:
-					-->
-	<!--securecookie host="^(www\.cdc|www)\.informatik\.tu-darmstadt\.de$" name="^fe_typo_user$" /-->
+	<target host="ai-da.tu-darmstadt.de" />
+	<target host="www.akaflieg.tu-darmstadt.de" />
+	<target host="ehemalige.akaflieg.tu-darmstadt.de" />
+	<target host="konsul.akaflieg.tu-darmstadt.de" />
+	<target host="wiki.akaflieg.tu-darmstadt.de" />
+	<target host="www.arc2019.tu-darmstadt.de" />
+	<target host="help.architektur.tu-darmstadt.de" />
+	<target host="seminarbasar.architektur.tu-darmstadt.de" />
+	<target host="toyblocks.architektur.tu-darmstadt.de" />
+	<target host="webmail.architektur.tu-darmstadt.de" />
+	<target host="auth-reload.asta.tu-darmstadt.de" />
+	<target host="mail.asta.tu-darmstadt.de" />
+	<target host="mail1.asta.tu-darmstadt.de" />
+	<target host="slmg.bauing.tu-darmstadt.de" />
+	<target host="bsprox.verkehr.bauing.tu-darmstadt.de" />
+	<target host="im.compbiol.bio.tu-darmstadt.de" />
+	<target host="office.oc.chemie.tu-darmstadt.de" />
+	<target host="cloud.theo.chemie.tu-darmstadt.de" />
+	<target host="www.cit.tu-darmstadt.de" />
+	<target host="it.crossing.tu-darmstadt.de" />
+	<target host="svn.crossing.tu-darmstadt.de" />
+	<target host="www.crossing-week-2019.tu-darmstadt.de" />
+	<target host="www.cs.tu-darmstadt.de" />
+	<target host="seemoo.cs.tu-darmstadt.de" />
+	<target host="www.seemoo.cs.tu-darmstadt.de" />
+	<target host="svn.cysec.tu-darmstadt.de" />
+	<target host="www.dads.tu-darmstadt.de" />
+	<target host="deutschlandstipendium.tu-darmstadt.de" />
+	<target host="www.dh-concepts.tu-darmstadt.de" />
+	<target host="www.digital-philology.tu-darmstadt.de" />
+	<target host="www.digitalhumanities.tu-darmstadt.de" />
+	<target host="datterich.digitalhumanities.tu-darmstadt.de" />
+	<target host="www.digitalphilology.tu-darmstadt.de" />
+	<target host="www.distributed-ledger-center.tu-darmstadt.de" />
+	<target host="blog.e-learning.tu-darmstadt.de" />
+	<target host="ost.dek.e-technik.tu-darmstadt.de" />
+	<target host="must.emk.e-technik.tu-darmstadt.de" />
+	<target host="pc229.hf.e-technik.tu-darmstadt.de" />
+	<target host="cloud.rtm.e-technik.tu-darmstadt.de" />
+	<target host="mail.rtm.e-technik.tu-darmstadt.de" />
+	<target host="www.ees.tu-darmstadt.de" />
+	<target host="www.energygov.tu-darmstadt.de" />
+	<target host="www.es.tu-darmstadt.de" />
+	<target host="evaluation.tu-darmstadt.de" />
+	<target host="www.fif.tu-darmstadt.de" />
+	<target host="www.filmkreis.tu-darmstadt.de" />
+	<target host="foren.tu-darmstadt.de" />
+	<target host="forum.tu-darmstadt.de" />
+	<target host="www.fsk.tu-darmstadt.de" />
+	<target host="www.fsr.tu-darmstadt.de" />
+	<target host="gomera.geo.tu-darmstadt.de" />
+	<target host="www.glr.tu-darmstadt.de" />
+	<target host="www.gugw.tu-darmstadt.de" />
+	<target host="247-230.gugw.tu-darmstadt.de" />
+	<target host="office.247-230.gugw.tu-darmstadt.de" />
+	<target host="247-232.gugw.tu-darmstadt.de" />
+	<target host="247-233.gugw.tu-darmstadt.de" />
+	<target host="test2.247-233.gugw.tu-darmstadt.de" />
+	<target host="test3.247-233.gugw.tu-darmstadt.de" />
+	<target host="test4.247-233.gugw.tu-darmstadt.de" />
+	<target host="cloud.gugw.tu-darmstadt.de" />
+	<target host="office.cloud.gugw.tu-darmstadt.de" />
+	<target host="fb2-pc202.gugw.tu-darmstadt.de" />
+	<target host="ifs-pc206.gugw.tu-darmstadt.de" />
+	<target host="lists.gugw.tu-darmstadt.de" />
+	<target host="mail.gugw.tu-darmstadt.de" />
+	<target host="saturn.chaos.hg.tu-darmstadt.de" />
+	<target host="uranus.chaos.hg.tu-darmstadt.de" />
+	<target host="cloud.chor.hg.tu-darmstadt.de" />
+	<target host="intern.chor.hg.tu-darmstadt.de" />
+	<target host="wiki.chor.hg.tu-darmstadt.de" />
+	<target host="server.sailingteam.hg.tu-darmstadt.de" />
+	<target host="ipa.wegerecht.hg.tu-darmstadt.de" />
+	<target host="piwigo.wegerecht.hg.tu-darmstadt.de" />
+	<target host="wgr1.wegerecht.hg.tu-darmstadt.de" />
+	<target host="www.hrz.tu-darmstadt.de" />
+	<target host="arswww.hrz.tu-darmstadt.de" />
+	<target host="arswww-dev.hrz.tu-darmstadt.de" />
+	<target host="cgi.hrz.tu-darmstadt.de" />
+	<target host="download.hrz.tu-darmstadt.de" />
+	<target host="mahara.hrz.tu-darmstadt.de" />
+	<target host="mail-control.hrz.tu-darmstadt.de" />
+	<target host="medienportal.hrz.tu-darmstadt.de" />
+	<target host="download.mmag.hrz.tu-darmstadt.de" />
+	<target host="moodle-schulung.hrz.tu-darmstadt.de" />
+	<target host="cup1.net.hrz.tu-darmstadt.de" />
+	<target host="cup2.net.hrz.tu-darmstadt.de" />
+	<target host="cup3.net.hrz.tu-darmstadt.de" />
+	<target host="cup4.net.hrz.tu-darmstadt.de" />
+	<target host="mrtg.net.hrz.tu-darmstadt.de" />
+	<target host="olw-material.hrz.tu-darmstadt.de" />
+	<target host="openlearnware.hrz.tu-darmstadt.de" />
+	<target host="testolw.hrz.tu-darmstadt.de" />
+	<target host="testolw-material.hrz.tu-darmstadt.de" />
+	<target host="ticket.hrz.tu-darmstadt.de" />
+	<target host="www-cgi.hrz.tu-darmstadt.de" />
+	<target host="www-cgi03.hrz.tu-darmstadt.de" />
+	<target host="www.idm.tu-darmstadt.de" />
+	<target host="imap.ifs.tu-darmstadt.de" />
+	<target host="development.l3ams.ifs.tu-darmstadt.de" />
+	<target host="smtp.ifs.tu-darmstadt.de" />
+	<target host="typo3.ifs.tu-darmstadt.de" />
+	<target host="www.informatik.tu-darmstadt.de" />
+	<target host="www.algo.informatik.tu-darmstadt.de" />
+	<target host="nabla.algo.informatik.tu-darmstadt.de" />
+	<target host="testing.algo.informatik.tu-darmstadt.de" />
+	<target host="cast.informatik.tu-darmstadt.de" />
+	<target host="cfp.cast.informatik.tu-darmstadt.de" />
+	<target host="www.cdc.informatik.tu-darmstadt.de" />
+	<target host="crossing-cloud.cdc.informatik.tu-darmstadt.de" />
+	<target host="longtermsecurity.cdc.informatik.tu-darmstadt.de" />
+	<target host="roundcube.cdc.informatik.tu-darmstadt.de" />
+	<target host="svn.cdc.informatik.tu-darmstadt.de" />
+	<target host="aud.cryptoplexity.informatik.tu-darmstadt.de" />
+	<target host="doku.dekanat.informatik.tu-darmstadt.de" />
+	<target host="www.esa.informatik.tu-darmstadt.de" />
+	<target host="pw.esa.informatik.tu-darmstadt.de" />
+	<target host="daswesentliche.fachschaft.informatik.tu-darmstadt.de" />
+	<target host="glados.fachschaft.informatik.tu-darmstadt.de" />
+	<target host="host37.fachschaft.informatik.tu-darmstadt.de" />
+	<target host="mail.fachschaft.informatik.tu-darmstadt.de" />
+	<target host="hiwis.informatik.tu-darmstadt.de" />
+	<target host="www.ias.informatik.tu-darmstadt.de" />
+	<target host="lehre.ias.informatik.tu-darmstadt.de" />
+	<target host="mail.ias.informatik.tu-darmstadt.de" />
+	<target host="minsky.ias.informatik.tu-darmstadt.de" />
+	<target host="www.mais.informatik.tu-darmstadt.de" />
+	<target host="www.ml.informatik.tu-darmstadt.de" />
+	<target host="mon-01.informatik.tu-darmstadt.de" />
+	<target host="moodle.informatik.tu-darmstadt.de" />
+	<target host="www.parallel.informatik.tu-darmstadt.de" />
+	<target host="icinga.rbg.informatik.tu-darmstadt.de" />
+	<target host="mypage.rbg.informatik.tu-darmstadt.de" />
+	<target host="tools.rbg.informatik.tu-darmstadt.de" />
+	<target host="vm4.rbg.informatik.tu-darmstadt.de" />
+	<target host="adimat.sc.informatik.tu-darmstadt.de" />
+	<target host="scm.informatik.tu-darmstadt.de" />
+	<target host="seemoo.informatik.tu-darmstadt.de" />
+	<target host="www.seemoo.informatik.tu-darmstadt.de" />
+	<target host="share.informatik.tu-darmstadt.de" />
+	<target host="www.sit.informatik.tu-darmstadt.de" />
+	<target host="www.student.informatik.tu-darmstadt.de" />
+	<target host="coffee.tk.informatik.tu-darmstadt.de" />
+	<target host="recording.tk.informatik.tu-darmstadt.de" />
+	<target host="tupass.tk.informatik.tu-darmstadt.de" />
+	<target host="bugzilla.ukp.informatik.tu-darmstadt.de" />
+	<target host="dhconvalidator.ukp.informatik.tu-darmstadt.de" />
+	<target host="public.ukp.informatik.tu-darmstadt.de" />
+	<target host="wiki.ukp.informatik.tu-darmstadt.de" />
+	<target host="web.informatik.tu-darmstadt.de" />
+	<target host="cloud.ise.tu-darmstadt.de" />
+	<target host="survey.ise.tu-darmstadt.de" />
+	<target host="www.fachschaft.ist.tu-darmstadt.de" />
+	<target host="www.konaktiva.tu-darmstadt.de" />
+	<target host="kondb.konaktiva.tu-darmstadt.de" />
+	<target host="messe.konaktiva.tu-darmstadt.de" />
+	<target host="portal.konaktiva.tu-darmstadt.de" />
+	<target host="www.korruptionsforschung.tu-darmstadt.de" />
+	<target host="imap.kritis.tu-darmstadt.de" />
+	<target host="smtp.kritis.tu-darmstadt.de" />
+	<target host="imap.linglit.tu-darmstadt.de" />
+	<target host="smtp.linglit.tu-darmstadt.de" />
+	<target host="socialmedia.linglit.tu-darmstadt.de" />
+	<target host="lists.tu-darmstadt.de" />
+	<target host="vs04.lzm.maschinenbau.tu-darmstadt.de" />
+	<target host="mail.ptu.maschinenbau.tu-darmstadt.de" />
+	<target host="support.vkm.maschinenbau.tu-darmstadt.de" />
+	<target host="fb04142.mathematik.tu-darmstadt.de" />
+	<target host="linux.mathematik.tu-darmstadt.de" />
+	<target host="linux2.mathematik.tu-darmstadt.de" />
+	<target host="num.mathematik.tu-darmstadt.de" />
+	<target host="numawww.mathematik.tu-darmstadt.de" />
+	<target host="osm.mathematik.tu-darmstadt.de" />
+	<target host="svn.mathematik.tu-darmstadt.de" />
+	<target host="wwwdid.mathematik.tu-darmstadt.de" />
+	<target host="wwwrt.mathematik.tu-darmstadt.de" />
+	<target host="moodle.tu-darmstadt.de" />
+	<target host="www.neue-politische-literatur.tu-darmstadt.de" />
+	<target host="nicer.tu-darmstadt.de" />
+	<target host="www.nicer.tu-darmstadt.de" />
+	<target host="www.oapp.tu-darmstadt.de" />
+	<target host="olw.tu-darmstadt.de" />
+	<target host="www.olw.tu-darmstadt.de" />
+	<target host="openlearnware.tu-darmstadt.de" />
+	<target host="www.openlearnware.tu-darmstadt.de" />
+	<target host="www.owl.tu-darmstadt.de" />
+	<target host="imap.pg.tu-darmstadt.de" />
+	<target host="smtp.pg.tu-darmstadt.de" />
+	<target host="imap.phil.tu-darmstadt.de" />
+	<target host="smtp.phil.tu-darmstadt.de" />
+	<target host="www.fachschaft.physik.tu-darmstadt.de" />
+	<target host="dev.fachschaft.physik.tu-darmstadt.de" />
+	<target host="chaos3.fkp.physik.tu-darmstadt.de" />
+	<target host="element.fkp.physik.tu-darmstadt.de" />
+	<target host="ezra.fkp.physik.tu-darmstadt.de" />
+	<target host="gp-portal.physik.tu-darmstadt.de" />
+	<target host="chaos.iap.physik.tu-darmstadt.de" />
+	<target host="ernie.iap.physik.tu-darmstadt.de" />
+	<target host="mailhost.iap.physik.tu-darmstadt.de" />
+	<target host="crunch.ikp.physik.tu-darmstadt.de" />
+	<target host="lwapsr.ikp.physik.tu-darmstadt.de" />
+	<target host="targetlab.ikp.physik.tu-darmstadt.de" />
+	<target host="theorie.ikp.physik.tu-darmstadt.de" />
+	<target host="mailhost.physik.tu-darmstadt.de" />
+	<target host="olav.physik.tu-darmstadt.de" />
+	<target host="prp0.prp.physik.tu-darmstadt.de" />
+	<target host="www.pmv.tu-darmstadt.de" />
+	<target host="www.ptu.tu-darmstadt.de" />
+	<target host="www.ptw.tu-darmstadt.de" />
+	<target host="ticket.pvw.tu-darmstadt.de" />
+	<target host="www1.rmr.tu-darmstadt.de" />
+	<target host="www.rsm.tu-darmstadt.de" />
+	<target host="www1.rtm.tu-darmstadt.de" />
+	<target host="seemoo.tu-darmstadt.de" />
+	<target host="www.seemoo.tu-darmstadt.de" />
+	<target host="account.seemoo.tu-darmstadt.de" />
+	<target host="auth01.seemoo.tu-darmstadt.de" />
+	<target host="icnp.seemoo.tu-darmstadt.de" />
+	<target host="lectures.seemoo.tu-darmstadt.de" />
+	<target host="share.seemoo.tu-darmstadt.de" />
+	<target host="team.seemoo.tu-darmstadt.de" />
+	<target host="welcome.seemoo.tu-darmstadt.de" />
+	<target host="www.self-assessment.tu-darmstadt.de" />
+	<target host="analytics.self-assessment.tu-darmstadt.de" />
+	<target host="www.sfb1194.tu-darmstadt.de" />
+	<target host="www.sfb1245.tu-darmstadt.de" />
+	<target host="securitylab.sit.tu-darmstadt.de" />
+	<target host="imap.stadtforschung.tu-darmstadt.de" />
+	<target host="smtp.stadtforschung.tu-darmstadt.de" />
+	<target host="www.tdt.tu-darmstadt.de" />
+	<target host="www.tfi.tu-darmstadt.de" />
+	<target host="imap.theol.tu-darmstadt.de" />
+	<target host="smtp.theol.tu-darmstadt.de" />
+	<target host="www.theologie.tu-darmstadt.de" />
+	<target host="www.ttd.tu-darmstadt.de" />
+	<target host="www.tucan.tu-darmstadt.de" />
+	<target host="wwwvs.tucan.tu-darmstadt.de" />
+	<target host="www.tuday.tu-darmstadt.de" />
+	<target host="www.ulb.tu-darmstadt.de" />
+	<target host="astarchiv.ulb.tu-darmstadt.de" />
+	<target host="buechner.ulb.tu-darmstadt.de" />
+	<target host="hertz.ulb.tu-darmstadt.de" />
+	<target host="imd-test.ulb.tu-darmstadt.de" />
+	<target host="kompass.ulb.tu-darmstadt.de" />
+	<target host="kompass-dev.ulb.tu-darmstadt.de" />
+	<target host="kompass-hmz.ulb.tu-darmstadt.de" />
+	<target host="kompass-hmz-dev.ulb.tu-darmstadt.de" />
+	<target host="leitsystem.ulb.tu-darmstadt.de" />
+	<target host="static.ulb.tu-darmstadt.de" />
+	<target host="tickets.ulb.tu-darmstadt.de" />
+	<target host="tubama.ulb.tu-darmstadt.de" />
+	<target host="tubiblio.ulb.tu-darmstadt.de" />
+	<target host="tudata-test.ulb.tu-darmstadt.de" />
+	<target host="tudatalib.ulb.tu-darmstadt.de" />
+	<target host="tudmo.ulb.tu-darmstadt.de" />
+	<target host="tudmo-test.ulb.tu-darmstadt.de" />
+	<target host="tujournals.ulb.tu-darmstadt.de" />
+	<target host="tuprints.ulb.tu-darmstadt.de" />
+	<target host="ulbiblio.ulb.tu-darmstadt.de" />
+	<target host="zci.ulb.tu-darmstadt.de" />
+	<target host="online-anmeldung.usz.tu-darmstadt.de" />
+	<target host="www.veranstaltungskalender.tu-darmstadt.de" />
+	<target host="psgd-nas.ipg.verm.tu-darmstadt.de" />
+	<target host="www.vwl2.wi.tu-darmstadt.de" />
+	<target host="www.vwl3.wi.tu-darmstadt.de" />
+	<target host="imap.wissensordnung.tu-darmstadt.de" />
+	<target host="smtp.wissensordnung.tu-darmstadt.de" />
+	<target host="www-cgi.tu-darmstadt.de" />
 
 
 	<rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/TU-Darmstadt.de.xml
+++ b/src/chrome/content/rules/TU-Darmstadt.de.xml
@@ -5,7 +5,7 @@
 
 	This includes: 
 		- all manually added subdomains from 210332db950e2b4a3a89a51ba59c3629dc7c6407
-		- all subdomains from brutelist3r that returned a HTTP200 status code
+		- all subdomains from Sublist3r that returned a HTTP200 status code
 -->
 <ruleset name="TU-Darmstadt.de">
 


### PR DESCRIPTION
add all subdomains from Sublist3r that return a HTTP200 status code when querying root on https

After I've not recieved much feedback on #19421 I've gone ahead and included all subdomains that return HTTP200 status codes when being queried over https (point 7 from the list in the linked issue).

Greetings Nmxcgeo