### PR TITLE
Remove S3 Reference from SMF for Free

### DIFF
--- a/src/chrome/content/rules/SMF_for_Free.xml
+++ b/src/chrome/content/rules/SMF_for_Free.xml
@@ -17,12 +17,7 @@
 <ruleset name="SMF for Free (partial)">
 
 	<target host="cdn.smfboards.com" />
-	<target host="images.smfboards.com" />
-
-
-
-	<rule from="^http://images\.smfboards\.com/"
-		to="https://s3.amazonaws.com/images.smfboards.com/" />
+	<!-- <target host="images.smfboards.com" /> -->
 
 	<rule from="^http:" to="https:" />
 </ruleset>


### PR DESCRIPTION
Related #17912 

<details>
<summary>Tl;DR Summary</summary>
<blockquote>
...In other words, all rulesets that have a to= using the s3.amazonaws.com hostname will stop working. We should update all of these before then. Here's the current list of 115 affected rulesets:
</blockquote>
</details>