### PR TITLE
Modification: Opera CRX Creation

### DIFF
--- a/browser-dist/browser-dist.md
+++ b/browser-dist/browser-dist.md
@@ -1,0 +1,32 @@
+# Browser Distribution Special Cases
+
+## Edge
+
+Case:
+Edge does not accept CRX files for direct upload to store.
+
+Work around: `edge.sh`
+
+## Opera
+
+Case:
+Opera does not accept `default.rulesets` due to strict MIME type restriction
+
+In order to not disrupt many downstream channels, we are building a separate CRX file for Opera for now.
+
+Work around: `opera.sh`
+
+## Build process
+
+These scripts are normally ran after main build and deployment is finished. The reason being we want a confirmed CRX file upload to Chrome to build the Edge zip and Opera crx distributions on.
+
+## CRX Verification of Files before Upload
+
+Install Node Package for CRX Verification via NPM
+`[sudo] npm -g i crx3-utils`
+
+### Verify CRX file
+
+1. `crx3-info rsa 0 < $crx > public.pem`
+2. `crx3-verify rsa 0 public.pem < $crx`
+3. `echo "CRX verified"`

--- a/browser-dist/edge.sh
+++ b/browser-dist/edge.sh
@@ -1,17 +1,10 @@
 #!/bin/bash
 # Written for transparency and reproducibility on Edge upload
+# See browser-dist.md for more info
 
-# Install Node Package for CRX Verification via NPM
-# [sudo] npm -g i crx3-utils
-
-# Verify CRX file
-# crx3-info rsa 0 < $crx_cws > public.pem
-# crx3-verify rsa 0 public.pem < $crx_cws
-# echo "CRX verified"
-
-VERSION=`python3.6 -c "import json ; print(json.loads(open('chromium/manifest.json').read())['version'])"`
-crx_cws="pkg/https-everywhere-$VERSION-cws.crx"
-crx_eff="pkg/https-everywhere-$VERSION-eff.crx"
+VERSION=`python3.6 -c "import json ; print(json.loads(open('../chromium/manifest.json').read())['version'])"`
+crx_cws="../pkg/https-everywhere-$VERSION-cws.crx"
+crx_eff="../pkg/https-everywhere-$VERSION-eff.crx"
 
 crx3-info rsa 0 < $crx_cws > public.pem
 crx3-verify rsa 0 public.pem < $crx_cws
@@ -24,7 +17,7 @@ crx3-info < $crx_eff | awk '/^header/ {print $2}' \
 
 echo >&2 "Edge zip package has sha256sum: `openssl dgst -sha256 -binary "https-everywhere-$VERSION-edge.zip" | xxd -p`"
 
-mv https-everywhere-$VERSION-edge.zip pkg/https-everywhere-$VERSION-edge.zip
+mv https-everywhere-$VERSION-edge.zip ../pkg/https-everywhere-$VERSION-edge.zip
 
 echo "Created pkg/https-everywhere-$VERSION-edge.zip"
 

