### PR TITLE
Update the rules for dwheeler.com

### DIFF
--- a/src/chrome/content/rules/DWheeler.xml
+++ b/src/chrome/content/rules/DWheeler.xml
@@ -4,6 +4,6 @@
 	<target host="www.dwheeler.com"/>
 
 	<rule from="^http://(?:www\.)?dwheeler\.com/"
-		to="https://www.dwheeler.com/"/>
+		to="https://dwheeler.com/"/>
 
 </ruleset>


### PR DESCRIPTION
The www subdomain doesn't do https but the root does
and both have equivalent content on the same URL paths.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring existing code
- [ ] New Ruleset
- [x] Existing Ruleset