### PR TITLE
Re-enabled OSU Foundation

### DIFF
--- a/src/chrome/content/rules/osufoundation.org.xml
+++ b/src/chrome/content/rules/osufoundation.org.xml
@@ -2,10 +2,13 @@
 	For other Oregon State University coverage, see
 
 
-	^osufoundation.org: dropped
+        http://osufoundation.org redirects to http://www.osufoundation.org
+        redirects to https://www.osufoundation.org, so normal users don't see
+        the need for the complication. However, osufoundation.org does not
+        respond to https, so it is still needed.
 
 -->
-<ruleset name="OSU Foundation.org" default_off="mismatched">
+<ruleset name="OSU Foundation.org">
 
 	<!--	Direct rewrites:
 				-->


### PR DESCRIPTION
* osufoundation.org now works, both with/without www prefix

This is part of a series of splits resulting from #19536 as asked
