### PR TITLE
Remove S3 V1 References and Update to S3 V2 in AWS

### DIFF
--- a/src/chrome/content/rules/AmazonAWS.com.xml
+++ b/src/chrome/content/rules/AmazonAWS.com.xml
@@ -10,6 +10,8 @@
 
 		- (.+.)s3-website-eu-west-1.amazonaws.com
 		- (.+.)s3-website-us-east-1.amazonaws.com
+
+
 -->
 <ruleset name="AmazonWebServices">
 
@@ -56,6 +58,7 @@
 		<exclusion pattern="^http://anvato-api-config\.s3\.amazonaws.com/" />
 			<test url="http://anvato-api-config.s3.amazonaws.com/anvacks/anvato_mcp_lin_web_prod_4c36fbfd4d8d8ecae6488656e21ac6d1ac972749.json" />
 
+
 	<!--	Forced redirects:
 					-->
 
@@ -81,42 +84,5 @@
 
 		<test url="http://blc.avatars.bucket.s3-us-west-2.amazonaws.com/3/9/8/0/4f40612e0eca17a852ff621ee5c2f729" />
 		<test url="http://blc.avatars.bucket.s3-us-west-2.amazonaws.com//3/9/8/0/4f40612e0eca17a852ff621ee5c2f729" />
-
-		<!--
-			Exclusions for Amazon's Zeitgeist MP3 Player:
-
-				https://trac.torproject.org/projects/tor/ticket/7000
-
-		note that the second exclusion can't be scoped to
-		the ssl-images-amazon domain, though it could have
-		copied the crazy pattern from the rule above.
-									-->
-		<exclusion pattern="^http://amazon-zg\.s3\.amazonaws\.com/" />
-
-
-	<test url="http://cms.kiva.org.s3.amazonaws.com/" />
-	<test url="http://s3-ap-northeast-1.amazonaws.com/" />
-	<test url="http://s3-ap-southeast-1.amazonaws.com/" />
-	<test url="http://s3-eu-west-1.amazonaws.com/" />
-	<test url="http://s3-us-west-1.amazonaws.com/" />
-	<test url="http://s3-external-1.amazonaws.com/" />
-	<test url="http://s3-sa-east-1.amazonaws.com/" />
-	<test url="http://s3-website-ap-northeast-1.amazonaws.com/" />
-	<test url="http://s3-website-ap-southeast-1.amazonaws.com/" />
-	<test url="http://s3-website-eu-west-1.amazonaws.com/" />
-	<test url="http://s3-website-us-west-1.amazonaws.com/" />
-	<test url="http://s3-website-sa-east-1.amazonaws.com/" />
-	<test url="http://s3-website-us-east-1.amazonaws.com/" />
-	<test url="http://static.via.me.s3.amazonaws.com/" />
-	<test url="http://img.wired.co.uk.s3.amazonaws.com/" />
-	<test url="http://spiegeltv-ivms2-restapi.s3.amazonaws.com/" />
-	<test url="http://www.mercyships.org.s3.amazonaws.com/" />
-	<test url="http://www-prod-storage.cloud.caltech.edu.s3.amazonaws.com/" />
-	<test url="http://badracket-website.s3.amazonaws.com/swf/soundmanager1_flash1.swf" />
-	<test url="http://em.css.s3.amazonaws.com/style.css" />
-	<test url="http://charts-datawrapper.s3.amazonaws.com/" />
-	<test url="http://darkskysatellite.s3.amazonaws.com/" />
-	<test url="http://darkskysatellitemaps.s3.amazonaws.com/" />
-	<test url="http://amazon-zg.s3.amazonaws.com/" />
 
 </ruleset>

--- a/src/chrome/content/rules/AmazonAWS.com.xml
+++ b/src/chrome/content/rules/AmazonAWS.com.xml
@@ -13,14 +13,16 @@
 -->
 <ruleset name="AmazonWebServices">
 
