### PR TITLE
Fix unexpected arithmetic operations on strings

### DIFF
--- a/chromium/background-scripts/ip_utils.js
+++ b/chromium/background-scripts/ip_utils.js
@@ -4,7 +4,7 @@
 
 /**
  * Parse and convert literal IP address into numerical IP address.
- * @param {string} ip 
+ * @param {string} ip
  * @returns {number}
  */
 const parseIp = ip => {
@@ -40,8 +40,8 @@ const parseIp = ip => {
 
 /**
  * Check if the numeric IP address is within a certain range.
- * @param {number} ip 
- * @param {number[]} range 
+ * @param {number} ip
+ * @param {number[]} range
  * @returns {boolean}
  */
 const isIpInRange = (ip, [rangeIp, mask]) => (ip & mask) >>> 0 === rangeIp;
@@ -57,7 +57,7 @@ const localRanges = [
 
 /**
  * Check if the numeric IP address is inside the local IP address ranges.
- * @param {number} ip 
+ * @param {number} ip
  * @returns {boolean}
  */
 const isLocalIp = ip => localRanges.some(range => isIpInRange(ip, range));

--- a/chromium/background-scripts/ip_utils.js
+++ b/chromium/background-scripts/ip_utils.js
@@ -26,7 +26,7 @@ const parseIp = ip => {
       return -1;
     }
 
-    ipN = (ipN << 8) | octet;
+    ipN = (ipN << 8) | octetN;
   }
 
   return ipN >>> 0;

--- a/chromium/background-scripts/ip_utils.js
+++ b/chromium/background-scripts/ip_utils.js
@@ -2,11 +2,17 @@
 
 (function (exports) {
 
+/**
+ * Parse and convert literal IP address into numerical IP address.
+ * @param {string} ip 
+ * @returns {number}
+ */
 const parseIp = ip => {
   if (!/^[0-9.]+$/.test(ip)) {
     return -1;
   }
 
+  /** @type {string[]} */
   const octets = ip.split('.');
 
   if (octets.length !== 4) {
@@ -32,8 +38,15 @@ const parseIp = ip => {
   return ipN >>> 0;
 };
 
+/**
+ * Check if the numeric IP address is within a certain range.
+ * @param {number} ip 
+ * @param {number[]} range 
+ * @returns {boolean}
+ */
 const isIpInRange = (ip, [rangeIp, mask]) => (ip & mask) >>> 0 === rangeIp;
 
+// A list of local IP address ranges
 const localRanges = [
   [/* 0.0.0.0         */ 0x00000000, /* 255.255.255.255 */ 0xffffffff],
   [/* 127.0.0.0       */ 0x7f000000, /* 255.0.0.0       */ 0xff000000],
@@ -42,6 +55,11 @@ const localRanges = [
   [/* 192.168.0.0     */ 0xc0a80000, /* 255.255.0.0     */ 0xffff0000],
 ];
 
+/**
+ * Check if the numeric IP address is inside the local IP address ranges.
+ * @param {number} ip 
+ * @returns {boolean}
+ */
 const isLocalIp = ip => localRanges.some(range => isIpInRange(ip, range));
 
 Object.assign(exports, {


### PR DESCRIPTION
@pipboy96 would you kindly check if this is a bug?

`octet` is a `string` type, per typescript check

> the right-hard side of an arithmetic operation must be of type `any`, `number`, `bigint` or an `enum` type. 

`octetN` is not used otherwise.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring existing code
- [ ] New Ruleset
- [ ] Existing Ruleset
