### PR TITLE
Update Wuala.xml

### DIFF
--- a/src/chrome/content/rules/Wuala.xml
+++ b/src/chrome/content/rules/Wuala.xml
@@ -1,14 +1,6 @@
-<ruleset name="wuala">
-  <target host="wuala.com" />
-  <target host="*.wuala.com" />
+<ruleset name="Wuala.com">
+	<target host="wuala.com" />
+	<target host="www.wuala.com" />
 
-	<!--	Not secured by server:
-					-->
-	<!--securecookie host="^support\.wuala\.com$" name="^_icl_current_language$" /-->
-	<!--securecookie host="^www\.wuala\.com$" name="^PHPSESSID$" /-->
-
-  <securecookie host="^(?:(?:www|forum|stats|support|thumb\d+)\.)?wuala\.com$" name=".+" />
-
-  <rule from="^http://wuala\.com/" to="https://wuala.com/"/>
-  <rule from="^http://(www|cdn|forum|stats|support|thumb\d+)\.wuala\.com/" to="https://$1.wuala.com/"/>
+	<rule from="^http:" to="https:" />
 </ruleset>


### PR DESCRIPTION
Related to #19410

## Type of change

- [x] Existing Ruleset

## For Rulesets: Testing

- [ ] Travis CI completed without errors (triggered upon pull request)

Wuala cloud storage had shut down, but there is an information page remaining on the same domain.