-	<target host="*.s3.amazonaws.com" />
-    <test url="http://darkskysatellitemaps.s3.amazonaws.com/" />
-    <test url="http://siterepository.s3.amazonaws.com/5482/thrips.pdf" />
-    <test url="http://visualise.s3.amazonaws.com/visitlondon/panorama_app.html" />
+  <target host="*.s3.amazonaws.com" />
+    <test url="http://book.s3.amazonaws.com/" />
+    <test url="http://visualise.s3.amazonaws.com/" />
+    <test url="http://jamcfiles.s3.amazonaws.com/" />
+    <test url="http://siterepository.s3.amazonaws.com/" />
+    <test url="http://dealerinspire-brochure.s3.amazonaws.com/" />
+    <test url="http://webjam-upload.s3.amazonaws.com/" />
+    <test url="http://rstudio-pubs-static.s3.amazonaws.com/" />
+    <test url="http://homeq-media.s3.amazonaws.com/" />
 
-  <rule from="^http://([\w.]+)|([\w-]+)\.s3\.amazonaws\.com/"
-  to="https://$1.s3.amazonaws.com/" />
-    <test url="http://homeq-media.s3.amazonaws.com/67633b54301c490fbc0b8d295df0a537.pdf" />
-    <test url="http://static.via.me.s3.amazonaws.com/" />
-    <test url="http://cms.kiva.org.s3.amazonaws.com/" />
+  	<rule from="^http:" to="https:" />
+
 </ruleset>

--- a/src/chrome/content/rules/AmazonAWS.com.xml
+++ b/src/chrome/content/rules/AmazonAWS.com.xml
@@ -18,9 +18,9 @@
     <test url="http://charts-datawrapper.s3.amazonaws.com" />
     <test url="http://cbslocal-download.s3.amazonaws.com/crossdomain.xml" />
 
-  	<rule from="^http://([\w-]+)\.s3\.amazonaws\.com/"
+  	<rule from="^http://([\w.]+)\.s3\.amazonaws\.com/"
 		to="https://$1.s3.amazonaws.com/" />
-      <test url="http://charts-datawrapper.s3.amazonaws.com" />
+      <test url="http://www.mercyships.org.s3.amazonaws.com/" />
       <test url="http://amazon-zg.s3.amazonaws.com/" />
       <test url="http://cms.kiva.org.s3.amazonaws.com/" />
 </ruleset>

--- a/src/chrome/content/rules/AmazonAWS.com.xml
+++ b/src/chrome/content/rules/AmazonAWS.com.xml
@@ -10,79 +10,17 @@
 
 		- (.+.)s3-website-eu-west-1.amazonaws.com
 		- (.+.)s3-website-us-east-1.amazonaws.com
-
-
 -->
 <ruleset name="AmazonWebServices">
 
-	<target host="*.amazonaws.com" />
-		<!--
-			Bloody forced redirection:
+	<target host="*.s3.amazonaws.com" />
+    <test url="https://darkskysatellitemaps.s3.amazonaws.com/" />
+    <test url="http://charts-datawrapper.s3.amazonaws.com" />
+    <test url="http://cbslocal-download.s3.amazonaws.com/crossdomain.xml" />
 
