### PR TITLE
Update Adobe.xml

### DIFF
--- a/src/chrome/content/rules/Adobe.xml
+++ b/src/chrome/content/rules/Adobe.xml
@@ -19,8 +19,6 @@
 
 	CDN buckets:
 
-		- s3.amazonaws.com/images.groups.adobe.com/
-
 		- thumbnails-tv.adobe.com.edgekey.net
 		- wwwimages2.adobe.com.edgekey.net
 
@@ -217,7 +215,6 @@
 	<target host="cookbooks.adobe.com" />
 	<target host="edexchange.adobe.com" />
 	<target host="cem.events.adobe.com" />
-	<target host="images.groups.adobe.com" />
 	<target host="stats.adobe.com" />
 	<target host="techlive.adobe.com" />
 
@@ -285,9 +282,6 @@
 
 		<test url="http://cem.events.adobe.com/?" />
 		<test url="http://cem.events.adobe.com//" />
-
-	<rule from="^http://images\.groups\.adobe\.com/"
-		to="https://s3.amazonaws.com/images.groups.adobe.com/" />
 
 	<rule from="^http://stats\.adobe\.com/"
 		to="https://mxmacromedia.d1.sc.omtrdc.net/" />


### PR DESCRIPTION
#17912 `images.groups.adobe.com` is gone from DNS