### PR TITLE
Fix chromium-driver for Debian 10+; Use firefox-esr instead of iceweasel

### DIFF
--- a/install-dev-dependencies.sh
+++ b/install-dev-dependencies.sh
@@ -35,10 +35,9 @@ if type apt-get>/dev/null 2>&1;  then
   BROWSERS="firefox chromium-browser"
   CHROMEDRIVER="chromium-chromedriver"
   if [[ "$(lsb_release -is)" == "Debian" ]]; then
-    # Iceweasel is the rebranded Firefox that Debian ships, and Chromium
-    # takes the name of 'chromium' instead of 'chromium-browser' in
+    # Chromium takes the name of 'chromium' instead of 'chromium-browser' in
     # Debian 7 (wheezy) and later.
-    BROWSERS="iceweasel chromium"
+    BROWSERS="firefox-esr chromium"
     CHROMEDRIVER="chromedriver"
   fi
   $SUDO_SHIM apt-get install -y libxml2-dev libxml2-utils libxslt1-dev \

--- a/install-dev-dependencies.sh
+++ b/install-dev-dependencies.sh
@@ -38,7 +38,7 @@ if type apt-get>/dev/null 2>&1;  then
     # Chromium takes the name of 'chromium' instead of 'chromium-browser' in
     # Debian 7 (wheezy) and later.
     BROWSERS="firefox-esr chromium"
-    CHROMEDRIVER="chromedriver"
+    CHROMEDRIVER="chromium-driver"
   fi
   $SUDO_SHIM apt-get install -y libxml2-dev libxml2-utils libxslt1-dev \
     python3.6-dev $BROWSERS zip sqlite3 python3-pip libcurl4-openssl-dev xvfb \


### PR DESCRIPTION
Ref: https://wiki.debian.org/Firefox#Iceweasel

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring existing code
- [ ] New Ruleset
- [ ] Existing Ruleset
