### PR TITLE
Remove S3 Refernces to FeedBlitz

### DIFF
--- a/src/chrome/content/rules/FeedBlitz.xml
+++ b/src/chrome/content/rules/FeedBlitz.xml
@@ -1,8 +1,6 @@
 <!--
 	CDN buckets:
 
-		- s3.amazonaws.com/assets.feedblitz.com/
-		- s3.amazonaws.com/users.feedblitz.com/
 		- ne1.wpc.edgecastcdn.net/0002B4/
 
 		- cee47999521ce01e5baae088241054d9.edgesuite.net
@@ -34,9 +32,6 @@
 		- spnsrs	(→ p.liadm.com)
 		- t		(→ ei.rlcdn.com)
 		- users *
-
-	* → s3.amazonaws.com
-
 
 	Mixed content:
 
@@ -74,11 +69,6 @@
 
 
 	<securecookie host="^w*\.feedblitz\.com$" name=".+" />
-
-
-
-	<rule from="^http://(asset|user)s\.feedblitz\.com/"
-		to="https://s3.amazonaws.com/$1s.feedblitz.com/" />
 
 	<!--	Redirects like so:
 					-->


### PR DESCRIPTION
Related #17912

<details>
<summary>Tl;DR Summary</summary>
<blockquote>
...In other words, all rulesets that have a to= using the s3.amazonaws.com hostname will stop working. We should update all of these before then. Here's the current list of 115 affected rulesets:
</blockquote>
</details>
