### PR TITLE
Add rules for Archive.today and related sites

### DIFF
--- a/src/chrome/content/rules/Archive.today.xml
+++ b/src/chrome/content/rules/Archive.today.xml
@@ -1,0 +1,11 @@
+<ruleset name="Archive.today">
+	<target host="*.archive.today" />
+	<target host="*.archive.is" />
+	<target host="*.archive.fo" />
+	<target host="*.archive.li" />
+	<target host="*.archive.vn" />
+	<target host="*.archive.md" />
+	<target host="*.archive.ph" />
+
+	<rule from="^http:" to="https:" />
+</ruleset>


### PR DESCRIPTION
Add rules for Archive.today and related sites

each domain has the following subdomains:
archive.xx
www.archive.xx
blog.archive.xx
