### PR TITLE
Re-enabled and extended OSU

### DIFF
--- a/src/chrome/content/rules/Oregon-State-University.xml
+++ b/src/chrome/content/rules/Oregon-State-University.xml
@@ -1,8 +1,5 @@
 
 <!--
-Disabled by https-everywhere-checker because:
-Fetch error: http://osulibrary.oregonstate.edu/ => https://osulibrary.oregonstate.edu/: (60, 'SSL certificate problem: unable to get local issuer certificate')
-
 	Other Oregon State University rulesets:
 
 		- osufoundation.org.xml
@@ -11,29 +8,19 @@ Fetch error: http://osulibrary.oregonstate.edu/ => https://osulibrary.oregonstat
 
 	Nonfunctional hosts in *oregonstate.edu:
 
-		- ecampus ᵃ
-
-	ᵃ Shows another domain
-
-
 	www.oregonstate.edu: mismatched
 
-
-	Mixed content:
-
-		- css on osulibrary from fonts.googleapis.com ˢ
-		- Images on ^ from $self ˢ
-
-	ˢ Secured by us, see https://www.paulirish.com/2010/the-protocol-relative-url/
-
 -->
-<ruleset name="Oregon State.edu (partial)" default_off="failed ruleset test">
+<ruleset name="Oregon State.edu (partial)">
 
 	<!--	Direct rewrites:
 				-->
 	<target host="oregonstate.edu" />
 	<target host="drupalweb.forestry.oregonstate.edu" />
 	<target host="osulibrary.oregonstate.edu" />
+	<target host="library.oregonstate.edu" />
+	<target host="ecampus.oregonstate.edu" />
+	<target host="web.engr.oregonstate.edu" />
 	<target host="secure.oregonstate.edu" />
 
 	<!--	Complications:


### PR DESCRIPTION
* Re-enabled ruleset, as those certificate problems have been fixed
* Mixed-content has been fixed
* osulibrary.oregonstate.edu works and redirects to
  library.oregonstate.edu
* web.engr.oregonstate.edu and ecampus.oregonstate.edu now work

This is part of a series of splits resulting from #19536 as asked
