### PR TITLE
Update deprecated log function

### DIFF
--- a/test/script.py
+++ b/test/script.py
@@ -58,7 +58,7 @@ if sys.argv[1] == "Firefox":
     try:
         if len(sys.argv) == 4:
             binary = FirefoxBinary(sys.argv[3])
-            driver = webdriver.Firefox(fp, firefox_binary=binary, log_path=os.devnull)
+            driver = webdriver.Firefox(fp, firefox_binary=binary, service_log_path=os.devnull)
         else:
             driver = webdriver.Firefox(fp, log_path=os.devnull)
     except WebDriverException as e:

--- a/test/script.py
+++ b/test/script.py
@@ -60,7 +60,7 @@ if sys.argv[1] == "Firefox":
             binary = FirefoxBinary(sys.argv[3])
             driver = webdriver.Firefox(fp, firefox_binary=binary, service_log_path=os.devnull)
         else:
-            driver = webdriver.Firefox(fp, log_path=os.devnull)
+            driver = webdriver.Firefox(fp, service_log_path=os.devnull)
     except WebDriverException as e:
         error = e.__str__()
 


### PR DESCRIPTION
Update old `log_path` function for selenium Firefox driver to the new `service_log_path`. This suppresses the warning that is thrown during testing.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring existing code
- [ ] New Ruleset
- [ ] Existing Ruleset
