### PR TITLE
Fix invalid ruleset scope typings

### DIFF
--- a/chromium/background-scripts/rules.js
+++ b/chromium/background-scripts/rules.js
@@ -251,7 +251,7 @@ RuleSets.prototype = {
         ruleJson,
         settings.enableMixedRulesets,
         this.ruleActiveStates,
-        getScope(scope));
+        scope);
     } else {
       for (let ruleset of ruleJson) {
         try {

--- a/chromium/background-scripts/rules.js
+++ b/chromium/background-scripts/rules.js
@@ -242,9 +242,8 @@ RuleSets.prototype = {
   },
 
   /**
-   * 
-   * @param {*} ruleJson 
-   * @param {string} scope 
+   * @param {*} ruleJson
+   * @param {string} scope
    */
   addFromJson: function(ruleJson, scope) {
     if (this.wasm_rs) {

--- a/chromium/background-scripts/rules.js
+++ b/chromium/background-scripts/rules.js
@@ -16,7 +16,11 @@ const trivial_cookie_rule_c = /.+/;
 /* A map of all scope RegExp objects */
 const scopes = new Map();
 
-/* Returns the scope object from the map for the given scope string */
+/**
+ * Returns the scope object from the map for the given scope string
+ * @param {string} scope
+ * @returns {RegExp}
+ */
 function getScope(scope) {
   if (!scopes.has(scope)) {
     scopes.set(scope, new RegExp(scope));
@@ -398,7 +402,7 @@ RuleSets.prototype = {
   loadStoredUserRules: function() {
     return this.getStoredUserRules()
       .then(userRules => {
-        this.addFromJson(userRules, getScope());
+        this.addFromJson(userRules, '');
         util.log(util.INFO, `loaded ${userRules.length} stored user rules`);
       });
   },
@@ -409,7 +413,7 @@ RuleSets.prototype = {
   * @param cb: Callback to call after success/fail
   * */
   addNewRuleAndStore: async function(params) {
-    if (this.addUserRule(params, getScope())) {
+    if (this.addUserRule(params, '')) {
       // If we successfully added the user rule, save it in the storage
       // api so it's automatically applied when the extension is
       // reloaded.

--- a/chromium/background-scripts/rules.js
+++ b/chromium/background-scripts/rules.js
@@ -18,7 +18,7 @@ const scopes = new Map();
 
 /**
  * Returns the scope object from the map for the given scope string.
- * @param {string} scope literal ruleset scope
+ * @param {string} scope ruleset scope string
  * @returns {RegExp}
  */
 function getScope(scope) {
@@ -81,7 +81,7 @@ function CookieRule(host, cookiename) {
  *A collection of rules
  * @param {string} set_name The name of this set
  * @param {boolean} default_state activity state
- * @param {RegExp} scope compiled RegExp ruleset scope
+ * @param {string} scope ruleset scope string
  * @param {string} note Note will be displayed in popup
  * @constructor
  */
@@ -92,7 +92,7 @@ function RuleSet(set_name, default_state, scope, note) {
   this.cookierules = null;
   this.active = default_state;
   this.default_state = default_state;
-  this.scope = scope;
+  this.scope = getScope(scope);
   this.note = note;
 }
 
@@ -291,7 +291,7 @@ RuleSets.prototype = {
       note += "Platform(s): " + platform + "\n";
     }
 
-    var rule_set = new RuleSet(ruletag["name"], default_state, getScope(scope), note.trim());
+    var rule_set = new RuleSet(ruletag["name"], default_state, scope, note.trim());
 
     // Read user prefs
     if (rule_set.name in this.ruleActiveStates) {
@@ -582,7 +582,7 @@ RuleSets.prototype = {
     if (this.wasm_rs) {
       let pa = this.wasm_rs.potentially_applicable(host);
       results = new Set([...pa].map(ruleset => {
-        let rs = new RuleSet(ruleset.name, ruleset.default_state, getScope(ruleset.scope), ruleset.note);
+        let rs = new RuleSet(ruleset.name, ruleset.default_state, ruleset.scope, ruleset.note);
 
         if (ruleset.cookierules) {
           let cookierules = ruleset.cookierules.map(cookierule => {

--- a/chromium/background-scripts/rules.js
+++ b/chromium/background-scripts/rules.js
@@ -17,7 +17,7 @@ const trivial_cookie_rule_c = /.+/;
 const scopes = new Map();
 
 /**
- * Compile literal ruleset scope into RegExp
+ * Returns the scope object from the map for the given scope string.
  * @param {string} scope literal ruleset scope
  * @returns {RegExp}
  */

--- a/chromium/background-scripts/update.js
+++ b/chromium/background-scripts/update.js
@@ -215,7 +215,7 @@ async function applyStoredRulesets(rulesets_obj) {
   }
 
   if(!replaces) {
-    rulesets_obj.addFromJson(util.loadExtensionFile('rules/default.rulesets', 'json'));
+    rulesets_obj.addFromJson(util.loadExtensionFile('rules/default.rulesets', 'json'), '');
   }
 }
 


### PR DESCRIPTION
This PR makes compiling `scope` into `RegExp` automatic. Pass the string literal version of the `scope` parameter everywhere, except for when constructing rulesets/ ~WASM calls~. 

- `getScope` expected a required string parameter, but get none. It is also called multiple time when passed to `addFromJson`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring existing code
- [ ] New Ruleset
- [ ] Existing Ruleset
