### PR TITLE
add frankfurt-university.de.xml

### DIFF
--- a/src/chrome/content/rules/frankfurt-university.de.xml
+++ b/src/chrome/content/rules/frankfurt-university.de.xml
@@ -1,14 +1,13 @@
 <ruleset name="frankfurt-university.de">
 	<target host="frankfurt-university.de" />
-  <target host="www.frankfurt-university.de" />
 	<target host="*.frankfurt-university.de" />
-    <test url="http://idm.frankfurt-university.de/" />
-    <test url="http://webmail.frankfurt-university.de/" />
-    <test url="http://intranet.frankfurt-university.de/" />
+    	<test url="http://idm.frankfurt-university.de/" />
+    	<test url="http://webmail.frankfurt-university.de/" />
+    	<test url="http://intranet.frankfurt-university.de/" />
 
 	<exclusion pattern="^http://sea-[0-9][0-9]\.cit\.frankfurt-university\.de:32224/" />
-    <test url="http://sea-01.cit.frankfurt-university.de:32224/" />
-    <test url="http://sea-02.cit.frankfurt-university.de:32224/" />
+    	<test url="http://sea-01.cit.frankfurt-university.de:32224/" />
+    	<test url="http://sea-02.cit.frankfurt-university.de:32224/" />
     
   <rule from="^http:" to="https:" />
 </ruleset>

--- a/src/chrome/content/rules/frankfurt-university.de.xml
+++ b/src/chrome/content/rules/frankfurt-university.de.xml
@@ -1,0 +1,14 @@
+<ruleset name="frankfurt-university.de">
+	<target host="frankfurt-university.de" />
+  <target host="www.frankfurt-university.de" />
+	<target host="*.frankfurt-university.de" />
+    <test url="http://idm.frankfurt-university.de/" />
+    <test url="http://webmail.frankfurt-university.de/" />
+    <test url="http://intranet.frankfurt-university.de/" />
+
+	<exclusion pattern="^http://sea-[0-9][0-9]\.cit\.frankfurt-university\.de:32224/" />
+    <test url="http://sea-01.cit.frankfurt-university.de:32224/" />
+    <test url="http://sea-02.cit.frankfurt-university.de:32224/" />
+    
+  <rule from="^http:" to="https:" />
+</ruleset>


### PR DESCRIPTION
Add `frankfurt-university.de` to exclude `http://sea-01.cit.frankfurt-university.de:32224` because even the forwarding to insecure site sometimes fails (workaround)