--- a/browser-dist/opera.sh
+++ b/browser-dist/opera.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+
+# Build an HTTPS Everywhere Opera CRX Distribution
+# Written for transparency and reproducibility on Opera upload
+# See browser-dist.md for more info
+
+# To build the current state of the tree:
+#
+#     ./browser-dist-opera.sh
+#
+# To build a particular tagged release:
+#
+#     ./browser-dist-opera.sh <version number>
+#
+# eg:
+#
+#     ./browser-dist-opera.sh 2017.8.15
+#
+# Note that .crx files must be signed; this script makes you a
+# "dummy-chromium.pem" private key for you to sign your own local releases,
+# but these .crx files won't detect and upgrade to official HTTPS Everywhere
+# releases signed by EFF :/.  We should find a more elegant arrangement.
+
+! getopt --test > /dev/null
+if [[ ${PIPESTATUS[0]} -ne 4 ]]; then
+  echo 'I’m sorry, `getopt --test` failed in this environment.'
+  exit 1
+fi
+
+OPTIONS=eck:
+LONGOPTS=remove-extension-update,remove-update-channels,key:
+! PARSED=$(getopt --options=$OPTIONS --longoptions=$LONGOPTS --name "$0" -- "$@")
+if [[ ${PIPESTATUS[0]} -ne 0 ]]; then
+  # e.g. return value is 1
+  #  then getopt has complained about wrong arguments to stdout
+  exit 2
+fi
+
+# read getopt’s output this way to handle the quoting right:
+eval set -- "$PARSED"
+
+REMOVE_EXTENSION_UPDATE=false
+REMOVE_UPDATE_CHANNELS=false
+KEY=$(pwd)/dummy-chromium.pem
+while true; do
+  case "$1" in
+    -e|--remove-extension-update)
+      REMOVE_EXTENSION_UPDATE=true
+      shift
+      ;;
+    -c|--remove-update-channels)
+      REMOVE_UPDATE_CHANNELS=true
+      shift
+      ;;
+    -k|--key)
+      KEY="$2"
+      shift 2
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *)
+      echo "Programming error"
+      exit 3
+      ;;
+  esac
+done
+
+if [ "${KEY:0:1}" != "/" ]; then
+  echo "Key must be specified as an absolute path."
+  exit 4
+fi
+
+cd $(dirname $0)
+
+if [ -n "$1" ]; then
+  BRANCH=`git branch | head -n 1 | cut -d \  -f 2-`
+  SUBDIR=checkout
+  [ -d $SUBDIR ] || mkdir $SUBDIR
+  cp -r -f -a .git $SUBDIR
+  cd $SUBDIR
+  git reset --hard "$1"
+  git submodule update --recursive -f
+fi
+
+VERSION=`python3.6 -c "import json ; print(json.loads(open('../chromium/manifest.json').read())['version'])"`
+
+echo "Building version" $VERSION
+
+[ -d pkg ] || mkdir -p ../pkg
+[ -e pkg/crx-opera ] && rm -rf ../pkg/crx-opera
+
+# Clean up obsolete ruleset databases, just in case they still exist.
+rm -f src/chrome/content/rules/default.rulesets src/defaults/rulesets.sqlite
+
+mkdir -p ../pkg/crx-opera/rules
+cd ../pkg/crx-opera
+cp -a ../../chromium/* ./
+# Turn the Firefox translations into the appropriate Chrome format:
+rm -rf _locales/
+mkdir _locales/
+python3.6 ../../utils/chromium-translations.py ../../translations/ _locales/
+python3.6 ../../utils/chromium-translations.py ../../src/chrome/locale/ _locales/
+do_not_ship="*.py *.xml"
+rm -f $do_not_ship
+
+mkdir wasm
+cp ../../lib-wasm/pkg/*.wasm wasm
+cp ../../lib-wasm/pkg/*.js wasm
+
+cd ../..
+
+python3.6 ./utils/merge-rulesets.py || exit 5
+
+cp src/chrome/content/rules/default.rulesets.json pkg/crx-opera/rules/default.rulesets.json
+
+sed -i -e "s/VERSION/$VERSION/g" pkg/crx-opera/manifest.json
+
+for x in `cat .build_exclusions`; do
+  rm -rf pkg/crx-opera/$x
+done
+
+#Create Opera CRX caveat
+cd pkg/crx-opera
+sed -i 's/rules\/default.rulesets/rules\/default.rulesets.json/g' background-scripts/update.js
+cd ../..
+
+# Remove the 'applications' manifest key from the crx version of the extension, change the 'author' string to a hash, and add the "update_url" manifest key
+# "update_url" needs to be present to avoid problems reported in https://bugs.chromium.org/p/chromium/issues/detail?id=805755
+python3.6 -c "import json; m=json.loads(open('pkg/crx-opera/manifest.json').read()); m['author']={'email': 'eff.software.projects@gmail.com'}; del m['applications']; open('pkg/crx-opera/manifest.json','w').write(json.dumps(m,indent=4,sort_keys=True))"
+
+# If the --remove-update-channels flag is set, remove all out-of-band update channels
+if $REMOVE_UPDATE_CHANNELS; then
+  echo "Flag --remove-update-channels specified.  Removing all out-of-band update channels."
+  echo "require.scopes.update_channels.update_channels = [];" >> pkg/crx-opera/background-scripts/update_channels.js
+fi
+
+if [ -n "$BRANCH" ] ; then
+  crx_opera="pkg/https-everywhere-$VERSION-opera.crx"
+else
+  crx_opera="pkg/https-everywhere-$VERSION-pre-opera.crx"
+fi
+if ! [ -f "$KEY" ] ; then
+  echo "Making a dummy signing key for local build purposes"
+  openssl genrsa -out /tmp/dummy-chromium.pem 768
+  openssl pkcs8 -topk8 -nocrypt -in /tmp/dummy-chromium.pem -out $KEY
+fi
+
+# now pack the crx'es
+BROWSER="chromium-browser"
+which $BROWSER || BROWSER="chromium"
+
+$BROWSER --no-message-box --pack-extension="pkg/crx-opera" --pack-extension-key="$KEY" 2> /dev/null
+
+mv pkg/crx-opera.crx $crx_opera
+
+echo >&2 "Opera crx package has sha256sum: `openssl dgst -sha256 -binary "$crx_opera" | xxd -p`"
+echo >&2 "Total included rules: `find src/chrome/content/rules -name "*.xml" | wc -l`"
+echo >&2 "Rules disabled by default: `find src/chrome/content/rules -name "*.xml" | xargs grep -F default_off | wc -l`"
+
+echo "Created $crx_opera"
+
+if [ -n "$BRANCH" ]; then
+  cd ..
+  cp $SUBDIR/$crx_opera pkg
+  rm -rf $SUBDIR
+fi

--- a/make.sh
+++ b/make.sh
@@ -92,7 +92,6 @@ echo "Building version" $VERSION
 [ -d pkg ] || mkdir -p pkg
 [ -e pkg/crx-cws ] && rm -rf pkg/crx-cws
 [ -e pkg/crx-eff ] && rm -rf pkg/crx-eff
-[ -e pkg/crx-opera ] && rm -rf pkg/crx-opera
 [ -e pkg/xpi-amo ] && rm -rf pkg/xpi-amo
 [ -e pkg/xpi-eff ] && rm -rf pkg/xpi-eff
 
@@ -119,7 +118,6 @@ cd ../..
 python3.6 ./utils/merge-rulesets.py || exit 5
 
 cp src/chrome/content/rules/default.rulesets pkg/crx-cws/rules/default.rulesets
-cp src/chrome/content/rules/default.rulesets.json pkg/crx-cws/rules/default.rulesets.json
 
 sed -i -e "s/VERSION/$VERSION/g" pkg/crx-cws/manifest.json
 
@@ -128,23 +126,16 @@ for x in `cat .build_exclusions`; do
 done
 
 cp -a pkg/crx-cws pkg/crx-eff
-cp -a pkg/crx-cws pkg/crx-opera
 cp -a pkg/crx-cws pkg/xpi-amo
 cp -a pkg/crx-cws pkg/xpi-eff
 cp -a src/META-INF pkg/xpi-amo
 cp -a src/META-INF pkg/xpi-eff
 
-#Create Opera CRX caveat
-cd pkg/crx-opera
-sed -i 's/rules\/default.rulesets/rules\/default.rulesets.json/g' background-scripts/update.js
-rm rules/default.rulesets
-cd ../..
 
 # Remove the 'applications' manifest key from the crx version of the extension, change the 'author' string to a hash, and add the "update_url" manifest key
 # "update_url" needs to be present to avoid problems reported in https://bugs.chromium.org/p/chromium/issues/detail?id=805755
 python3.6 -c "import json; m=json.loads(open('pkg/crx-cws/manifest.json').read()); m['author']={'email': 'eff.software.projects@gmail.com'}; del m['applications']; m['update_url'] = 'https://clients2.google.com/service/update2/crx'; open('pkg/crx-cws/manifest.json','w').write(json.dumps(m,indent=4,sort_keys=True))"
 python3.6 -c "import json; m=json.loads(open('pkg/crx-eff/manifest.json').read()); m['author']={'email': 'eff.software.projects@gmail.com'}; del m['applications']; open('pkg/crx-eff/manifest.json','w').write(json.dumps(m,indent=4,sort_keys=True))"
-python3.6 -c "import json; m=json.loads(open('pkg/crx-opera/manifest.json').read()); m['author']={'email': 'eff.software.projects@gmail.com'}; del m['applications']; open('pkg/crx-opera/manifest.json','w').write(json.dumps(m,indent=4,sort_keys=True))"
 # Remove the 'update_url' manifest key from the xpi version of the extension delivered to AMO
 python3.6 -c "import json; m=json.loads(open('pkg/xpi-amo/manifest.json').read()); del m['applications']['gecko']['update_url']; m['applications']['gecko']['id'] = 'https-everywhere@eff.org'; open('pkg/xpi-amo/manifest.json','w').write(json.dumps(m,indent=4,sort_keys=True))"
 
@@ -160,7 +151,6 @@ if $REMOVE_UPDATE_CHANNELS; then
   echo "Flag --remove-update-channels specified.  Removing all out-of-band update channels."
   echo "require.scopes.update_channels.update_channels = [];" >> pkg/crx-cws/background-scripts/update_channels.js
   echo "require.scopes.update_channels.update_channels = [];" >> pkg/crx-eff/background-scripts/update_channels.js
-  echo "require.scopes.update_channels.update_channels = [];" >> pkg/crx-opera/background-scripts/update_channels.js
   echo "require.scopes.update_channels.update_channels = [];" >> pkg/xpi-amo/background-scripts/update_channels.js
   echo "require.scopes.update_channels.update_channels = [];" >> pkg/xpi-eff/background-scripts/update_channels.js
 fi
@@ -168,14 +158,12 @@ fi
 if [ -n "$BRANCH" ] ; then
   crx_cws="pkg/https-everywhere-$VERSION-cws.crx"
   crx_eff="pkg/https-everywhere-$VERSION-eff.crx"
-  crx_opera="pkg/https-everywhere-$VERSION-opera.crx"
   xpi_amo="pkg/https-everywhere-$VERSION-amo.xpi"
   xpi_eff="pkg/https-everywhere-$VERSION-eff.xpi"
 
 else
   crx_cws="pkg/https-everywhere-$VERSION~pre-cws.crx"
   crx_eff="pkg/https-everywhere-$VERSION~pre-eff.crx"
-  crx_opera="pkg/https-everywhere-$VERSION-pre-opera.crx"
   xpi_amo="pkg/https-everywhere-$VERSION~pre-amo.xpi"
   xpi_eff="pkg/https-everywhere-$VERSION~pre-eff.xpi"
 fi
@@ -192,15 +180,12 @@ which $BROWSER || BROWSER="chromium"
 
 $BROWSER --no-message-box --pack-extension="pkg/crx-cws" --pack-extension-key="$KEY" 2> /dev/null
 $BROWSER --no-message-box --pack-extension="pkg/crx-eff" --pack-extension-key="$KEY" 2> /dev/null
-$BROWSER --no-message-box --pack-extension="pkg/crx-opera" --pack-extension-key="$KEY" 2> /dev/null
 
 mv pkg/crx-cws.crx $crx_cws
 mv pkg/crx-eff.crx $crx_eff
-mv pkg/crx-opera.crx $crx_opera
 
 echo >&2 "CWS crx package has sha256sum: `openssl dgst -sha256 -binary "$crx_cws" | xxd -p`"
 echo >&2 "EFF crx package has sha256sum: `openssl dgst -sha256 -binary "$crx_eff" | xxd -p`"
-echo >&2 "Opera crx package has sha256sum: `openssl dgst -sha256 -binary "$crx_opera" | xxd -p`"
 
 # now zip up the xpi AMO dir
 name=pkg/xpi-amo
@@ -235,13 +220,11 @@ echo "Created $xpi_amo"
 echo "Created $xpi_eff"
 echo "Created $crx_cws"
 echo "Created $crx_eff"
-echo "Created $crx_opera"
 
 if [ -n "$BRANCH" ]; then
   cd ..
   cp $SUBDIR/$crx_cws pkg
   cp $SUBDIR/$crx_eff pkg
-  cp $SUBDIR/$crx_opera pkg
   cp $SUBDIR/$xpi_amo pkg
   cp $SUBDIR/$xpi_eff pkg
   rm -rf $SUBDIR


### PR DESCRIPTION
- MIME Type restriction requires default.rulesets to be declared
- This is a better route than changing all downstream channels
- Process will entail signing the hash of the Opera CRX for assurance

Closes #19679 