### PR TITLE
Updated/extended Oregon State University rulesets

### DIFF
--- a/src/chrome/content/rules/Oregon-State-University.xml
+++ b/src/chrome/content/rules/Oregon-State-University.xml
@@ -1,39 +1,27 @@
-
 <!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://osulibrary.oregonstate.edu/ => https://osulibrary.oregonstate.edu/: (60, 'SSL certificate problem: unable to get local issuer certificate')
-
 	Other Oregon State University rulesets:
 
 		- osufoundation.org.xml
 		- osuosl.org.xml
+		- Oregon-State-University-mismatched.xml
 
-
-	Nonfunctional hosts in *oregonstate.edu:
-
-		- ecampus ᵃ
 
 	ᵃ Shows another domain
 
 
 	www.oregonstate.edu: mismatched
 
-
-	Mixed content:
-
-		- css on osulibrary from fonts.googleapis.com ˢ
-		- Images on ^ from $self ˢ
-
-	ˢ Secured by us, see https://www.paulirish.com/2010/the-protocol-relative-url/
-
 -->
-<ruleset name="Oregon State.edu (partial)" default_off="failed ruleset test">
+<ruleset name="Oregon State.edu (partial)">
 
 	<!--	Direct rewrites:
 				-->
 	<target host="oregonstate.edu" />
 	<target host="drupalweb.forestry.oregonstate.edu" />
 	<target host="osulibrary.oregonstate.edu" />
+	<target host="library.oregonstate.edu" />
+	<target host="ecampus.oregonstate.edu" />
+	<target host="web.engr.oregonstate.edu" />
 	<target host="secure.oregonstate.edu" />
 
 	<!--	Complications:

--- a/src/chrome/content/rules/osufoundation.org.xml
+++ b/src/chrome/content/rules/osufoundation.org.xml
@@ -1,23 +1,17 @@
 <!--
 	For other Oregon State University coverage, see
 
-
-	^osufoundation.org: dropped
+        osuosl.org.xml
+        Oregon-State-University.xml
+        Oregon-State-University-mismatches.xml
 
 -->
 <ruleset name="OSU Foundation.org" default_off="mismatched">
 
 	<!--	Direct rewrites:
 				-->
-	<target host="www.osufoundation.org" />
-
-	<!--	Complications:
-				-->
 	<target host="osufoundation.org" />
-
-
-	<rule from="^http://osufoundation\.org/"
-		to="https://www.osufoundation.org/"/>
+	<target host="www.osufoundation.org" />
 
 	<rule from="^http:"
 		to="https:" />

--- a/src/chrome/content/rules/osuosl.org.xml
+++ b/src/chrome/content/rules/osuosl.org.xml
@@ -1,6 +1,10 @@
 <!--
-	Disabled by https-everywhere-checker because:
-		nagios2.osuosl.org (60, 'SSL certificate problem: unable to get local issuer certificate')
+        For other Oregon State University coverage, see
+
+        osufoundation.org.xml
+        Oregon-State-University.xml
+        Oregon-State-University-mismatches.xml
+
 
 	HTTPS != HTTP:
 		internal-web1.osuosl.org


### PR DESCRIPTION
* Re-enabled rulesets, as those certificate problems have been fixed
* Mixed-content has been fixed
* osufoundation.org now self-redirects to www.osufoundation.org
* osulibrary.oregonstate.edu works and redirects to
  library.oregonstate.edu
* web.engr.oregonstate.edu and ecampus.oregonstate.edu now work
* More consistently cross-referenced the OSU files
