### PR TITLE
Update WikiFur.com rules

### DIFF
--- a/src/chrome/content/rules/WikiFur.xml
+++ b/src/chrome/content/rules/WikiFur.xml
@@ -35,9 +35,4 @@
   
   <securecookie host=".+" name=".+"/>
   <rule from="^http:" to="https:" />
-  
-  <test url="http://en.wikifur.com/" />
-  <test url="http://www.wikifur.com/" />
-  <test url="http://fr.wikifur.com/" />
-  <test url="http://fursuit.wikifur.com/" />
 </ruleset>

--- a/src/chrome/content/rules/WikiFur.xml
+++ b/src/chrome/content/rules/WikiFur.xml
@@ -1,8 +1,11 @@
 <ruleset name="WikiFur">
   <target host="wikifur.com" />
   <target host="*.wikifur.com" />
-
-  <securecookie host="^(?:[a-z][a-z]\.)?wikifur\.com$" name=".+" />
-
-  <rule from="^http://([a-z][a-z]\.)?wikifur\.com/" to="https://$1wikifur.com/" />
+  
+  <securecookie host=".+" name=".+"/>
+  <rule from="^http:" to="https:" />
+  
+  <testurl="http://en.wikifur.com/" />
+  <testurl="http://wikifur.com/" />
+  <testurl="http://fursuit.wikifur.com/" />
 </ruleset>

--- a/src/chrome/content/rules/WikiFur.xml
+++ b/src/chrome/content/rules/WikiFur.xml
@@ -5,7 +5,7 @@
   <securecookie host=".+" name=".+"/>
   <rule from="^http:" to="https:" />
   
-  <testurl="http://en.wikifur.com/" />
-  <testurl="http://wikifur.com/" />
-  <testurl="http://fursuit.wikifur.com/" />
+  <test url="http://en.wikifur.com/" />
+  <test url="http://wikifur.com/" />
+  <test url="http://fursuit.wikifur.com/" />
 </ruleset>

--- a/src/chrome/content/rules/WikiFur.xml
+++ b/src/chrome/content/rules/WikiFur.xml
@@ -7,5 +7,6 @@
   
   <test url="http://en.wikifur.com/" />
   <test url="http://www.wikifur.com/" />
+  <test url="http://fr.wikifur.com/" />
   <test url="http://fursuit.wikifur.com/" />
 </ruleset>

--- a/src/chrome/content/rules/WikiFur.xml
+++ b/src/chrome/content/rules/WikiFur.xml
@@ -33,6 +33,6 @@
 	<target host="uk.wikifur.com" />
 	<target host="zh.wikifur.com" />
   
-  <securecookie host=".+" name=".+"/>
-  <rule from="^http:" to="https:" />
+	<securecookie host=".+" name=".+"/>
+	<rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/WikiFur.xml
+++ b/src/chrome/content/rules/WikiFur.xml
@@ -1,6 +1,37 @@
 <ruleset name="WikiFur">
   <target host="wikifur.com" />
-  <target host="*.wikifur.com" />
+	<target host="www.wikifur.com" />
+	<target host="be.wikifur.com" />
+	<target host="be-tarask.wikifur.com" />
+	<target host="board.wikifur.com" />
+	<target host="by.wikifur.com" />
+	<target host="cs.wikifur.com" />
+	<target host="da.wikifur.com" />
+	<target host="de.wikifur.com" />
+	<target host="dk.wikifur.com" />
+	<target host="dumps.wikifur.com" />
+	<target host="en.wikifur.com" />
+	<target host="eo.wikifur.com" />
+	<target host="es.wikifur.com" />
+	<target host="et.wikifur.com" />
+	<target host="fr.wikifur.com" />
+	<target host="fursuit.wikifur.com" />
+	<target host="hu.wikifur.com" />
+	<target host="it.wikifur.com" />
+	<target host="ja.wikifur.com" />
+	<target host="ko.wikifur.com" />
+	<target host="nb.wikifur.com" />
+	<target host="nl.wikifur.com" />
+	<target host="no.wikifur.com" />
+	<target host="ny.wikifur.com" />
+	<target host="pl.wikifur.com" />
+	<target host="pool.wikifur.com" />
+	<target host="pt.wikifur.com" />
+	<target host="ru.wikifur.com" />
+	<target host="stats.wikifur.com" />
+	<target host="tl.wikifur.com" />
+	<target host="uk.wikifur.com" />
+	<target host="zh.wikifur.com" />
   
   <securecookie host=".+" name=".+"/>
   <rule from="^http:" to="https:" />

--- a/src/chrome/content/rules/WikiFur.xml
+++ b/src/chrome/content/rules/WikiFur.xml
@@ -6,6 +6,6 @@
   <rule from="^http:" to="https:" />
   
   <test url="http://en.wikifur.com/" />
-  <test url="http://wikifur.com/" />
+  <test url="http://www.wikifur.com/" />
   <test url="http://fursuit.wikifur.com/" />
 </ruleset>

--- a/src/chrome/content/rules/WikiFur.xml
+++ b/src/chrome/content/rules/WikiFur.xml
@@ -1,5 +1,5 @@
 <ruleset name="WikiFur">
-  <target host="wikifur.com" />
+	<target host="wikifur.com" />
 	<target host="www.wikifur.com" />
 	<target host="be.wikifur.com" />
 	<target host="be-tarask.wikifur.com" />


### PR DESCRIPTION
Update WikiFur.com rules to redirect subdomains that don't start with two letter

==List of subdomains (all support https)==
wikifur.com
admin.wikifur.com
be.wikifur,com
be-tarask.wikifur.com
board.wikifur.com
by.wikifur.com
cs.wikifur.com
da.wikifur.com
de.wikifur.com
dk.wikifur.com
dumps.wikifur.com
en.wikifur.com
eo.wikifur.com
es.wikifur.com
et.wikifur.com
fr.wikifur.com
fursuit.wikifur.com
hu.wikifur.com
it.wikifur.com
ja.wikifur.com
ko.wikifur.com
nb.wikifur.com
nl.wikifur.com
no.wikifur.com
ny.wikifur.com
pl.wikifur.com
pt.wikifur.com
pool.wikifur.com
ru.wikifur.com
se.wikifur.com
stats.wikifur.com
sv.wikifur.com
tl.wikifur.com
uk.wikifur.com
www.wikifur.com
zh.wikifur.com