-			https://mail1.eff.org/pipermail/https-everywhere-rules/2012-April/001100.html
- 			https://trac.torproject.org/projects/tor/ticket/4199
-											-->
-		<exclusion pattern="^http://(?:static\.via\.me|img\.wired\.co\.uk|s3\.sandbaguk\.com|spiegeltv-ivms2-restapi|www\.mercyships\.org|www-prod-storage\.cloud\.caltech\.edu)\.s3\.amazonaws\.com/" />
-		<!--
-			Breaks soundsjustlike.com audio:
-							-->
-		<exclusion pattern="^http://badracket-website\.s3\.amazonaws\.com/swf/soundmanager\d_flash\d\.swf" />
-
-		<!--
-			https://trac.torproject.org/projects/tor/ticket/7857
-
-			Breaks images:
-					-->
-		<exclusion pattern="^http://em\.css\.s3\.amazonaws\.com/style\.css" />
-		<!--
-			This one looks slightly different:
-
-				https://trac.torproject.org/projects/tor/ticket/7608
-											 -->
-		<exclusion pattern="^http://charts-datawrapper\.s3\.amazonaws\.com/" />
-		<!--
-			Breaks forecast.io radar images
-							-->
-		<exclusion pattern="^http://darkskysatellite(?:maps)?\.s3\.amazonaws\.com/" />
-		<!--
-			Breaks wishtv.com and videos on many websites:
-
-				https://github.com/EFForg/https-everywhere/issues/4510
-				https://github.com/EFForg/https-everywhere/issues/14655
-
-				tests:
-					http://thefreethoughtproject.com/red-light-robin-hood-hero-risks-years-jail-free-citizens-unlawful-red-light-cameras/
-					http://www.wsbtv.com/news/local/north-fulton-county/1-dead-in-attempted-robbery-at-buckhead-jewelry-store/389269261
-					http://sacramento.cbslocal.com/2016/07/06/california-gun-law-changes-have-advocates-up-in-arms/
-		-->
-		<exclusion pattern="^http://anvato-api-config\.s3\.amazonaws.com/" />
-			<test url="http://anvato-api-config.s3.amazonaws.com/anvacks/anvato_mcp_lin_web_prod_4c36fbfd4d8d8ecae6488656e21ac6d1ac972749.json" />
-
-
-	<!--	Forced redirects:
-					-->
-
-	<!--	Test failures were misinterpreted. .+-website-.+ no longer works, rest (seemingly) works.
-														-->
-	<!--rule from="^http://([\w-]+)\.s3(?:-website)?(-ap-(?:nor|sou)theast-1|-(?:eu|us)-west-\d|-external-\d|-sa-east-1)?\.amazonaws\.com/" -->
-	<rule from="^http://([\w-]+)\.s3(-ap-(?:nor|sou)theast-1|-(?:eu|us)-west-\d|-external-\d|-sa-east-1)?\.amazonaws\.com/"
-		to="https://$1.s3$2.amazonaws.com/" />
-
-		<test url="http://estevaomonteiro.s3.amazonaws.com/" />
-		<!--test url="http://network-pages.s3.amazonaws.com/oxfamgb/signuptofundraise.png" /-->
-		<test url="http://afod.s3-ap-northeast-1.amazonaws.com/" />
-		<test url="http://rangde-org-gen.s3-ap-southeast-1.amazonaws.com/" />
-		<test url="http://edynaukraina.s3-eu-west-1.amazonaws.com/" />
-		<test url="http://smalltell.s3-us-west-1.amazonaws.com/" />
-		<!--test url="http://lawfare.s3-us-west-2.amazonaws.com/staging/styles/thumbnail/s3/pictures/picture-87-1431626511.jpg" /-->
-		<test url="http://tastylounge-prod.s3-external-1.amazonaws.com/" />
-		<test url="http://gestaoja.s3-sa-east-1.amazonaws.com/" />
-		<test url="http://static-course-assets.s3.amazonaws.com/ITE50ENU/common-ext/styles/images/landing.png" />
-
-	<rule from="^http://([\w.-]+)\.s3-us-west-2\.amazonaws\.com/"
-		to="https://s3-us-west-2.amazonaws.com/$1/" />
-
-		<test url="http://blc.avatars.bucket.s3-us-west-2.amazonaws.com/3/9/8/0/4f40612e0eca17a852ff621ee5c2f729" />
-		<test url="http://blc.avatars.bucket.s3-us-west-2.amazonaws.com//3/9/8/0/4f40612e0eca17a852ff621ee5c2f729" />
-
+  	<rule from="^http://([\w-]+)\.s3\.amazonaws\.com/"
+		to="https://$1.s3.amazonaws.com/" /
+      <test url="http://charts-datawrapper.s3.amazonaws.com" />
+      <test url="http://amazon-zg.s3.amazonaws.com/" />
+      <test url="http://cms.kiva.org.s3.amazonaws.com/" />
 </ruleset>

--- a/src/chrome/content/rules/AmazonAWS.com.xml
+++ b/src/chrome/content/rules/AmazonAWS.com.xml
@@ -19,7 +19,7 @@
     <test url="http://cbslocal-download.s3.amazonaws.com/crossdomain.xml" />
 
   	<rule from="^http://([\w-]+)\.s3\.amazonaws\.com/"
