### PR TITLE
Background JS Cleanup: Move SSL Codes

### DIFF
--- a/chromium/background-scripts/background.js
+++ b/chromium/background-scripts/background.js
@@ -579,7 +579,6 @@ function onErrorOccurred(details) {
   if (httpNowhereOn &&
     details.type == "main_frame" &&
     browserSession.getRequest(details.requestId, "simple_http_nowhere_redirect", false) &&
-    session.getRequest(details.requestId, "simple_http_nowhere_redirect", false) &&
     // Enumerate errors that are likely due to HTTPS misconfigurations
     ssl_codes.error_list.some(message => details.error.includes(message))
   ) {

--- a/chromium/background-scripts/background.js
+++ b/chromium/background-scripts/background.js
@@ -12,8 +12,6 @@ const rules = require('./rules'),
   ipUtils = require('./ip_utils'),
   ssl_codes = require('./ssl_codes');
 
-  console.log(ssl_codes);
-
 let all_rules = new rules.RuleSets();
 let blooms = [];
 

--- a/chromium/background-scripts/background.js
+++ b/chromium/background-scripts/background.js
@@ -9,8 +9,10 @@ const rules = require('./rules'),
   update = require('./update'),
   { update_channels } = require('./update_channels'),
   wasm = require('./wasm'),
-  ipUtils = require('./ip_utils');
+  ipUtils = require('./ip_utils'),
+  ssl_codes = require('./ssl_codes');
 
+  console.log(ssl_codes);
 
 let all_rules = new rules.RuleSets();
 let blooms = [];
@@ -579,28 +581,10 @@ function onErrorOccurred(details) {
   if (httpNowhereOn &&
     details.type == "main_frame" &&
     browserSession.getRequest(details.requestId, "simple_http_nowhere_redirect", false) &&
-    ( // Enumerate a class of errors that are likely due to HTTPS misconfigurations
-      details.error.indexOf("net::ERR_SSL_") == 0 ||
-      details.error.indexOf("net::ERR_CERT_") == 0 ||
-      details.error.indexOf("net::ERR_CONNECTION_") == 0 ||
-      details.error.indexOf("net::ERR_ABORTED") == 0 ||
-      details.error.indexOf("net::ERR_SSL_PROTOCOL_ERROR") == 0 ||
-      details.error.indexOf("NS_ERROR_CONNECTION_REFUSED") == 0 ||
-      details.error.indexOf("NS_ERROR_NET_TIMEOUT") == 0 ||
-      details.error.indexOf("NS_ERROR_NET_ON_TLS_HANDSHAKE_ENDED") == 0 ||
-      details.error.indexOf("SSL received a record that exceeded the maximum permissible length.") == 0 ||
-      details.error.indexOf("Peer’s Certificate has expired.") == 0 ||
-      details.error.indexOf("Unable to communicate securely with peer: requested domain name does not match the server’s certificate.") == 0 ||
-      details.error.indexOf("Peer’s Certificate issuer is not recognized.") == 0 ||
-      details.error.indexOf("Peer’s Certificate has been revoked.") == 0 ||
-      details.error.indexOf("Peer reports it experienced an internal error.") == 0 ||
-      details.error.indexOf("The server uses key pinning (HPKP) but no trusted certificate chain could be constructed that matches the pinset. Key pinning violations cannot be overridden.") == 0 ||
-      details.error.indexOf("SSL received a weak ephemeral Diffie-Hellman key in Server Key Exchange handshake message.") == 0 ||
-      details.error.indexOf("The certificate was signed using a signature algorithm that is disabled because it is not secure.") == 0 ||
-      details.error.indexOf("Unable to communicate securely with peer: requested domain name does not match the server’s certificate.") == 0 ||
-      details.error.indexOf("Cannot communicate securely with peer: no common encryption algorithm(s).") == 0 ||
-      details.error.indexOf("SSL peer has no certificate for the requested DNS name.") == 0
-    )) {
+    session.getRequest(details.requestId, "simple_http_nowhere_redirect", false) &&
+    // Enumerate errors that are likely due to HTTPS misconfigurations
+    ssl_codes.error_list.some(message => details.error.includes(message))
+  ) {
     let url = new URL(details.url);
     if (url.protocol == "https:") {
       url.protocol = "http:";

--- a/chromium/background-scripts/modules/ssl_codes.js
+++ b/chromium/background-scripts/modules/ssl_codes.js
@@ -1,0 +1,48 @@
+"use strict";
+
+/**
+ * @exports error_list
+ * @type {array}
+ * @description A list of known SSL config errors to filter through and not try to upgrade the user
+ * @see
+ * Chrome SSL errors: https://github.com/chromium/chromium/blob/master/components/domain_reliability/util.cc
+ * Firefox SSL Errors: https://hg.mozilla.org/releases/mozilla-release/file/tip/security/manager/locales/en-US/chrome/pipnss/nsserrors.properties
+ */
+
+(function (exports) {
+
+const error_list = [
+  "net::ERR_SSL_PROTOCOL_ERROR",
+  "net::ERR_SSL_VERSION_OR_CIPHER_MISMATCH",
+  "net::ERR_SSL_UNRECOGNIZED_NAME_ALERT",
+  "net::ERR_SSL_PINNED_KEY_NOT_IN_CERT_CHAIN",
+  "net::ERR_CERT_COMMON_NAME_INVALID",
+  "net::ERR_CERT_DATE_INVALID",
+  "net::ERR_CERT_AUTHORITY_INVALID",
+  "net::ERR_CERT_REVOKED",
+  "net::ERR_CERT_INVALID",
+  "net::ERR_CONNECTION_CLOSED",
+  "net::ERR_CONNECTION_RESET",
+  "net::ERR_CONNECTION_REFUSED",
+  "net::ERR_CONNECTION_ABORTED",
+  "net::ERR_CONNECTION_FAILED",
+  "net::ERR_ABORTED", ,
+  "NS_ERROR_CONNECTION_REFUSED",
+  "NS_ERROR_NET_ON_TLS_HANDSHAKE_ENDED",
+  "NS_BINDING_ABORTED",
+  "SSL received a record that exceeded the maximum permissible length.",
+  "Peer’s Certificate has expired.",
+  "Unable to communicate securely with peer: requested domain name does not match the server’s certificate.",
+  "Peer’s Certificate issuer is not recognized.",
+  "Peer’s Certificate has been revoked.",
+  "Peer reports it experienced an internal error.",
+  "The server uses key pinning (HPKP) but no trusted certificate chain could be constructed that matches the pinset. Key pinning violations cannot be overridden.",
+  "SSL received a weak ephemeral Diffie-Hellman key in Server Key Exchange handshake message.",
+  "The certificate was signed using a signature algorithm that is disabled because it is not secure.",
+  "Cannot communicate securely with peer: no common encryption algorithm(s).",
+  "SSL peer has no certificate for the requested DNS name."
+];
+
+Object.assign(exports, { error_list });
+
+})(typeof exports !== 'undefined' ? exports : require.scopes.ssl_codes = {}); 

--- a/chromium/background-scripts/modules/ssl_codes.js
+++ b/chromium/background-scripts/modules/ssl_codes.js
@@ -45,4 +45,4 @@ const error_list = [
 
 Object.assign(exports, { error_list });
 
-})(typeof exports !== 'undefined' ? exports : require.scopes.ssl_codes = {}); 
+})(typeof exports !== 'undefined' ? exports : require.scopes.ssl_codes = {});

--- a/chromium/manifest.json
+++ b/chromium/manifest.json
@@ -19,6 +19,7 @@
             "external/pako-1.0.5/pako_inflate.min.js",
             "background-scripts/incognito.js",
             "background-scripts/ip_utils.js",
+            "background-scripts/modules/ssl_codes.js",
             "background-scripts/background.js"
         ]
     },


### PR DESCRIPTION
## Type of change

- [x] Refactoring existing code

In lieu of the lengthy `background.js` and [more massive PR](19737) that was created in a more optimistic manner, I decided to propose changes that help bring in the changes from that PR in more increments as I return to more core work throughout the summer.