### PR TITLE
Delete Recap_the_Law.xml

### DIFF
--- a/src/chrome/content/rules/Recap_the_Law.xml
+++ b/src/chrome/content/rules/Recap_the_Law.xml
@@ -1,9 +1,0 @@
-<ruleset name="Recap the Law">
-
-	<target host="recapthelaw.org" />
-	<target host="www.recapthelaw.org" />
-
-
-	<rule from="^http:" to="https:" />
-
-</ruleset>


### PR DESCRIPTION
I'm the lead developer at Free Law Project, which maintains this domain. 

It redirects itself these days, but anyway, we're going to stop supporting the domain and let it expire. I found the code in this repo while checking if letting the domain expire would cause any trouble. It seems some stray code in this extension is one of the few places the domain is still used, so I'm tidying this up.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring existing code
- [ ] New Ruleset
- [x] Existing Ruleset