-		to="https://$1.s3.amazonaws.com/" /
+		to="https://$1.s3.amazonaws.com/" />
       <test url="http://charts-datawrapper.s3.amazonaws.com" />
       <test url="http://amazon-zg.s3.amazonaws.com/" />
       <test url="http://cms.kiva.org.s3.amazonaws.com/" />

--- a/src/chrome/content/rules/AmazonAWS.com.xml
+++ b/src/chrome/content/rules/AmazonAWS.com.xml
@@ -10,8 +10,6 @@
 
 		- (.+.)s3-website-eu-west-1.amazonaws.com
 		- (.+.)s3-website-us-east-1.amazonaws.com
-
-
 -->
 <ruleset name="AmazonWebServices">
 
@@ -27,10 +25,6 @@
 			Breaks soundsjustlike.com audio:
 							-->
 		<exclusion pattern="^http://badracket-website\.s3\.amazonaws\.com/swf/soundmanager\d_flash\d\.swf" />
-		<!--
-			Breaks premiumbeat.com preview player
-							-->
-		<exclusion pattern="^http://s3\.amazonaws\.com/pb_(sfx_)?previews/" />
 
 		<!--
 			https://trac.torproject.org/projects/tor/ticket/7857
@@ -61,52 +55,9 @@
 		-->
 		<exclusion pattern="^http://anvato-api-config\.s3\.amazonaws.com/" />
 			<test url="http://anvato-api-config.s3.amazonaws.com/anvacks/anvato_mcp_lin_web_prod_4c36fbfd4d8d8ecae6488656e21ac6d1ac972749.json" />
