### PR TITLE
Fix Travis lint errors and regressions on wildcards, follow up #19479

### DIFF
--- a/chromium/pages/options/ux.js
+++ b/chromium/pages/options/ux.js
@@ -331,27 +331,19 @@ document.addEventListener("DOMContentLoaded", () => {
   const disabled_site_input = document.getElementById("disabled-site");
   const add_disabled_site_invalid_host = document.getElementById('add-disabled-site-invalid-host');
   disabled_site_input.setAttribute("placeholder", chrome.i18n.getMessage("options_enterDisabledSite"));
-  function isValidHost(host) {
-    try {
-      new URL(`http://${host}/`);
-      return true;
-    } catch {
-      return false;
-    }
-  }
-  add_disabled_site.addEventListener("click", function() {
-    const host = disabled_site_input.value;
 
-    if (isValidHost(host)) {
-      hide(add_disabled_site_invalid_host);
-      sendMessage("disable_on_site", disabled_site_input.value, okay => {
-        if (okay) {
-          chrome.tabs.reload();
-        }
-      });
-    } else {
-      show(add_disabled_site_invalid_host);
-    }
+  add_disabled_site.addEventListener("click", function() {
+    // Add host to the whitelist when clicked.
+    // Display error message when disable_on_site failed.
+    const host = disabled_site_input.value;
+    sendMessage("disable_on_site", host, okay => {
+      if (okay) {
+        hide(add_disabled_site_invalid_host);
+        chrome.tabs.reload();
+      } else {
+        show(add_disabled_site_invalid_host);
+      }
+    });
   });
 
   add_update_channel.addEventListener("click", () => {

--- a/chromium/pages/options/ux.js
+++ b/chromium/pages/options/ux.js
@@ -1,7 +1,7 @@
 /* global sendMessage */
 /* global getOption_ */
 /* global e */
-/* global hide */
+/* global show, hide */
 
 "use strict";
 


### PR DESCRIPTION
This PR fixes a regression from #19479 on wildcard support for disabled site (added since #18619) and some Travis lint errors. 

@zoracon is the UX redesign work being blocked by the pandemic? It would be much nicer to have a consistent CSS styles/ framework to work with when adding new UI elements. IMHO, it would be better if we could provide visual clues to our users that wildcards are supported.