### PR TITLE
Create onlineprospectus.net.xml

### DIFF
--- a/src/chrome/content/rules/onlineprospectus.net.xml
+++ b/src/chrome/content/rules/onlineprospectus.net.xml
@@ -1,0 +1,10 @@
+<ruleset name="onlineprospectus.net">
+	<target host="onlineprospectus.net" />
+	<target host="*.onlineprospectus.net" />
+
+	<rule from="^http:" to="https:" />
+	
+	<test url="http://direxioninvestments.onlineprospectus.net/DirexionInvestments//SPDN/index.html?open=Summary%20Prospectus" />
+	<test url="http://nationwidefunds.onlineprospectus.net/nationwidefunds/TD2025Fund/" />
+	<test url="http://direxioninvestments.onlineprospectus.net/DirexionInvestments/regulatory-documents/" />
+</ruleset>


### PR DESCRIPTION
cert works for root domain and `*.` 

Many subdomains currently are not forced https

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring existing code
- [x] New Ruleset
- [ ] Existing Ruleset
