### PR TITLE
Update test/setup_travis.sh

### DIFF
--- a/test/setup_travis.sh
+++ b/test/setup_travis.sh
@@ -19,7 +19,7 @@ function setup_chrome {
 function setup_firefox {
     # install the latest version of geckodriver (per Github release API)
     firefox_version=$("${BROWSER}" -version)
-    geckodriver_version=$(curl -s https://api.github.com/repos/mozilla/geckodriver/releases/latest | grep tag_name | cut -d '"' -f 4)
+    geckodriver_version=$(curl -svL https://api.github.com/repos/mozilla/geckodriver/releases/latest | grep tag_name | cut -d '"' -f 4)
     geckodriver_url="https://github.com/mozilla/geckodriver/releases/download/${geckodriver_version}/geckodriver-${geckodriver_version}-linux64.tar.gz"
 
     echo "Setting up geckodriver ${geckodriver_version} for ${firefox_version}"

--- a/test/setup_travis.sh
+++ b/test/setup_travis.sh
@@ -18,8 +18,9 @@ function setup_chrome {
 
 function setup_firefox {
     # install the latest version of geckodriver (per Github release API)
+    # https://docs.github.com/en/free-pro-team@latest/rest/reference/repos#get-the-latest-release
     firefox_version=$("${BROWSER}" -version)
-    geckodriver_version=$(curl -svL https://api.github.com/repos/mozilla/geckodriver/releases/latest | grep tag_name | cut -d '"' -f 4)
+    geckodriver_version=$(curl -svL -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/mozilla/geckodriver/releases/latest | grep tag_name | cut -d '"' -f 4)
     geckodriver_url="https://github.com/mozilla/geckodriver/releases/download/${geckodriver_version}/geckodriver-${geckodriver_version}-linux64.tar.gz"
 
     echo "Setting up geckodriver ${geckodriver_version} for ${firefox_version}"

--- a/test/setup_travis.sh
+++ b/test/setup_travis.sh
@@ -19,6 +19,8 @@ function setup_chrome {
 function setup_firefox {
     # install the latest version of geckodriver (per Github release API)
     # https://docs.github.com/en/free-pro-team@latest/rest/reference/repos#get-the-latest-release
+    # For unauthenticated requests, the rate limit allows for up to 60 requests per hour.
+    # See https://docs.github.com/en/free-pro-team@latest/rest/overview/resources-in-the-rest-api#rate-limiting
     firefox_version=$("${BROWSER}" -version)
     geckodriver_version=$(curl -svL -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/mozilla/geckodriver/releases/latest | grep tag_name | cut -d '"' -f 4)
     geckodriver_url="https://github.com/mozilla/geckodriver/releases/download/${geckodriver_version}/geckodriver-${geckodriver_version}-linux64.tar.gz"

--- a/test/setup_travis.sh
+++ b/test/setup_travis.sh
@@ -17,12 +17,9 @@ function setup_chrome {
 }
 
 function setup_firefox {
-    # install the latest version of geckodriver (per Github release API)
-    # https://docs.github.com/en/free-pro-team@latest/rest/reference/repos#get-the-latest-release
-    # For unauthenticated requests, the rate limit allows for up to 60 requests per hour.
-    # See https://docs.github.com/en/free-pro-team@latest/rest/overview/resources-in-the-rest-api#rate-limiting
+    # install the latest version of geckodriver
     firefox_version=$("${BROWSER}" -version)
-    geckodriver_version=$(curl -svL -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/mozilla/geckodriver/releases/latest | grep tag_name | cut -d '"' -f 4)
+    geckodriver_version=$(curl -sI https://github.com/mozilla/geckodriver/releases/latest | grep -i "^Location: " | sed 's/.*\///' | tr -d '\r')
     geckodriver_url="https://github.com/mozilla/geckodriver/releases/download/${geckodriver_version}/geckodriver-${geckodriver_version}-linux64.tar.gz"
 
     echo "Setting up geckodriver ${geckodriver_version} for ${firefox_version}"


### PR DESCRIPTION
> For unauthenticated requests, the rate limit allows for up to 60 requests per hour. Unauthenticated requests are associated with the originating IP address, and not the user making requests.

Look like the current approach to obtain the latest geckodriver is problematic on a Travis environment. Need another solution or fallback to the static URLs approach.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring existing code
- [ ] New Ruleset
- [ ] Existing Ruleset
