### PR TITLE
Update WordPress.xml: don't secure wordpress_logged_in cookie

### DIFF
--- a/src/chrome/content/rules/WordPress.xml
+++ b/src/chrome/content/rules/WordPress.xml
@@ -28,7 +28,7 @@
 		<test url="http://www.wp.com/music" />
 		<test url="http://get.wp.com/" />
 
-	<securecookie host=".+" name=".+" />
+	<securecookie host=".+" name="^(?!wordpress_logged_in$).+" />
 
 	<rule from="^http:" to="https:"/>
 </ruleset>


### PR DESCRIPTION
The wordpress.com site is already sending both secure and non-secure versions.
The non-secure version doesn't have a SameSite=None attribute, and securing it
would overwrite the secure cookie that has it.

Fixes #19954

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring existing code
- [ ] New Ruleset
- [x] Existing Ruleset
