### PR TITLE
Remove Radio.garden ruleset

### DIFF
--- a/src/chrome/content/rules/radio.garden.xml
+++ b/src/chrome/content/rules/radio.garden.xml
@@ -1,7 +1,0 @@
-<ruleset name="radio.garden">
-	<target host="radio.garden" />
-	<target host="www.radio.garden" />
-	<target host="submit.radio.garden" />
-
-	<rule from="^http:" to="https:" />
-</ruleset>


### PR DESCRIPTION
Site does not support HTTPS and redirects to HTTP

Fixes #19927

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Existing Ruleset
