### PR TITLE
Fix access to undefined property `state` of type `Ruleset`

### DIFF
--- a/chromium/background-scripts/rules.js
+++ b/chromium/background-scripts/rules.js
@@ -124,7 +124,7 @@ RuleSet.prototype = {
   isEquivalentTo: function(ruleset) {
     if(this.name != ruleset.name ||
        this.note != ruleset.note ||
-       this.state != ruleset.state ||
+       this.active != ruleset.active ||
        this.default_state != ruleset.default_state) {
       return false;
     }


### PR DESCRIPTION
Property `state` is not defined in `Ruleset`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring existing code
- [ ] New Ruleset
- [ ] Existing Ruleset
