### PR TITLE
Remove S3 References and Redirect in Adobe.xml

### DIFF
--- a/src/chrome/content/rules/Adobe.xml
+++ b/src/chrome/content/rules/Adobe.xml
@@ -19,8 +19,6 @@
 
 	CDN buckets:
 
-		- s3.amazonaws.com/images.groups.adobe.com/
-
 		- thumbnails-tv.adobe.com.edgekey.net
 		- wwwimages2.adobe.com.edgekey.net
 
@@ -112,7 +110,6 @@
 		- forums
 		- get
 		- get3
-		- images.groups	(→ s3.amazonaws.com)
 		- helpx
 		- images-tv
 		- kuler
@@ -155,7 +152,6 @@
 
 			- blogs from $self *
 			- blogs from dev.w3.org
-			- edex from ex-cms.s3.amazonaws.com *
 			- groups from $self
 			- groups from images.groups *
 			- tv from thumbnails.tv *
@@ -285,9 +281,6 @@
 
 		<test url="http://cem.events.adobe.com/?" />
 		<test url="http://cem.events.adobe.com//" />
-
-	<rule from="^http://images\.groups\.adobe\.com/"
-		to="https://s3.amazonaws.com/images.groups.adobe.com/" />
 
 	<rule from="^http://stats\.adobe\.com/"
 		to="https://mxmacromedia.d1.sc.omtrdc.net/" />


### PR DESCRIPTION
See #17912
<details>
<summary>Tl;DR Summary</summary>
<blockquote>
...In other words, all rulesets that have a to= using the s3.amazonaws.com hostname will stop working. We should update all of these before then. Here's the current list of 115 affected rulesets:
</blockquote>
</details>