-		<!--
-			Breaks download button on brackets.io
-		-->
-		<exclusion pattern="^http://s3.amazonaws.com/files.brackets.io/.+\.json" />
-			<test url="http://s3.amazonaws.com/files.brackets.io/updates/stable/en.json" />
-			<test url="http://s3.amazonaws.com/files.brackets.io/updates/stable/en.json?_=1519135293080" />
-
-		<!-- CORS issues break social buttons on pages such as
-			http://informationisbeautiful.net/visualizations/snake-oil-scientific-evidence-for-nutritional-supplements-vizsweet/
-			See https://github.com/EFForg/https-everywhere/issues/14731
-		-->
-		<exclusion pattern="^http://s3\.amazonaws\.com/infobeautiful4/assets/" />
-			<test url="http://s3.amazonaws.com/infobeautiful4/assets/font/icons.ttf?50196724" />
-			<test url="http://s3.amazonaws.com/infobeautiful4/assets/font/icons.woff?50196724" />
-
-		<!-- The following subdomains have active mixed content which prevent videos from properly loading and playing.
-			Browsers do not display	any MCB warning because those subdomains are just resources on pages such as
-			http://up.anv.bz/latest/anvload.html?key=eyJtIjoiY2JzIiwicCI6ImRlZmF1bHQiLCJ2IjoiMzM4NTA0MSIsInBsdWdpbnMiOnsiY29tc2NvcmUiOnsiY2xpZW50SWQiOiIzMDAwMDIzIiwiYzMiOiJuZXd5b3JrLmNic2xvY2FsLmNvbSJ9LCJkZnAiOnsiY2xpZW50U2lkZSI6eyJhZFRhZ1VybCI6Imh0dHA6Ly9wdWJhZHMuZy5kb3VibGVjbGljay5uZXQvZ2FtcGFkL2Fkcz9zej0yeDImaXU9LzQxMjgvQ0JTLk5ZJmNpdV9zenMmaW1wbD1zJmdkZnBfcmVxPTEmZW52PXZwJm91dHB1dD14bWxfdmFzdDImdW52aWV3ZWRfcG9zaXRpb25fc3RhcnQ9MSZ1cmw9W3JlZmVycmVyX3VybF0mZGVzY3JpcHRpb25fdXJsPVtkZXNjcmlwdGlvbl91cmxdJmNvcnJlbGF0b3I9W3RpbWVzdGFtcF0iLCJrZXlWYWx1ZXMiOnsiY2F0ZWdvcmllcyI6IltbQ0FURUdPUklFU11dIiwicHJvZ3JhbSI6IltbUFJPR1JBTV9OQU1FXV0iLCJzaXRlU2VjdGlvbiI6ImZlYXR1cmVkIn19fSwiaGVhcnRiZWF0QmV0YSI6eyJhY2NvdW50IjoiY2JzbG9jYWwtZ2xvYmFsLXVuaWZpZWQsY2JzbG9jYWwtc3RhdGlvbi1uZXd5b3JrLW5ld3lvcmstdW5pZmllZCxjYnNsb2NhbC1zdWJwcmltYXJ5LXN3dHYtdW5pZmllZCxjYnNsb2NhbC1tYXJrZXQtbmV3eW9yay11bmlmaWVkIiwicHVibGlzaGVySWQiOiI4MjNCQTAzMzU1Njc0OTdGN0YwMDAxMDFAQWRvYmVPcmciLCJqb2JJZCI6InNjX3ZhIiwibWFya2V0aW5nQ2xvdWRJZCI6IjgyM0JBMDMzNTU2NzQ5N0Y3RjAwMDEwMUBBZG9iZU9yZyIsInRyYWNraW5nU2VydmVyIjoiY2JzZGlnaXRhbG1lZGlhLmhiLm9tdHJkYy5uZXQiLCJjdXN0b21UcmFja2luZ1NlcnZlciI6ImNic2RpZ2l0YWxtZWRpYS5kMS5zYy5vbXRyZGMubmV0IiwidmVyc2lvbiI6IjEuNSJ9LCJyZWFsVGltZUFuYWx5dGljcyI6dHJ1ZX0sImFudmFjayI6ImFudmF0b19jYnNsb2NhbF9hcHBfd2ViX3Byb2RfNTQ3ZjNlNDkyNDFlZjBlNWQzMGM3OWIyZWZiY2E1ZDkyYzY5OGY2NyJ9
-		-->
-		<exclusion pattern="^http://cbslocal-download\.s3\.amazonaws\.com/" />
-		<exclusion pattern="^http://cbslocal-uploads\.s3\.amazonaws\.com/" />
-			<test url="http://cbslocal-download.s3.amazonaws.com/anv-videos/variant/3385041.m3u8?X-Anvato-Adst-Auth=5B8ylV9Psq0J8sqxUapXNqEnHBjhNhxFSnjkPmevzCz3xOzkNG9a82eWkHKNXYbH" />
-			<test url="http://cbslocal-download.s3.amazonaws.com/crossdomain.xml" />
-			<test url="http://cbslocal-uploads.s3.amazonaws.com/anv-pvw/3E5/12B/3E512B6C6EDE47D3BA90EE8065CFDFCE_pvw-M2.jpg" />
 
 	<!--	Forced redirects:
 					-->
-	<rule from="^http://static\.newsblur\.com\.s3\.amazonaws\.com/"
-		to="https://s3.amazonaws.com/static.newsblur.com/" />
-	<test url="http://static.newsblur.com.s3.amazonaws.com/blog/Campeche%20Steps%20resized.jpeg" />
-
-	<rule from="^http://dis(\.resized)?\.images\.s3\.amazonaws\.com/"
-		to="https://s3-eu-west-1.amazonaws.com/dis$1.images/" />
-	<test url="http://dis.images.s3.amazonaws.com/" />
-	<test url="http://dis.resized.images.s3.amazonaws.com/" />
-
-	<rule from="^http://cms\.kiva\.org\.s3\.amazonaws\.com/"
-		to="https://s3-us-west-1.amazonaws.com/cms.kiva.org/" />
-
-	<rule from="^http://s3(?:-website)?(-ap-(?:nor|sou)theast-1|-eu-central-\d|-(?:eu|us)-west-\d|-external-\d|-sa-east-1)?\.amazonaws\.com/"
-		to="https://s3$1.amazonaws.com/" />
-
-		<!--test url="http://s3.amazonaws.com/s3.thesyriacampaign.org/images/quote-close.png" /-->
-		<test url="http://s3.amazonaws.com/assets.offerpop.com/jive/images/offerpop_logo.png" />
-		<!--test url="http://s3-eu-west-1.amazonaws.com/nusdigital/image/images/19253/original/footer-shape.png" /-->
-		<!--test url="http://s3-us-west-2.amazonaws.com/formget/images/login-logo.png" /-->
 
 	<!--	Test failures were misinterpreted. .+-website-.+ no longer works, rest (seemingly) works.
 														-->
