### PR TITLE
Remove S3 Refernces to Issu Aps Ruleset

### DIFF
--- a/src/chrome/content/rules/Issuu_Aps.xml
+++ b/src/chrome/content/rules/Issuu_Aps.xml
@@ -5,16 +5,11 @@
 
 		- Isu.pub.xml
 
-
-	CDN buckets:
-
-		- s3.amazonaws.com/feed.issuu.com/
-		- s3.amazonaws.com/sidebar.issuu.com/
-
-
 	Nonfunctional hosts in *issuu.com:
 
 		- help *
+    - feed *
+    - sidebar *
 
 	* Zendesk / redirects to http
 
@@ -39,9 +34,7 @@
 
 	<!--	Complications:
 				-->
-	<target host="feed.issuu.com" />
 	<target host="help.issuu.com" />
-	<target host="sidebar.issuu.com" />
 
 		<exclusion pattern="^http://help\.issuu\.com/(?!/*(?:favicon\.ico|images/|system/))" />
 
@@ -63,10 +56,6 @@
 					-->
 	<!--securecookie host="^issuu\.com$" name="^experiment$" /-->
 	<!--securecookie host="^\.issuu\.com$" name="^(?:i18next|iutk)$" /-->
-
-
-	<rule from="^http://(feed|sidebar)\.issuu\.com/"
-		to="https://s3.amazonaws.com/$1.issuu.com/" />
 
 	<rule from="^http://help\.issuu\.com/"
 		to="https://issuu.zendesk.com/" />


### PR DESCRIPTION
See #17912
<details>
<summary>Tl;DR Summary</summary>
<blockquote>
...In other words, all rulesets that have a to= using the s3.amazonaws.com hostname will stop working. We should update all of these before then. Here's the current list of 115 affected rulesets:
</blockquote>
</details>
