### PR TITLE
Open option page in a single click on Android, follow up #19781

### DIFF
--- a/chromium/pages/options/index.html
+++ b/chromium/pages/options/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=.8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title></title>
     <link href="style.css" rel="stylesheet">
   </head>

--- a/chromium/pages/options/style.css
+++ b/chromium/pages/options/style.css
@@ -27,18 +27,6 @@ body{
   display: inline-block;
 }
 
-a.settings{
-	background-color: #1c87c9;
-	border: none;
-	color: white;
-	padding: 20px 34px;
-	text-align: center;
-	text-decoration: none;
-	display: inline-block;
-	font-size: 20px;
-	margin: 4px 2px;
-}
-
 .settings-wrapper{
   margin: 10px 0 0 0;
 }

--- a/chromium/pages/options/ux.js
+++ b/chromium/pages/options/ux.js
@@ -5,20 +5,6 @@
 
 "use strict";
 
-if (navigator.userAgent.includes("Android")) {
-  const url = new URL(window.location.href);
-  if (!url.searchParams.get('redirected')) {
-    url.searchParams.set('redirected', true);
-    document.body.innerText = "";
-    let link = document.createElement("a");
-    link.href = url.href;
-    link.target = "_blank";
-    link.className = "settings";
-    link.innerText = chrome.i18n.getMessage("options_settings");
-    document.body.appendChild(link);
-  }
-}
-
 document.addEventListener("DOMContentLoaded", () => {
   const secretArea = document.getElementById('secretArea');
 


### PR DESCRIPTION
On Android, click "Add-ons" > "HTTPS Everywhere"  > "Settings", _a button to the setting page_ is shown. The setting page is shown only after an user clicks the button.

This PR restores the default behavior and shows the setting page without the needing to click the button.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring existing code
- [ ] New Ruleset
- [ ] Existing Ruleset
