### PR TITLE
Hotfix: Patches Chrome Test Failure

### DIFF
--- a/test/script.py
+++ b/test/script.py
@@ -52,6 +52,9 @@ if sys.argv[1] == "Chrome":
             sys.exit(2)
         else:
             raise e
+    
+    # Allow the extension time to load
+    time.sleep(1)
 
 if sys.argv[1] == "Firefox":
     fp = webdriver.FirefoxProfile(sys.argv[2])


### PR DESCRIPTION
Adds sleeper to Chrome extension load before grabbing URL

Fixes #(issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)