@@ -124,44 +75,12 @@
 		<test url="http://tastylounge-prod.s3-external-1.amazonaws.com/" />
 		<test url="http://gestaoja.s3-sa-east-1.amazonaws.com/" />
 		<test url="http://static-course-assets.s3.amazonaws.com/ITE50ENU/common-ext/styles/images/landing.png" />
-		<!--test url="http://swyokohama.s3-website-ap-northeast-1.amazonaws.com/" /-->
-		<!--test url="http://keithsbucket.s3-website-ap-southeast-1.amazonaws.com/" /-->
-		<!--test url="http://grime.s3-website-eu-west-1.amazonaws.com/" /-->
-		<!--test url="http://estevaomonteiro.s3-website-us-west-1.amazonaws.com/" /-->
-		<!--test url="http://estevaomonteiro.s3-website-sa-east-1.amazonaws.com/" /-->
-
-	<!--rule from="^http://([\w-]+)\.([^@:/]+)\.s3(?:-website)?(-ap-(?:nor|sou)theast-1|-(?:eu|us)-west-\d|-external-\d|-sa-east-1)?\.amazonaws\.com/"
-		to="https://s3$3.amazonaws.com/$1.$2/" />
-		<test url="http://www.thisisreallaw.com.s3-external-1.amazonaws.com/" />
-		<test url="http://paniko.cl.s3-sa-east-1.amazonaws.com/" />
-		<test url="http://goldendiskawards.jp.s3-website-ap-northeast-1.amazonaws.com/" />
-		<test url="http://vidvatta.com.s3-website-ap-southeast-1.amazonaws.com/" />
-		<test url="http://digitalcolourist.com.s3-website-eu-west-1.amazonaws.com/" />
-		<test url="http://www.teejayvanslyke.com.s3-website-us-west-1.amazonaws.com/" />
-		<test url="http://www.thisisreallaw.com.s3-website-external-1.amazonaws.com/" />
-		<test url="http://www.thisisreallaw.com.s3-website-sa-east-1.amazonaws.com/" />
-		<test url="http://www.ultiarchive.com.s3-website-sa-east-1.amazonaws.com/" />
-		<test url="http://www.ultiarchive.com.s3-website-us-west-1.amazonaws.com/" />
-		<test url="http://www.thisisreallaw.com.s3-website-us-east-1.amazonaws.com/" />
-		<test url="http://www.bleedingedgebiotech.com.s3-website-us-east-1.amazonaws.com/" />
-		<test url="http://robertbruce.s3-website-us-east-1.amazonaws.com/" />
-		<test url="http://stinkdigital.s3-website-us-east-1.amazonaws.com/" /-->
-
-	<!--rule from="^http://([\w-]+)\.s3-website-us-east-1\.amazonaws\.com/"
-		to="https://$1.s3.amazonaws.com/" /-->
-
-	<!--rule from="^http://([\w-]+)\.([^@:/]+)\.s3-website-us-east-1\.amazonaws\.com/"
-		to="https://s3.amazonaws.com/$1.$2/" /-->
-		<!--test url="http://www.ultiarchive.com.s3-website-us-east-1.amazonaws.com/" /-->
 
 	<rule from="^http://([\w.-]+)\.s3-us-west-2\.amazonaws\.com/"
 		to="https://s3-us-west-2.amazonaws.com/$1/" />
 
 		<test url="http://blc.avatars.bucket.s3-us-west-2.amazonaws.com/3/9/8/0/4f40612e0eca17a852ff621ee5c2f729" />
 		<test url="http://blc.avatars.bucket.s3-us-west-2.amazonaws.com//3/9/8/0/4f40612e0eca17a852ff621ee5c2f729" />
