### PR TITLE
KSH: Add exclusion for /Statinfo/

### DIFF
--- a/src/chrome/content/rules/KSH.xml
+++ b/src/chrome/content/rules/KSH.xml
@@ -6,12 +6,13 @@
 
 	<rule from="^http://(?:www\.)?ksh\.hu/"
 		to="https://www.ksh.hu/" />
+	
+	<!-- These pages return a 404 error when requested over HTTPS -->
+	<exclusion pattern="^http://statinfo\.ksh\.hu/Statinfo/" />
+		<test url="http://statinfo.ksh.hu/Statinfo/">
+		<test url="http://statinfo.ksh.hu/Statinfo/themeSelector.jsp?lang=hu" />
+		<test url="http://statinfo.ksh.hu/Statinfo/QueryServlet?ha=TA2019_W" />
 
 	<rule from="^http://(statinfo|elektra)\.ksh\.hu/"
 		to="https://$1.ksh.hu/" />
-	
-	<exclusion pattern="^http://statinfo\.ksh\.hu/Statinfo/" />
-		<test url="http://statinfo.ksh.hu/Statinfo/">
-		<test url="http://statinfo.ksh.hu/Statinfo/themeSelector.jsp?lang=hu&utm_source=kshhu&utm_medium=banner&utm_campaign=theme-teruleti-adatok" />
-		<test url="http://statinfo.ksh.hu/Statinfo/QueryServlet?ha=TA2019_W" />
 </ruleset>

--- a/src/chrome/content/rules/KSH.xml
+++ b/src/chrome/content/rules/KSH.xml
@@ -9,7 +9,7 @@
 	
 	<!-- These pages return a 404 error when requested over HTTPS -->
 	<exclusion pattern="^http://statinfo\.ksh\.hu/Statinfo/" />
-		<test url="http://statinfo.ksh.hu/Statinfo/">
+		<test url="http://statinfo.ksh.hu/Statinfo/" />
 		<test url="http://statinfo.ksh.hu/Statinfo/themeSelector.jsp?lang=hu" />
 		<test url="http://statinfo.ksh.hu/Statinfo/QueryServlet?ha=TA2019_W" />
 

--- a/src/chrome/content/rules/KSH.xml
+++ b/src/chrome/content/rules/KSH.xml
@@ -9,4 +9,9 @@
 
 	<rule from="^http://(statinfo|elektra)\.ksh\.hu/"
 		to="https://$1.ksh.hu/" />
+	
+	<exclusion pattern="^http://statinfo\.ksh\.hu/Statinfo/" />
+		<test url="http://statinfo.ksh.hu/Statinfo/">
+		<test url="http://statinfo.ksh.hu/Statinfo/themeSelector.jsp?lang=hu&utm_source=kshhu&utm_medium=banner&utm_campaign=theme-teruleti-adatok" />
+		<test url="http://statinfo.ksh.hu/Statinfo/QueryServlet?ha=TA2019_W" />
 </ruleset>


### PR DESCRIPTION
Using HTTPS for these paths causes a 404 error. HTTP works fine.

Examples:
* http://statinfo.ksh.hu/Statinfo/
* http://statinfo.ksh.hu/Statinfo/themeSelector.jsp?lang=hu&utm_source=kshhu&utm_medium=banner&utm_campaign=theme-teruleti-adatok
* http://statinfo.ksh.hu/Statinfo/QueryServlet?ha=TA2019_W

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring existing code
- [ ] New Ruleset
- [ ] Existing Ruleset
