### PR TITLE
Add rules for Wikiscan.org

### DIFF
--- a/src/chrome/content/rules/Wikiscan.xml
+++ b/src/chrome/content/rules/Wikiscan.xml
@@ -1,0 +1,5 @@
+<ruleset name="Wikiscan">
+	<target host="*.wikiscan.org" />
+  
+    <rule from="^http:" to="https:" />
+</ruleset>

--- a/src/chrome/content/rules/Wikiscan.xml
+++ b/src/chrome/content/rules/Wikiscan.xml
@@ -2,7 +2,7 @@
 	<target host="*.wikiscan.org" />
   
     <rule from="^http:" to="https:" />
-<test url="http://www.wikiscan.org" />
-<test url="http://en.wikiscan.org" />
-<test url="http://eswikisource.wikiscan.org" />
+<test url="http://www.wikiscan.org/" />
+<test url="http://en.wikiscan.org/" />
+<test url="http://eswikisource.wikiscan.org/" />
 </ruleset>

--- a/src/chrome/content/rules/Wikiscan.xml
+++ b/src/chrome/content/rules/Wikiscan.xml
@@ -1,8 +1,9 @@
 <ruleset name="Wikiscan">
 	<target host="*.wikiscan.org" />
+        <target host="wikiscan.org" />
   
     <rule from="^http:" to="https:" />
-<test url="http://www.wikiscan.org/" />
 <test url="http://en.wikiscan.org/" />
+<test url="http://frwiktionary.wikiscan.org/" />
 <test url="http://eswikisource.wikiscan.org/" />
 </ruleset>

--- a/src/chrome/content/rules/Wikiscan.xml
+++ b/src/chrome/content/rules/Wikiscan.xml
@@ -2,4 +2,7 @@
 	<target host="*.wikiscan.org" />
   
     <rule from="^http:" to="https:" />
+<test url="http://www.wikiscan.org">
+<test url="http://en.wikiscan.org">
+<test url="http://eswikisource.wikiscan.org">
 </ruleset>

--- a/src/chrome/content/rules/Wikiscan.xml
+++ b/src/chrome/content/rules/Wikiscan.xml
@@ -1,9 +1,13 @@
+<!--
+	wikiscan.org has both a wildcard DNS record and a wildcard certificate.
+-->
 <ruleset name="Wikiscan">
+	<target host="wikiscan.org" />
 	<target host="*.wikiscan.org" />
-        <target host="wikiscan.org" />
-  
-    <rule from="^http:" to="https:" />
-<test url="http://en.wikiscan.org/" />
-<test url="http://frwiktionary.wikiscan.org/" />
-<test url="http://eswikisource.wikiscan.org/" />
+
+	<rule from="^http:" to="https:" />
+
+	<test url="http://en.wikiscan.org/" />
+	<test url="http://frwiktionary.wikiscan.org/" />
+	<test url="http://eswikisource.wikiscan.org/" />
 </ruleset>

--- a/src/chrome/content/rules/Wikiscan.xml
+++ b/src/chrome/content/rules/Wikiscan.xml
@@ -2,7 +2,7 @@
 	<target host="*.wikiscan.org" />
   
     <rule from="^http:" to="https:" />
-<test url="http://www.wikiscan.org">
-<test url="http://en.wikiscan.org">
-<test url="http://eswikisource.wikiscan.org">
+<test url="http://www.wikiscan.org" />
+<test url="http://en.wikiscan.org" />
+<test url="http://eswikisource.wikiscan.org" />
 </ruleset>


### PR DESCRIPTION
Add rules to redirect http://(&#42;).wikiscan.org -> https://(&#42;).wikiscan.org