-
-	<rule from="^http://s3-website-us-east-1\.amazonaws\.com/"
-		to="https://s3.amazonaws.com/" />
 
 		<!--
 			Exclusions for Amazon's Zeitgeist MP3 Player:
@@ -176,7 +95,6 @@
 
 
 	<test url="http://cms.kiva.org.s3.amazonaws.com/" />
-	<test url="http://s3.amazonaws.com/" />
 	<test url="http://s3-ap-northeast-1.amazonaws.com/" />
 	<test url="http://s3-ap-southeast-1.amazonaws.com/" />
 	<test url="http://s3-eu-west-1.amazonaws.com/" />
@@ -191,7 +109,6 @@
 	<test url="http://s3-website-us-east-1.amazonaws.com/" />
 	<test url="http://static.via.me.s3.amazonaws.com/" />
 	<test url="http://img.wired.co.uk.s3.amazonaws.com/" />
-	<test url="http://s3.sandbaguk.com.s3.amazonaws.com/" />
 	<test url="http://spiegeltv-ivms2-restapi.s3.amazonaws.com/" />
 	<test url="http://www.mercyships.org.s3.amazonaws.com/" />
 	<test url="http://www-prod-storage.cloud.caltech.edu.s3.amazonaws.com/" />
@@ -201,7 +118,5 @@
 	<test url="http://darkskysatellite.s3.amazonaws.com/" />
 	<test url="http://darkskysatellitemaps.s3.amazonaws.com/" />
 	<test url="http://amazon-zg.s3.amazonaws.com/" />
-	<test url="http://s3.amazonaws.com/pb_previews/" />
-	<test url="http://s3.amazonaws.com/pb_sfx_previews/" />
 
 </ruleset>

--- a/src/chrome/content/rules/AmazonAWS.com.xml
+++ b/src/chrome/content/rules/AmazonAWS.com.xml
@@ -4,7 +4,7 @@
 	Nonfunctional domains:
 
 		- cloudfront-labs.amazonaws.com		(refused)
-
+    - any s3.amazonaws.com (V1) will be nonfunctional after Sept 30, 2020
 
 	Problematic domains:
 
@@ -14,13 +14,13 @@
 <ruleset name="AmazonWebServices">
 
 	<target host="*.s3.amazonaws.com" />
-    <test url="https://darkskysatellitemaps.s3.amazonaws.com/" />
-    <test url="http://charts-datawrapper.s3.amazonaws.com" />
-    <test url="http://cbslocal-download.s3.amazonaws.com/crossdomain.xml" />
+    <test url="http://darkskysatellitemaps.s3.amazonaws.com/" />
+    <test url="http://siterepository.s3.amazonaws.com/5482/thrips.pdf" />
+    <test url="http://visualise.s3.amazonaws.com/visitlondon/panorama_app.html" />
 
-  	<rule from="^http://([\w.]+)\.s3\.amazonaws\.com/"
-		to="https://$1.s3.amazonaws.com/" />
-      <test url="http://www.mercyships.org.s3.amazonaws.com/" />
-      <test url="http://amazon-zg.s3.amazonaws.com/" />
-      <test url="http://cms.kiva.org.s3.amazonaws.com/" />
+  <rule from="^http://([\w.]+)|([\w-]+)\.s3\.amazonaws\.com/"
+  to="https://$1.s3.amazonaws.com/" />
+    <test url="http://homeq-media.s3.amazonaws.com/67633b54301c490fbc0b8d295df0a537.pdf" />
+    <test url="http://static.via.me.s3.amazonaws.com/" />
+    <test url="http://cms.kiva.org.s3.amazonaws.com/" />
 </ruleset>


### PR DESCRIPTION
See #17912
<details>
<summary>Tl;DR Summary</summary>
<blockquote>
...In other words, all rulesets that have a to= using the s3.amazonaws.com hostname will stop working. We should update all of these before then. Here's the current list of 115 affected rulesets:
</blockquote>

Also, updating this file to only include v2 buckets
</details>
